### PR TITLE
SQL-480: Disabled failing integration and tdvt tests

### DIFF
--- a/src/integration-test/java/com/mongodb/jdbc/integration/IntegrationTest.java
+++ b/src/integration-test/java/com/mongodb/jdbc/integration/IntegrationTest.java
@@ -166,7 +166,8 @@ public class IntegrationTest {
         for (int i = 0; i < columns.length; ++i) {
             assertEquals(rsmd.getColumnLabel(i + 1), columns[i]);
         }
-        assertTrue(countRows(rs) >= 299);
+        // Disabled: SQL-539
+        // assertTrue(countRows(rs) >= 299);
     }
 
     @Test
@@ -333,7 +334,8 @@ public class IntegrationTest {
         for (int i = 0; i < columns.length; ++i) {
             assertEquals(rsmd.getColumnLabel(i + 1), columns[i]);
         }
-        assertEquals(0, countRows(rs));
+        // Disabled: SQL-539
+        // assertEquals(0, countRows(rs));
     }
 
     @Test
@@ -358,7 +360,8 @@ public class IntegrationTest {
         for (int i = 0; i < columns.length; ++i) {
             assertEquals(rsmd.getColumnLabel(i + 1), columns[i]);
         }
-        assertEquals(0, countRows(rs));
+        // Disabled: SQL-539
+        // assertEquals(0, countRows(rs));
     }
 
     @Test
@@ -417,7 +420,8 @@ public class IntegrationTest {
         for (int i = 0; i < columns.length; ++i) {
             assertEquals(rsmd.getColumnLabel(i + 1), columns[i]);
         }
-        assertTrue(countRows(rs) >= 29);
+        // Disabled: SQL-539
+        // assertTrue(countRows(rs) >= 29);
     }
 
     @Test
@@ -627,9 +631,10 @@ public class IntegrationTest {
         for (int i = 0; i < columns.length; ++i) {
             assertEquals(rsmd.getColumnLabel(i + 1), columns[i]);
         }
-        assertEquals(23, countRows(rs));
-        rs = dbmd.getTables(catalogPattern, null, tableNamePattern, null);
-        assertEquals(7, countRows(rs));
+        // Disabled: SQL-539
+        // assertEquals(23, countRows(rs));
+        // rs = dbmd.getTables(catalogPattern, null, tableNamePattern, null);
+        // assertEquals(7, countRows(rs));
     }
 
     @Test
@@ -685,11 +690,12 @@ public class IntegrationTest {
         for (int i = 0; i < columns.length; ++i) {
             assertEquals(rsmd.getColumnLabel(i + 1), columns[i]);
         }
-        assertEquals(186, countRows(rs));
-        rs = dbmd.getColumns(catalogPattern, null, tableNamePattern, null);
-        assertEquals(67, countRows(rs));
-        rs = dbmd.getColumns(catalogPattern, null, tableNamePattern, columnNamePattern);
-        assertEquals(1, countRows(rs));
+        // Disabled: SQL-539
+        // assertEquals(186, countRows(rs));
+        // rs = dbmd.getColumns(catalogPattern, null, tableNamePattern, null);
+        // assertEquals(67, countRows(rs));
+        // rs = dbmd.getColumns(catalogPattern, null, tableNamePattern, columnNamePattern);
+        // assertEquals(1, countRows(rs));
         rs = dbmd.getColumns(catalogPattern, null, tableNamePattern, columnNamePattern2);
         assertEquals(0, countRows(rs));
     }

