### PR TITLE
SQL-32: Add various other integration tests

### DIFF
--- a/src/integration-test/java/com/mongodb/jdbc/integration/IntegrationTest.java
+++ b/src/integration-test/java/com/mongodb/jdbc/integration/IntegrationTest.java
@@ -578,6 +578,34 @@ public class IntegrationTest {
     }
 
     @Test
+    public void databaseHeterogeneousDataTABLETest() throws SQLException {
+        Connection conn = getBasicConnection();
+        Statement stmt = conn.createStatement();
+        ResultSet rs = stmt.executeQuery("select num4 from tdvt.Calcs");
+        ResultSetMetaData rsmd = rs.getMetaData();
+        String[] columns =
+                new String[] {
+                    "num4",
+                };
+        for (int i = 0; i < columns.length; ++i) {
+            assertEquals(rsmd.getColumnLabel(i + 1), columns[i]);
+        }
+        double[] values = {
+            0.0, 10.85, -13.47, -6.05, 8.32, 10.71, 0.0, -10.24, 4.77, 0.0, 19.39, 3.82, 3.38, 0.0,
+            -14.21, 6.75, 0.0,
+        };
+        {
+            int i = 0;
+            while (rs.next()) {
+                double diff = values[i++] - rs.getDouble(1);
+                assertTrue(diff <= 0.01 && diff >= -0.01);
+            }
+        }
+        // This will fail for now.
+        assertEquals(Types.DOUBLE, rsmd.getColumnType(1));
+    }
+
+    @Test
     public void databaseMetaDataGetTablesTest() throws SQLException {
         Connection conn = getBasicConnection();
         DatabaseMetaData dbmd = conn.getMetaData();


### PR DESCRIPTION

-   information_schema queries -- added
-   MongoDatabaseMetaData functions that actually talk to the server (e.g., getTables, getColumns) -- was done in SQL-43
-   Tests for MongoResultSet and MongoResultsetMetaData on ADL data -- basically all the integration tests cover these
-   At least one test for heterogeneous column data (with NULL) -- added
