### PR TITLE
SQL-213: Rationalize get/setAutoCommit behavior

### DIFF
--- a/src/main/java/com/mongodb/jdbc/MongoConnection.java
+++ b/src/main/java/com/mongodb/jdbc/MongoConnection.java
@@ -135,12 +135,16 @@ public class MongoConnection implements Connection {
     @Override
     public void setAutoCommit(boolean autoCommit) throws SQLException {
         checkConnection();
+        if (autoCommit) {
+            throw new SQLFeatureNotSupportedException(
+                    Thread.currentThread().getStackTrace()[1].toString());
+        }
     }
 
     @Override
     public boolean getAutoCommit() throws SQLException {
-        throw new SQLFeatureNotSupportedException(
-                Thread.currentThread().getStackTrace()[1].toString());
+        checkConnection();
+        return false;
     }
 
     @Override

--- a/src/test/java/com/mongodb/jdbc/MongoConnectionTest.java
+++ b/src/test/java/com/mongodb/jdbc/MongoConnectionTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.*;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Savepoint;
 import java.sql.Statement;
 import org.junit.jupiter.api.BeforeAll;
@@ -74,7 +75,14 @@ class MongoConnectionTest extends MongoMock {
 
     @Test
     void testSetAutoCommit() {
-        testNoop(() -> mongoConnection.setAutoCommit(true));
+        assertThrows(
+                SQLFeatureNotSupportedException.class, () -> mongoConnection.setAutoCommit(true));
+        testNoop(() -> mongoConnection.setAutoCommit(false));
+    }
+
+    @Test
+    void testGetAutoCommit() throws SQLException {
+        assertFalse(mongoConnection.getAutoCommit());
     }
 
     @Test


### PR DESCRIPTION
This PR modifies the `getAutoCommit()` to always return false. 
Modifies `setAutoCommit()` to throw SQLFeatureNotSupportedException if input parameter is set to `true`, no-op in case of `false`.