--- a/src/tdvt/java/com/mongodb/jdbc/tdvt/TDVTTest.java
+++ b/src/tdvt/java/com/mongodb/jdbc/tdvt/TDVTTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.*;
 import java.lang.Math;
 import java.sql.*;
 import java.util.ArrayList;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -159,7 +160,8 @@ public class TDVTTest {
         if (!tyName.equals("double")) {
             System.out.println(tyName + " == " + "double");
         }
-        assertTrue("failed type check", tyName.equals("double"));
+        // Disabled: SQL-539
+        // assertTrue("failed type check", tyName.equals("double"));
         tyName = rsmd.getColumnTypeName(3);
         if (!tyName.equals("double")) {
             System.out.println(tyName + " == " + "double");
@@ -187,7 +189,8 @@ public class TDVTTest {
             // This will be false if both ArrayLists are the same
             System.out.println(expected.toString());
             System.out.println(rsSet.toString());
-            assertTrue("failed result check", false);
+            // Disabled: SQL-539
+            // assertTrue("failed result check", false);
         }
     }
 
@@ -2123,7 +2126,8 @@ public class TDVTTest {
         if (!tyName.equals("string")) {
             System.out.println(tyName + " == " + "string");
         }
-        assertTrue("failed type check", tyName.equals("string"));
+        // Disabled: SQL-539
+        // assertTrue("failed type check", tyName.equals("string"));
         ArrayList<ArrayList<Object>> expected = new ArrayList<>(17);
         ArrayList<Object> expectedRow;
         expectedRow = new ArrayList<>(1);
@@ -2182,7 +2186,8 @@ public class TDVTTest {
             // This will be false if both ArrayLists are the same
             System.out.println(expected.toString());
             System.out.println(rsSet.toString());
-            assertTrue("failed result check", false);
+            // Disabled: SQL-539
+            // assertTrue("failed result check", false);
         }
     }
 
@@ -2200,7 +2205,8 @@ public class TDVTTest {
         if (!tyName.equals("string")) {
             System.out.println(tyName + " == " + "string");
         }
-        assertTrue("failed type check", tyName.equals("string"));
+        // Disabled: SQL-539
+        // assertTrue("failed type check", tyName.equals("string"));
         ArrayList<ArrayList<Object>> expected = new ArrayList<>(17);
         ArrayList<Object> expectedRow;
         expectedRow = new ArrayList<>(1);
@@ -2259,7 +2265,8 @@ public class TDVTTest {
             // This will be false if both ArrayLists are the same
             System.out.println(expected.toString());
             System.out.println(rsSet.toString());
-            assertTrue("failed result check", false);
+            // Disabled: SQL-539
+            // assertTrue("failed result check", false);
         }
     }
 
@@ -2454,7 +2461,8 @@ public class TDVTTest {
         if (!tyName.equals("string")) {
             System.out.println(tyName + " == " + "string");
         }
-        assertTrue("failed type check", tyName.equals("string"));
+        // Disabled: SQL-539
+        // assertTrue("failed type check", tyName.equals("string"));
         ArrayList<ArrayList<Object>> expected = new ArrayList<>(17);
         ArrayList<Object> expectedRow;
         expectedRow = new ArrayList<>(1);
@@ -2513,7 +2521,8 @@ public class TDVTTest {
             // This will be false if both ArrayLists are the same
             System.out.println(expected.toString());
             System.out.println(rsSet.toString());
-            assertTrue("failed result check", false);
+            // Disabled: SQL-539
+            // assertTrue("failed result check", false);
         }
     }
 
@@ -2677,7 +2686,8 @@ public class TDVTTest {
         if (!tyName.equals("string")) {
             System.out.println(tyName + " == " + "string");
         }
-        assertTrue("failed type check", tyName.equals("string"));
+        // Disabled: SQL-539
+        // assertTrue("failed type check", tyName.equals("string"));
         ArrayList<ArrayList<Object>> expected = new ArrayList<>(17);
         ArrayList<Object> expectedRow;
         expectedRow = new ArrayList<>(1);
@@ -2736,7 +2746,8 @@ public class TDVTTest {
             // This will be false if both ArrayLists are the same
             System.out.println(expected.toString());
             System.out.println(rsSet.toString());
-            assertTrue("failed result check", false);
+            // Disabled: SQL-539
+            // assertTrue("failed result check", false);
         }
     }
 
@@ -3355,7 +3366,8 @@ public class TDVTTest {
             // This will be false if both ArrayLists are the same
             System.out.println(expected.toString());
             System.out.println(rsSet.toString());
-            assertTrue("failed result check", false);
+            // Disabled: SQL-539
+            // assertTrue("failed result check", false);
         }
     }
 
@@ -6000,7 +6012,8 @@ public class TDVTTest {
         if (!tyName.equals("string")) {
             System.out.println(tyName + " == " + "string");
         }
-        assertTrue("failed type check", tyName.equals("string"));
+        // Disabled: SQL-539
+        // assertTrue("failed type check", tyName.equals("string"));
         ArrayList<ArrayList<Object>> expected = new ArrayList<>(17);
         ArrayList<Object> expectedRow;
         expectedRow = new ArrayList<>(1);
@@ -6059,7 +6072,8 @@ public class TDVTTest {
             // This will be false if both ArrayLists are the same
             System.out.println(expected.toString());
             System.out.println(rsSet.toString());
-            assertTrue("failed result check", false);
+            // Disabled: SQL-539
+            // assertTrue("failed result check", false);
         }
     }
 
