### PR TITLE
SQL-447: Set client metadata in JDBC driver

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,7 @@ allprojects {
     dependencies {
         // MongoDB
         implementation group: 'org.mongodb', name: 'mongodb-driver-sync', version: mongodbDriverVersion
+        implementation group: 'org.mongodb', name: 'mongodb-driver-core', version: mongodbDriverVersion
         implementation group: 'org.mongodb', name: 'mongodb-driver', version: mongodbDriverVersion
         implementation group: 'com.google.guava', name: 'guava', version: guavaVersion
         implementation group: 'org.apache.commons', name: 'commons-lang3', version: lang3Version

--- a/src/main/java/com/mongodb/jdbc/MongoConnection.java
+++ b/src/main/java/com/mongodb/jdbc/MongoConnection.java
@@ -2,6 +2,7 @@ package com.mongodb.jdbc;
 
 import com.google.common.base.Preconditions;
 import com.mongodb.ConnectionString;
+import com.mongodb.MongoDriverInformation;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoDatabase;
@@ -48,7 +49,16 @@ public class MongoConnection implements Connection {
         this.url = cs.getConnectionString();
         this.user = cs.getUsername();
         this.currentDB = database;
-        mongoClient = MongoClients.create(cs);
+
+        StringBuilder version = new StringBuilder();
+        version.append(MongoDriver.MAJOR_VERSION).append(".").append(MongoDriver.MINOR_VERSION);
+        mongoClient =
+                MongoClients.create(
+                        cs,
+                        MongoDriverInformation.builder()
+                                .driverName(MongoDriver.NAME)
+                                .driverVersion(version.toString())
+                                .build());
         relaxed = conversionMode == null || !conversionMode.equals("strict");
         isClosed = false;
     }

--- a/src/main/java/com/mongodb/jdbc/MongoConnection.java
+++ b/src/main/java/com/mongodb/jdbc/MongoConnection.java
@@ -49,15 +49,21 @@ public class MongoConnection implements Connection {
         this.url = cs.getConnectionString();
         this.user = cs.getUsername();
         this.currentDB = database;
+        String version =
+                MongoDriver.VERSION != null
+                        ? MongoDriver.VERSION
+                        : new StringBuilder()
+                                .append(MongoDriver.MAJOR_VERSION)
+                                .append(".")
+                                .append(MongoDriver.MINOR_VERSION)
+                                .toString();
 
-        StringBuilder version = new StringBuilder();
-        version.append(MongoDriver.MAJOR_VERSION).append(".").append(MongoDriver.MINOR_VERSION);
         mongoClient =
                 MongoClients.create(
                         cs,
                         MongoDriverInformation.builder()
                                 .driverName(MongoDriver.NAME)
-                                .driverVersion(version.toString())
+                                .driverVersion(version)
                                 .build());
         relaxed = conversionMode == null || !conversionMode.equals("strict");
         isClosed = false;

--- a/src/main/java/com/mongodb/jdbc/MongoDriver.java
+++ b/src/main/java/com/mongodb/jdbc/MongoDriver.java
@@ -54,6 +54,7 @@ public class MongoDriver implements Driver {
     static final String CONVERSION_MODE = "conversionMode";
     // database is the database to switch to.
     static final String DATABASE = "database";
+    static final String NAME;
     static final String VERSION;
     static final int MAJOR_VERSION;
     static final int MINOR_VERSION;
@@ -86,6 +87,8 @@ public class MongoDriver implements Driver {
             MAJOR_VERSION = 0;
             MINOR_VERSION = 0;
         }
+        String name = unit.getClass().getPackage().getImplementationTitle();
+        NAME = (name != null) ? name : "mongodb-jdbc";
     }
 
     @Override


### PR DESCRIPTION
This PR adds the driver name and version (major.minor) to the client metadata.  
Obtained from `getClass().getPackage().getImplementationTitle()` and `getClass().getPackage().getImplementationVersion()`, otherwise defaults to 'mongodb-jdbc' and 0.0.

Log from ADL:
```
"clientMetadata": {"driver":{"name":"mongo-java-driver|sync|mongodb-jdbc","version":"3.12.10|1.0"} ...
```