@@ -6077,7 +6091,8 @@ public class TDVTTest {
         if (!tyName.equals("string")) {
             System.out.println(tyName + " == " + "string");
         }
-        assertTrue("failed type check", tyName.equals("string"));
+        // Disabled: SQL-539
+        // assertTrue("failed type check", tyName.equals("string"));
         ArrayList<ArrayList<Object>> expected = new ArrayList<>(17);
         ArrayList<Object> expectedRow;
         expectedRow = new ArrayList<>(1);
@@ -6136,7 +6151,8 @@ public class TDVTTest {
             // This will be false if both ArrayLists are the same
             System.out.println(expected.toString());
             System.out.println(rsSet.toString());
-            assertTrue("failed result check", false);
+            // Disabled: SQL-539
+            // assertTrue("failed result check", false);
         }
     }
 
@@ -8739,7 +8755,8 @@ public class TDVTTest {
             // This will be false if both ArrayLists are the same
             System.out.println(expected.toString());
             System.out.println(rsSet.toString());
-            assertTrue("failed result check", false);
+            // Disabled: SQL-539
+            // assertTrue("failed result check", false);
         }
     }
 
@@ -8945,7 +8962,8 @@ public class TDVTTest {
             // This will be false if both ArrayLists are the same
             System.out.println(expected.toString());
             System.out.println(rsSet.toString());
-            assertTrue("failed result check", false);
+            // Disabled: SQL-539
+            // assertTrue("failed result check", false);
         }
     }
 
@@ -8974,7 +8992,7 @@ public class TDVTTest {
             // This will be false if both ArrayLists are the same
             System.out.println(expected.toString());
             System.out.println(rsSet.toString());
-            assertTrue("failed result check", false);
+            // assertTrue("failed result check", false);
         }
     }
 
@@ -8992,7 +9010,8 @@ public class TDVTTest {
         if (!tyName.equals("string")) {
             System.out.println(tyName + " == " + "string");
         }
-        assertTrue("failed type check", tyName.equals("string"));
+        // Disabled: SQL-539
+        // assertTrue("failed type check", tyName.equals("string"));
         ArrayList<ArrayList<Object>> expected = new ArrayList<>(17);
         ArrayList<Object> expectedRow;
         expectedRow = new ArrayList<>(1);
@@ -9051,7 +9070,8 @@ public class TDVTTest {
             // This will be false if both ArrayLists are the same
             System.out.println(expected.toString());
             System.out.println(rsSet.toString());
-            assertTrue("failed result check", false);
+            // Disabled: SQL-539
+            // assertTrue("failed result check", false);
         }
     }
 
@@ -9924,7 +9944,8 @@ public class TDVTTest {
             // This will be false if both ArrayLists are the same
             System.out.println(expected.toString());
             System.out.println(rsSet.toString());
-            assertTrue("failed result check", false);
+            // Disabled: SQL-539
+            // assertTrue("failed result check", false);
         }
     }
 
@@ -9956,7 +9977,8 @@ public class TDVTTest {
             // This will be false if both ArrayLists are the same
             System.out.println(expected.toString());
             System.out.println(rsSet.toString());
-            assertTrue("failed result check", false);
+            // Disabled: SQL-539
+            // assertTrue("failed result check", false);
         }
     }
 
@@ -15593,7 +15615,8 @@ public class TDVTTest {
             // This will be false if both ArrayLists are the same
             System.out.println(expected.toString());
             System.out.println(rsSet.toString());
-            assertTrue("failed result check", false);
+            // Disabled: SQL-539
+            // assertTrue("failed result check", false);
         }
     }
 
@@ -17108,6 +17131,8 @@ public class TDVTTest {
         }
     }
 
+    // Disabled: SQL-539
+    @Ignore
     @Test
     public void testCALCS410() throws SQLException {
         System.out.println("==============================CALCS410");
@@ -18725,7 +18750,8 @@ public class TDVTTest {
             // This will be false if both ArrayLists are the same
             System.out.println(expected.toString());
             System.out.println(rsSet.toString());
-            assertTrue("failed result check", false);
+            // Disabled: SQL-539
+            // assertTrue("failed result check", false);
         }
     }
 
@@ -18802,7 +18828,8 @@ public class TDVTTest {
             // This will be false if both ArrayLists are the same
             System.out.println(expected.toString());
             System.out.println(rsSet.toString());
-            assertTrue("failed result check", false);
+            // Disabled: SQL-539
+            // assertTrue("failed result check", false);
         }
     }
 
@@ -22403,7 +22430,8 @@ public class TDVTTest {
             // This will be false if both ArrayLists are the same
             System.out.println(expected.toString());
             System.out.println(rsSet.toString());
-            assertTrue("failed result check", false);
+            // Disabled: SQL-539
+            // assertTrue("failed result check", false);
         }
     }
 
@@ -22432,7 +22460,8 @@ public class TDVTTest {
             // This will be false if both ArrayLists are the same
             System.out.println(expected.toString());
             System.out.println(rsSet.toString());
-            assertTrue("failed result check", false);
+            // Disabled: SQL-539
+            // assertTrue("failed result check", false);
         }
     }
 
@@ -22461,7 +22490,8 @@ public class TDVTTest {
             // This will be false if both ArrayLists are the same
             System.out.println(expected.toString());
             System.out.println(rsSet.toString());
-            assertTrue("failed result check", false);
+            // Disabled: SQL-539
+            // assertTrue("failed result check", false);
         }
     }
 
@@ -22490,7 +22520,8 @@ public class TDVTTest {
             // This will be false if both ArrayLists are the same
             System.out.println(expected.toString());
             System.out.println(rsSet.toString());
-            assertTrue("failed result check", false);
+            // Disabled: SQL-539
+            // assertTrue("failed result check", false);
         }
     }
 
@@ -22519,7 +22550,8 @@ public class TDVTTest {
             // This will be false if both ArrayLists are the same
             System.out.println(expected.toString());
             System.out.println(rsSet.toString());
-            assertTrue("failed result check", false);
+            // Disabled: SQL-539
+            // assertTrue("failed result check", false);
         }
     }
 
@@ -24095,7 +24127,8 @@ public class TDVTTest {
         if (!tyName.equals("string")) {
             System.out.println(tyName + " == " + "string");
         }
-        assertTrue("failed type check", tyName.equals("string"));
+        // Disabled: SQL-539
+        // assertTrue("failed type check", tyName.equals("string"));
         ArrayList<ArrayList<Object>> expected = new ArrayList<>(17);
         ArrayList<Object> expectedRow;
         expectedRow = new ArrayList<>(1);
@@ -24154,7 +24187,8 @@ public class TDVTTest {
             // This will be false if both ArrayLists are the same
             System.out.println(expected.toString());
             System.out.println(rsSet.toString());
-            assertTrue("failed result check", false);
+            // Disabled: SQL-539
+            // assertTrue("failed result check", false);
         }
     }
 
@@ -24172,7 +24206,8 @@ public class TDVTTest {
         if (!tyName.equals("string")) {
             System.out.println(tyName + " == " + "string");
         }
-        assertTrue("failed type check", tyName.equals("string"));
+        // Disabled: SQL-539
+        // assertTrue("failed type check", tyName.equals("string"));
         ArrayList<ArrayList<Object>> expected = new ArrayList<>(17);
         ArrayList<Object> expectedRow;
         expectedRow = new ArrayList<>(1);
@@ -24231,7 +24266,8 @@ public class TDVTTest {
             // This will be false if both ArrayLists are the same
             System.out.println(expected.toString());
             System.out.println(rsSet.toString());
-            assertTrue("failed result check", false);
+            // Disabled: SQL-539
+            // assertTrue("failed result check", false);
         }
     }
 
@@ -25661,7 +25697,8 @@ public class TDVTTest {
             // This will be false if both ArrayLists are the same
             System.out.println(expected.toString());
             System.out.println(rsSet.toString());
-            assertTrue("failed result check", false);
+            // Disabled: SQL-539
+            // assertTrue("failed result check", false);
         }
     }
 
@@ -29002,6 +29039,8 @@ public class TDVTTest {
         }
     }
 
+    // Disabled: SQL-539
+    @Ignore
     @Test
     public void testLOGICAL_CALCS10() throws SQLException {
         System.out.println("==============================LOGICAL_CALCS10");
@@ -29056,7 +29095,8 @@ public class TDVTTest {
             // This will be false if both ArrayLists are the same
             System.out.println(expected.toString());
             System.out.println(rsSet.toString());
-            assertTrue("failed result check", false);
+            // Disabled: SQL-539
+            // assertTrue("failed result check", false);
         }
     }
 }

--- a/src/tdvt/java/com/mongodb/jdbc/tdvt/TDVTTest.java
+++ b/src/tdvt/java/com/mongodb/jdbc/tdvt/TDVTTest.java
@@ -8992,6 +8992,7 @@ public class TDVTTest {
             // This will be false if both ArrayLists are the same
             System.out.println(expected.toString());
             System.out.println(rsSet.toString());
+            // Disabled: SQL-539
             // assertTrue("failed result check", false);
         }
     }


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/SQL-480

Created ticket to address fixing and reenabling tests, added notes on a few of the test failures: 
https://jira.mongodb.org/browse/SQL-539

Disabled tests with @Ignore annotation when executeQuery was failing
Disabled by commenting failing asserts when other passing asserts are in test