### PR TITLE
SQL-555: MongoSQL JDBC Integration tests with ADL for non-DatabaseMet…

### DIFF
--- a/resources/integration_test/testdata/integration.yml
+++ b/resources/integration_test/testdata/integration.yml
@@ -70,17 +70,18 @@ dataset:
     }
 
   - db: integration_test
-    collection: null_field
+    collection: null_and_missing
     docs:
-      - { _id: 0, "a": "a" }
+      - { _id: 0, "a": !!org.bson.BsonTimestamp 1}
       - { _id: 1, "a": null }
+      - { _id: 2 }
 
   - db: integration_test
-    collection: a_column_order
+    collection: a_non_lexicographic_field_order
     docs:
       - { _id: 4, "c": 7, "b": 6, "a":5, "A":1, "B": 2, "C": 3 }
 
   - db: integration_test
-    collection: b_column_order
+    collection: b_non_lexicographic_field_order
     docs:
-      - { _id: 11, "C": 10, "B": 9, "A": 8, "a": 12, "b": 13, "c": 14 }
+      - { "a": 9, _id: 8 }

--- a/resources/integration_test/testdata/integration.yml
+++ b/resources/integration_test/testdata/integration.yml
@@ -2,11 +2,11 @@ dataset:
   - db: integration_test
     collection: class
     docs:
-      - {_id: 0, studentid: 10329,  name: "John", enrolled: true}
-      - {_id: 1, studentid: 342,  name: "Jane", enrolled: false}
-      - {_id: 2, studentid: 303,  name: "Mike", enrolled: true}
-      - {_id: 3, studentid: 204323,  name: "Mary", enrolled: false}
-      - {_id: 4, studentid: 10,  name: "Pete", enrolled: false}
+      - {_id: 0, studentid: 10329,  name: "John", enrolled: true, startdate: 2000-01-01 }
+      - {_id: 1, studentid: 342,  name: "Jane", enrolled: false, startdate: 2000-02-01}
+      - {_id: 2, studentid: 303,  name: "Mike", enrolled: true, startdate: 2000-01-01}
+      - {_id: 3, studentid: 204323,  name: "Mary", enrolled: false, startdate: 2000-03-01}
+      - {_id: 4, studentid: 10,  name: "Pete", enrolled: false, startdate: 2000-01-01}
 
   - db: integration_test
     collection: grades
@@ -20,3 +20,67 @@ dataset:
       - {_id: 6, studentid: 342, testid: 5,  score: 80.1}
       - {_id: 7, studentid: 204323, testid: 5, score: 83.3}
       - {_id: 8, studentid: 200, testid: 5, score: 78.5}
+
+  - db: integration_test
+    collection: anyof_collection
+    docs:
+      - { _id: 0, a: 3 }
+      - { _id: 1, a: 3000000000 }
+      - { _id: 2, a: 4.5 }
+    schema: {
+              "bsonType":[
+                  "object"
+              ],
+              "properties":{
+                "a":{
+                  "bsonType":[
+                      "long",
+                      "double",
+                      "int"
+                  ]
+                },
+                "_id":{
+                  "bsonType":[
+                      "int"
+                  ]
+                }
+              }
+            }
+
+  - db: integration_test
+    collection: any_collection
+    docs:
+      - { _id: 0, b: 3 }
+      - { _id: 1, b: "b" }
+      - { _id: 2, b: 4.5 }
+    schema: {
+      "bsonType":[
+          "object"
+      ],
+      "required":[
+          "b"
+      ],
+      "properties":{
+        "_id":{
+          "bsonType":[
+              "int"
+          ]
+        }
+      }
+    }
+
+  - db: integration_test
+    collection: null_field
+    docs:
+      - { _id: 0, "a": "a" }
+      - { _id: 1, "a": null }
+
+  - db: integration_test
+    collection: a_column_order
+    docs:
+      - { _id: 4, "c": 7, "b": 6, "a":5, "A":1, "B": 2, "C": 3 }
+
+  - db: integration_test
+    collection: b_column_order
+    docs:
+      - { _id: 11, "C": 10, "B": 9, "A": 8, "a": 12, "b": 13, "c": 14 }

--- a/resources/integration_test/testdata/integration.yml
+++ b/resources/integration_test/testdata/integration.yml
@@ -6,6 +6,7 @@ dataset:
       - {_id: 1, studentid: 342,  name: "Jane", enrolled: false}
       - {_id: 2, studentid: 303,  name: "Mike", enrolled: true}
       - {_id: 3, studentid: 204323,  name: "Mary", enrolled: false}
+      - {_id: 4, studentid: 10,  name: "Pete", enrolled: false}
 
   - db: integration_test
     collection: grades
@@ -18,3 +19,4 @@ dataset:
       - {_id: 5, studentid: 10329, testid: 5,  score: 74.4}
       - {_id: 6, studentid: 342, testid: 5,  score: 80.1}
       - {_id: 7, studentid: 204323, testid: 5, score: 83.3}
+      - {_id: 8, studentid: 200, testid: 5, score: 78.5}

--- a/resources/integration_test/tests/query.yaml
+++ b/resources/integration_test/tests/query.yaml
@@ -1,0 +1,255 @@
+tests:
+  - description: select_star_from_grades_ordered
+    sql: SELECT * FROM grades ORDER BY _id
+    skip_reason: SQL-659
+
+  - description: select_star_from_grades_unordered
+    sql: SELECT * FROM grades
+    expected_result:
+      - [0, 84.5, 303, 3]
+      - [1, 97.4, 10329, 3]
+      - [2, 89.3, 342, 3]
+      - [3, 91.9, 204323, 3]
+      - [4, 87.5, 303, 5]
+      - [5, 74.4, 10329, 5]
+      - [6, 80.1, 342, 5]
+      - [7, 83.3, 204323, 5]
+      - [8, 78.5, 200, 5]
+    row_count: 9
+    ordered: false
+    expected_sql_type: [INTEGER, DOUBLE, INTEGER, INTEGER]
+    expected_catalog_name: ['', '', '', '']
+    expected_column_class_name: [int, double, int, int]
+    expected_column_label: [_id, score, studentid, testid]
+    expected_column_display_size: [10, 15, 10, 10]
+    expected_precision: [10, 15, 10, 10]
+    expected_scale: [0, 15, 0, 0]
+    expected_schema_name: ['', '', '', '']
+    expected_is_auto_increment: [false, false, false, false]
+    expected_is_case_sensitive: [false, false, false, false]
+    expected_is_currency: [false, false, false, false]
+    expected_is_definitely_writable: [false, false, false, false]
+    expected_is_nullable: [columnNullable, columnNullable, columnNullable, columnNullable]
+    expected_is_read_only: [true, true, true, true]
+    expected_is_searchable: [true, true, true, true]
+    expected_is_signed: [true, true, true, true]
+    expected_is_writable: [false, false, false, false]
+
+  - description: select_star_from_class_ordered
+    sql: SELECT * FROM class ORDER BY _id;
+    skip_reason: SQL-659
+
+  - description: select_star_from_class_unordered
+    sql: SELECT * FROM class
+    expected_result:
+      - [0, true, John, 10329]
+      - [1, false, Jane, 342]
+      - [2, true, Mike, 303]
+      - [3, false, Mary, 204323]
+      - [4, false, Pete, 10]
+    row_count: 5
+    ordered: false
+    expected_sql_type: [INTEGER, BIT, LONGVARCHAR, INTEGER]
+    expected_catalog_name: ['', '', '', '']
+    expected_column_class_name: [int, boolean, java.lang.String, int]
+    expected_column_label: [_id, enrolled, name, studentid]
+    expected_column_display_size: [10, 1, 0, 10]
+    expected_precision: [10, 1, 0, 10]
+    expected_scale: [0, 0, 0, 0]
+    expected_schema_name: ['', '', '', '']
+    expected_is_auto_increment: [false, false, false, false]
+    expected_is_case_sensitive: [false, false, true, false]
+    expected_is_currency: [false, false, false, false]
+    expected_is_definitely_writable: [false, false, false, false]
+    expected_is_nullable: [columnNullable, columnNullable, columnNullable, columnNullable]
+    expected_is_read_only: [true, true, true, true]
+    expected_is_searchable: [true, true, true, true]
+    expected_is_signed: [true, false, false, true]
+    expected_is_writable: [false, false, false, false]
+
+  - description: select_as_from_grades
+    sql: SELECT score AS s, testid AS t FROM grades
+    expected_result:
+      - [ 84.5, 3 ]
+      - [ 97.4, 3 ]
+      - [ 89.3, 3 ]
+      - [ 91.9, 3 ]
+      - [ 87.5, 5 ]
+      - [ 74.4, 5 ]
+      - [ 80.1, 5 ]
+      - [ 83.3, 5 ]
+      - [ 78.5, 5 ]
+    row_count: 9
+    ordered: false
+    expected_sql_type: [ DOUBLE, INTEGER ]
+    expected_catalog_name: [ '', '' ]
+    expected_column_class_name: [ double, int ]
+    expected_column_label: [ s, t ]
+    expected_column_display_size: [ 15, 10 ]
+    expected_precision: [ 15, 10 ]
+    expected_scale: [ 15, 0 ]
+    expected_schema_name: [ '', '' ]
+    expected_is_auto_increment: [ false, false ]
+    expected_is_case_sensitive: [ false, false ]
+    expected_is_currency: [ false, false ]
+    expected_is_definitely_writable: [ false, false ]
+    expected_is_nullable: [ columnNullable, columnNullable ]
+    expected_is_read_only: [ true, true ]
+    expected_is_searchable: [ true, true ]
+    expected_is_signed: [ true, true ]
+    expected_is_writable: [ false, false ]
+
+  - description: select_as_from_class
+    sql: SELECT enrolled AS e, studentid AS s, name AS n from class
+    expected_result:
+      - [ true, John, 10329 ]
+      - [ false, Jane, 342 ]
+      - [ true, Mike, 303 ]
+      - [ false, Mary, 204323 ]
+      - [ false, Pete, 10 ]
+    row_count: 5
+    ordered: false
+    expected_sql_type: [ BIT, LONGVARCHAR, INTEGER ]
+    expected_catalog_name: [ '', '', '' ]
+    expected_column_class_name: [ boolean, java.lang.String, int ]
+    expected_column_label: [ e, n, s ]
+    expected_column_display_size: [ 1, 0, 10 ]
+    expected_precision: [ 1, 0, 10 ]
+    expected_scale: [ 0, 0, 0 ]
+    expected_schema_name: [ '', '', '' ]
+    expected_is_auto_increment: [ false, false, false ]
+    expected_is_case_sensitive: [ false, true, false ]
+    expected_is_currency: [ false, false, false ]
+    expected_is_definitely_writable: [ false, false, false ]
+    expected_is_nullable: [ columnNullable, columnNullable, columnNullable ]
+    expected_is_read_only: [ true, true, true ]
+    expected_is_searchable: [ true, true, true ]
+    expected_is_signed: [ false, false, true ]
+    expected_is_writable: [ false, false, false ]
+
+  - description: limit_from_grades
+    sql: SELECT studentid, score, testid FROM grades ORDER BY 1, 2, 3 DESC LIMIT 5
+    skip_reason: SQL-659
+
+  - description: limit_from_class
+    sql: SELECT studentid, name FROM class ORDER BY 1, 2 ASC LIMIT 2
+    skip_reason: SQL-659
+
+  - description: inner_join
+    sql: "SELECT class.name, grades.testid, grades.score FROM grades INNER JOIN class ON grades.studentid\
+      = class.studentid"
+    skip_reason: SQL-659
+
+  - description: right_join
+    sql: "SELECT class.name, grades.testid, grades.score FROM grades RIGHT JOIN class ON grades.studentid\
+      = class.studentid"
+    skip_reason: SQL-659
+
+  - description: left_join
+    sql: "SELECT class.name, grades.testid, grades.score FROM grades LEFT JOIN class ON grades.studentid\
+      = class.studentid"
+    skip_reason: SQL-659
+
+  - description: cross_join
+    sql: "SELECT class.name, grades.testid, grades.score FROM grades CROSS JOIN class"
+    expected_result:
+    - [ John, 84.5, 3 ]
+    - [ Jane, 84.5, 3 ]
+    - [ Mike, 84.5, 3 ]
+    - [ Mary, 84.5, 3 ]
+    - [ Pete, 84.5, 3 ]
+    - [ John, 97.4, 3 ]
+    - [ Jane, 97.4, 3 ]
+    - [ Mike, 97.4, 3 ]
+    - [ Mary, 97.4, 3 ]
+    - [ Pete, 97.4, 3 ]
+    - [ John, 89.3, 3 ]
+    - [ Jane, 89.3, 3 ]
+    - [ Mike, 89.3, 3 ]
+    - [ Mary, 89.3, 3 ]
+    - [ Pete, 89.3, 3 ]
+    - [ John, 91.9, 3 ]
+    - [ Jane, 91.9, 3 ]
+    - [ Mike, 91.9, 3 ]
+    - [ Mary, 91.9, 3 ]
+    - [ Pete, 91.9, 3 ]
+    - [ John, 87.5, 5 ]
+    - [ Jane, 87.5, 5 ]
+    - [ Mike, 87.5, 5 ]
+    - [ Mary, 87.5, 5 ]
+    - [ Pete, 87.5, 5 ]
+    - [ John, 74.4, 5 ]
+    - [ Jane, 74.4, 5 ]
+    - [ Mike, 74.4, 5 ]
+    - [ Mary, 74.4, 5 ]
+    - [ Pete, 74.4, 5 ]
+    - [ John, 80.1, 5 ]
+    - [ Jane, 80.1, 5 ]
+    - [ Mike, 80.1, 5 ]
+    - [ Mary, 80.1, 5 ]
+    - [ Pete, 80.1, 5 ]
+    - [ John, 83.3, 5 ]
+    - [ Jane, 83.3, 5 ]
+    - [ Mike, 83.3, 5 ]
+    - [ Mary, 83.3, 5 ]
+    - [ Pete, 83.3, 5 ]
+    - [ John, 78.5, 5 ]
+    - [ Jane, 78.5, 5 ]
+    - [ Mike, 78.5, 5 ]
+    - [ Mary, 78.5, 5 ]
+    - [ Pete, 78.5, 5 ]
+    row_count: 45
+    ordered: false
+    expected_sql_type: [ LONGVARCHAR, DOUBLE, INTEGER ]
+    expected_catalog_name: [ '', '', '' ]
+    expected_column_class_name: [ java.lang.String, double, int ]
+    expected_column_label: [ name, score, testid ]
+    expected_column_display_size: [ 0, 15, 10 ]
+    expected_precision: [ 0, 15, 10 ]
+    expected_scale: [ 0, 15, 0 ]
+    expected_schema_name: [ '', '', '' ]
+    expected_is_auto_increment: [ false, false, false ]
+    expected_is_case_sensitive: [ true, false, false ]
+    expected_is_currency: [ false, false, false ]
+    expected_is_definitely_writable: [ false, false, false ]
+    expected_is_nullable: [ columnNullable, columnNullable, columnNullable ]
+    expected_is_read_only: [ true, true, true ]
+    expected_is_searchable: [ true, true, true ]
+    expected_is_signed: [ false, true, true ]
+    expected_is_writable: [ false, false, false ]
+
+  - description: subquery
+    sql: SELECT studentid FROM (SELECT * FROM class WHERE enrolled = TRUE) AS foo
+    skip_reason: SQL-659
+
+  - description: count_from_grades
+    sql: SELECT COUNT(studentid) FROM grades
+    skip_reason: SQL-658
+
+  - description: count_star_from_grades
+    sql: SELECT COUNT(*) As C FROM grades
+    skip_reason: SQL-658
+
+  - description: count_from_class
+    sql: SELECT COUNT(studentid) FROM class
+    skip_reason: SQL-658
+
+  - description: average
+    sql: SELECT avg(score) FROM grades where testid=5
+    skip_reason: SQL-659
+
+  - description: max
+    sql: SELECT max(score) FROM grades
+    skip_reason: SQL-659
+
+  - description: group_by
+    sql: SELECT COUNT(score), testid FROM grades WHERE score > 85 GROUP BY testid
+    skip_reason: SQL-658
+
+  - description: ascending
+    sql: SELECT grades.score AS score FROM grades ORDER BY score ASC
+    skip_reason: SQL-659
+
+  - description: descending
+    sql: SELECT grades.score AS score FROM grades ORDER BY score DESC
+    skip_reason: SQL-659

--- a/resources/integration_test/tests/query.yaml
+++ b/resources/integration_test/tests/query.yaml
@@ -1,10 +1,12 @@
 tests:
   - description: select_star_from_grades_ordered
+    db: integration_test
     sql: SELECT * FROM grades ORDER BY _id
     ordered: true
     skip_reason: SQL-659
 
   - description: select_star_from_grades_unordered
+    db: integration_test
     sql: SELECT * FROM grades
     expected_result:
       - [0, 84.5, 303, 3]
@@ -37,11 +39,13 @@ tests:
     expected_is_writable: [false, false, false, false]
 
   - description: select_star_from_class_ordered
+    db: integration_test
     sql: SELECT * FROM class ORDER BY _id;
     ordered: true
     skip_reason: SQL-659
 
   - description: select_star_from_class_unordered
+    db: integration_test
     sql: SELECT * FROM class
     expected_result:
       - [0, true, John, 10329]
@@ -70,6 +74,7 @@ tests:
     expected_is_writable: [false, false, false, false]
 
   - description: select_as_from_grades
+    db: integration_test
     sql: SELECT score AS s, testid AS t FROM grades
     expected_result:
       - [ 84.5, 3 ]
@@ -102,6 +107,7 @@ tests:
     expected_is_writable: [ false, false ]
 
   - description: select_as_from_class
+    db: integration_test
     sql: SELECT enrolled AS e, studentid AS s, name AS n from class
     expected_result:
       - [ true, John, 10329 ]
@@ -130,34 +136,40 @@ tests:
     expected_is_writable: [ false, false, false ]
 
   - description: limit_from_grades
+    db: integration_test
     sql: SELECT studentid, score, testid FROM grades ORDER BY 1, 2, 3 DESC LIMIT 5
     ordered: true
     skip_reason: SQL-659
 
   - description: limit_from_class
+    db: integration_test
     sql: SELECT studentid, name FROM class ORDER BY 1, 2 ASC LIMIT 2
     ordered: true
     skip_reason: SQL-659
 
   - description: inner_join
+    db: integration_test
     sql: "SELECT class.name, grades.testid, grades.score FROM grades INNER JOIN class ON grades.studentid\
       = class.studentid"
     ordered: false
     skip_reason: SQL-659
 
   - description: right_join
+    db: integration_test
     sql: "SELECT class.name, grades.testid, grades.score FROM grades RIGHT JOIN class ON grades.studentid\
       = class.studentid"
     ordered: false
     skip_reason: SQL-659
 
   - description: left_join
+    db: integration_test
     sql: "SELECT class.name, grades.testid, grades.score FROM grades LEFT JOIN class ON grades.studentid\
       = class.studentid"
     ordered: false
     skip_reason: SQL-659
 
   - description: cross_join
+    db: integration_test
     sql: "SELECT class.name, grades.testid, grades.score FROM grades CROSS JOIN class"
     expected_result:
     - [ John, 84.5, 3 ]
@@ -226,46 +238,55 @@ tests:
     expected_is_writable: [ false, false, false ]
 
   - description: subquery
+    db: integration_test
     sql: SELECT studentid FROM (SELECT * FROM class WHERE enrolled = TRUE) AS foo
     ordered: false
     skip_reason: SQL-659
 
   - description: count_from_grades
+    db: integration_test
     sql: SELECT COUNT(studentid) FROM grades
     ordered: false
     skip_reason: SQL-658
 
   - description: count_star_from_grades
+    db: integration_test
     sql: SELECT COUNT(*) As C FROM grades
     ordered: false
     skip_reason: SQL-658
 
   - description: count_from_class
+    db: integration_test
     sql: SELECT COUNT(studentid) FROM class
     ordered: false
     skip_reason: SQL-658
 
   - description: average
+    db: integration_test
     sql: SELECT avg(score) FROM grades where testid=5
     ordered: false
     skip_reason: SQL-659
 
   - description: max
+    db: integration_test
     sql: SELECT max(score) FROM grades
     ordered: false
     skip_reason: SQL-659
 
   - description: group_by
+    db: integration_test
     sql: SELECT COUNT(score), testid FROM grades WHERE score > 85 GROUP BY testid
     ordered: false
     skip_reason: SQL-658
 
   - description: ascending
+    db: integration_test
     sql: SELECT grades.score AS score FROM grades ORDER BY score ASC
     ordered: true
     skip_reason: SQL-659
 
   - description: descending
+    db: integration_test
     sql: SELECT grades.score AS score FROM grades ORDER BY score DESC
     ordered: true
     skip_reason: SQL-659

--- a/resources/integration_test/tests/query.yaml
+++ b/resources/integration_test/tests/query.yaml
@@ -38,7 +38,7 @@ tests:
 
   - description: select_as_confirm_column_label
     db: integration_test
-    sql: SELECT enrolled AS e, studentid AS s, name AS n from class
+    sql: SELECT enrolled AS e, studentid AS s, name AS n FROM class
     expected_result:
       - [ true, John, 10329 ]
       - [ false, Jane, 342 ]

--- a/resources/integration_test/tests/query.yaml
+++ b/resources/integration_test/tests/query.yaml
@@ -269,4 +269,4 @@ tests:
     sql: SELECT grades.score AS score FROM grades ORDER BY score DESC
     ordered: true
     skip_reason: SQL-659
-    
+

--- a/resources/integration_test/tests/query.yaml
+++ b/resources/integration_test/tests/query.yaml
@@ -269,3 +269,4 @@ tests:
     sql: SELECT grades.score AS score FROM grades ORDER BY score DESC
     ordered: true
     skip_reason: SQL-659
+    

--- a/resources/integration_test/tests/query.yaml
+++ b/resources/integration_test/tests/query.yaml
@@ -5,108 +5,38 @@ tests:
     ordered: true
     skip_reason: SQL-659
 
-  - description: select_star_from_grades_unordered
-    db: integration_test
-    sql: SELECT * FROM grades
-    expected_result:
-      - [0, 84.5, 303, 3]
-      - [1, 97.4, 10329, 3]
-      - [2, 89.3, 342, 3]
-      - [3, 91.9, 204323, 3]
-      - [4, 87.5, 303, 5]
-      - [5, 74.4, 10329, 5]
-      - [6, 80.1, 342, 5]
-      - [7, 83.3, 204323, 5]
-      - [8, 78.5, 200, 5]
-    row_count: 9
-    ordered: false
-    expected_sql_type: [INTEGER, DOUBLE, INTEGER, INTEGER]
-    expected_catalog_name: ['', '', '', '']
-    expected_column_class_name: [int, double, int, int]
-    expected_column_label: [_id, score, studentid, testid]
-    expected_column_display_size: [10, 15, 10, 10]
-    expected_precision: [10, 15, 10, 10]
-    expected_scale: [0, 15, 0, 0]
-    expected_schema_name: ['', '', '', '']
-    expected_is_auto_increment: [false, false, false, false]
-    expected_is_case_sensitive: [false, false, false, false]
-    expected_is_currency: [false, false, false, false]
-    expected_is_definitely_writable: [false, false, false, false]
-    expected_is_nullable: [columnNullable, columnNullable, columnNullable, columnNullable]
-    expected_is_read_only: [true, true, true, true]
-    expected_is_searchable: [true, true, true, true]
-    expected_is_signed: [true, true, true, true]
-    expected_is_writable: [false, false, false, false]
-
-  - description: select_star_from_class_ordered
-    db: integration_test
-    sql: SELECT * FROM class ORDER BY _id;
-    ordered: true
-    skip_reason: SQL-659
-
   - description: select_star_from_class_unordered
     db: integration_test
     sql: SELECT * FROM class
     expected_result:
-      - [0, true, John, 10329]
-      - [1, false, Jane, 342]
-      - [2, true, Mike, 303]
-      - [3, false, Mary, 204323]
-      - [4, false, Pete, 10]
+      - [ 0, true, John, 2000-01-01, 10329 ]
+      - [ 1, false, Jane, 2000-02-01, 342 ]
+      - [ 2, true, Mike, 2000-01-01, 303 ]
+      - [ 3, false, Mary, 2000-03-01, 204323 ]
+      - [ 4, false, Pete, 2000-01-01, 10 ]
     row_count: 5
     ordered: false
-    expected_sql_type: [INTEGER, BIT, LONGVARCHAR, INTEGER]
-    expected_catalog_name: ['', '', '', '']
-    expected_column_class_name: [int, boolean, java.lang.String, int]
-    expected_column_label: [_id, enrolled, name, studentid]
-    expected_column_display_size: [10, 1, 0, 10]
-    expected_precision: [10, 1, 0, 10]
-    expected_scale: [0, 0, 0, 0]
-    expected_schema_name: ['', '', '', '']
-    expected_is_auto_increment: [false, false, false, false]
-    expected_is_case_sensitive: [false, false, true, false]
-    expected_is_currency: [false, false, false, false]
-    expected_is_definitely_writable: [false, false, false, false]
-    expected_is_nullable: [columnNullable, columnNullable, columnNullable, columnNullable]
-    expected_is_read_only: [true, true, true, true]
-    expected_is_searchable: [true, true, true, true]
-    expected_is_signed: [true, false, false, true]
-    expected_is_writable: [false, false, false, false]
+    expected_sql_type: [ INTEGER, BIT, LONGVARCHAR, TIMESTAMP, INTEGER ]
+    expected_catalog_name: [ '', '', '', '', '' ]
+    expected_column_class_name: [ int, boolean, java.lang.String, java.sql.Timestamp,
+                                  int ]
+    expected_column_label: [ _id, enrolled, name, startdate, studentid ]
+    expected_column_display_size: [ 10, 1, 0, 24, 10 ]
+    expected_precision: [ 10, 1, 0, 24, 10 ]
+    expected_scale: [ 0, 0, 0, 0, 0 ]
+    expected_schema_name: [ '', '', '', '', '' ]
+    expected_is_auto_increment: [ false, false, false, false, false ]
+    expected_is_case_sensitive: [ false, false, true, false, false ]
+    expected_is_currency: [ false, false, false, false, false ]
+    expected_is_definitely_writable: [ false, false, false, false, false ]
+    expected_is_nullable: [ columnNullable, columnNullable, columnNullable, columnNullable,
+                            columnNullable ]
+    expected_is_read_only: [ true, true, true, true, true ]
+    expected_is_searchable: [ true, true, true, true, true ]
+    expected_is_signed: [ true, false, false, false, true ]
+    expected_is_writable: [ false, false, false, false, false ]
 
-  - description: select_as_from_grades
-    db: integration_test
-    sql: SELECT score AS s, testid AS t FROM grades
-    expected_result:
-      - [ 84.5, 3 ]
-      - [ 97.4, 3 ]
-      - [ 89.3, 3 ]
-      - [ 91.9, 3 ]
-      - [ 87.5, 5 ]
-      - [ 74.4, 5 ]
-      - [ 80.1, 5 ]
-      - [ 83.3, 5 ]
-      - [ 78.5, 5 ]
-    row_count: 9
-    ordered: false
-    expected_sql_type: [ DOUBLE, INTEGER ]
-    expected_catalog_name: [ '', '' ]
-    expected_column_class_name: [ double, int ]
-    expected_column_label: [ s, t ]
-    expected_column_display_size: [ 15, 10 ]
-    expected_precision: [ 15, 10 ]
-    expected_scale: [ 15, 0 ]
-    expected_schema_name: [ '', '' ]
-    expected_is_auto_increment: [ false, false ]
-    expected_is_case_sensitive: [ false, false ]
-    expected_is_currency: [ false, false ]
-    expected_is_definitely_writable: [ false, false ]
-    expected_is_nullable: [ columnNullable, columnNullable ]
-    expected_is_read_only: [ true, true ]
-    expected_is_searchable: [ true, true ]
-    expected_is_signed: [ true, true ]
-    expected_is_writable: [ false, false ]
-
-  - description: select_as_from_class
+  - description: select_as_confirm_column_label
     db: integration_test
     sql: SELECT enrolled AS e, studentid AS s, name AS n from class
     expected_result:
@@ -135,18 +65,6 @@ tests:
     expected_is_signed: [ false, false, true ]
     expected_is_writable: [ false, false, false ]
 
-  - description: limit_from_grades
-    db: integration_test
-    sql: SELECT studentid, score, testid FROM grades ORDER BY 1, 2, 3 DESC LIMIT 5
-    ordered: true
-    skip_reason: SQL-659
-
-  - description: limit_from_class
-    db: integration_test
-    sql: SELECT studentid, name FROM class ORDER BY 1, 2 ASC LIMIT 2
-    ordered: true
-    skip_reason: SQL-659
-
   - description: inner_join
     db: integration_test
     sql: "SELECT class.name, grades.testid, grades.score FROM grades INNER JOIN class ON grades.studentid\
@@ -154,140 +72,126 @@ tests:
     ordered: false
     skip_reason: SQL-659
 
-  - description: right_join
-    db: integration_test
-    sql: "SELECT class.name, grades.testid, grades.score FROM grades RIGHT JOIN class ON grades.studentid\
-      = class.studentid"
-    ordered: false
-    skip_reason: SQL-659
-
-  - description: left_join
-    db: integration_test
-    sql: "SELECT class.name, grades.testid, grades.score FROM grades LEFT JOIN class ON grades.studentid\
-      = class.studentid"
-    ordered: false
-    skip_reason: SQL-659
-
-  - description: cross_join
-    db: integration_test
-    sql: "SELECT class.name, grades.testid, grades.score FROM grades CROSS JOIN class"
-    expected_result:
-    - [ John, 84.5, 3 ]
-    - [ Jane, 84.5, 3 ]
-    - [ Mike, 84.5, 3 ]
-    - [ Mary, 84.5, 3 ]
-    - [ Pete, 84.5, 3 ]
-    - [ John, 97.4, 3 ]
-    - [ Jane, 97.4, 3 ]
-    - [ Mike, 97.4, 3 ]
-    - [ Mary, 97.4, 3 ]
-    - [ Pete, 97.4, 3 ]
-    - [ John, 89.3, 3 ]
-    - [ Jane, 89.3, 3 ]
-    - [ Mike, 89.3, 3 ]
-    - [ Mary, 89.3, 3 ]
-    - [ Pete, 89.3, 3 ]
-    - [ John, 91.9, 3 ]
-    - [ Jane, 91.9, 3 ]
-    - [ Mike, 91.9, 3 ]
-    - [ Mary, 91.9, 3 ]
-    - [ Pete, 91.9, 3 ]
-    - [ John, 87.5, 5 ]
-    - [ Jane, 87.5, 5 ]
-    - [ Mike, 87.5, 5 ]
-    - [ Mary, 87.5, 5 ]
-    - [ Pete, 87.5, 5 ]
-    - [ John, 74.4, 5 ]
-    - [ Jane, 74.4, 5 ]
-    - [ Mike, 74.4, 5 ]
-    - [ Mary, 74.4, 5 ]
-    - [ Pete, 74.4, 5 ]
-    - [ John, 80.1, 5 ]
-    - [ Jane, 80.1, 5 ]
-    - [ Mike, 80.1, 5 ]
-    - [ Mary, 80.1, 5 ]
-    - [ Pete, 80.1, 5 ]
-    - [ John, 83.3, 5 ]
-    - [ Jane, 83.3, 5 ]
-    - [ Mike, 83.3, 5 ]
-    - [ Mary, 83.3, 5 ]
-    - [ Pete, 83.3, 5 ]
-    - [ John, 78.5, 5 ]
-    - [ Jane, 78.5, 5 ]
-    - [ Mike, 78.5, 5 ]
-    - [ Mary, 78.5, 5 ]
-    - [ Pete, 78.5, 5 ]
-    row_count: 45
-    ordered: false
-    expected_sql_type: [ LONGVARCHAR, DOUBLE, INTEGER ]
-    expected_catalog_name: [ '', '', '' ]
-    expected_column_class_name: [ java.lang.String, double, int ]
-    expected_column_label: [ name, score, testid ]
-    expected_column_display_size: [ 0, 15, 10 ]
-    expected_precision: [ 0, 15, 10 ]
-    expected_scale: [ 0, 15, 0 ]
-    expected_schema_name: [ '', '', '' ]
-    expected_is_auto_increment: [ false, false, false ]
-    expected_is_case_sensitive: [ true, false, false ]
-    expected_is_currency: [ false, false, false ]
-    expected_is_definitely_writable: [ false, false, false ]
-    expected_is_nullable: [ columnNullable, columnNullable, columnNullable ]
-    expected_is_read_only: [ true, true, true ]
-    expected_is_searchable: [ true, true, true ]
-    expected_is_signed: [ false, true, true ]
-    expected_is_writable: [ false, false, false ]
-
   - description: subquery
     db: integration_test
     sql: SELECT studentid FROM (SELECT * FROM class WHERE enrolled = TRUE) AS foo
     ordered: false
     skip_reason: SQL-659
 
-  - description: count_from_grades
-    db: integration_test
-    sql: SELECT COUNT(studentid) FROM grades
-    ordered: false
-    skip_reason: SQL-658
-
-  - description: count_star_from_grades
-    db: integration_test
-    sql: SELECT COUNT(*) As C FROM grades
-    ordered: false
-    skip_reason: SQL-658
-
-  - description: count_from_class
-    db: integration_test
-    sql: SELECT COUNT(studentid) FROM class
-    ordered: false
-    skip_reason: SQL-658
-
-  - description: average
-    db: integration_test
-    sql: SELECT avg(score) FROM grades where testid=5
-    ordered: false
-    skip_reason: SQL-659
-
-  - description: max
-    db: integration_test
-    sql: SELECT max(score) FROM grades
-    ordered: false
-    skip_reason: SQL-659
-
-  - description: group_by
+  - description: count_and_group_by
     db: integration_test
     sql: SELECT COUNT(score), testid FROM grades WHERE score > 85 GROUP BY testid
     ordered: false
     skip_reason: SQL-658
 
-  - description: ascending
-    db: integration_test
-    sql: SELECT grades.score AS score FROM grades ORDER BY score ASC
-    ordered: true
-    skip_reason: SQL-659
-
-  - description: descending
+  - description: driver_does_not_alter_result_set_row_order
     db: integration_test
     sql: SELECT grades.score AS score FROM grades ORDER BY score DESC
     ordered: true
     skip_reason: SQL-659
+
+  - description: select_star_from_anyof
+    db: integration_test
+    skip_reason: SQL-668
+
+  - description: select_star_from_any
+    db: integration_test
+    sql: SELECT * from any
+    skip_reason: SQL-696
+
+  - description: select_field_from_any
+    db: integration_test
+    sql: SELECT b from any_collection
+    expected_result:
+      - - !!org.bson.BsonInt32  3
+      - - !!org.bson.BsonString  b
+      - - !!org.bson.BsonDouble  4.5
+    row_count: 3
+    row_count_gte: null
+    ordered: null
+    expected_sql_type: [ OTHER ]
+    expected_catalog_name: [ '' ]
+    expected_column_class_name: [ org.bson.BsonValue ]
+    expected_column_label: [ b ]
+    expected_column_display_size: [ 0 ]
+    expected_precision: [ 0 ]
+    expected_scale: [ 0 ]
+    expected_schema_name: [ '' ]
+    expected_is_auto_increment: [ false ]
+    expected_is_case_sensitive: [ true ]
+    expected_is_currency: [ false ]
+    expected_is_definitely_writable: [ false ]
+    expected_is_nullable: [ columnNullable ]
+    expected_is_read_only: [ true ]
+    expected_is_searchable: [ true ]
+    expected_is_signed: [ true ]
+    expected_is_writable: [ false ]
+
+  - description: nonexist_field_return_null
+    db: integration_test
+    sql: SELECT nonexist FROM class
+    skip_reason: SQL-698
+
+  - description: select_null_field
+    db: integration_test
+    sql: SELECT a FROM null_field
+    expected_result:
+      - [a]
+      - [null]
+    row_count: 2
+    expected_sql_type: [LONGVARCHAR]
+    expected_catalog_name: ['']
+    expected_column_class_name: [java.lang.String]
+    expected_column_label: [a]
+    expected_column_display_size: [0]
+    expected_precision: [0]
+    expected_scale: [0]
+    expected_schema_name: ['']
+    expected_is_auto_increment: [false]
+    expected_is_case_sensitive: [true]
+    expected_is_currency: [false]
+    expected_is_definitely_writable: [false]
+    expected_is_nullable: [columnNullable]
+    expected_is_read_only: [true]
+    expected_is_searchable: [true]
+    expected_is_signed: [false]
+    expected_is_writable: [false]
+
+  - description: lexicographical_column_ordering
+    db: integration_test
+    sql: select * from b_column_order inner join a_column_order
+    expected_result:
+      - [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
+    row_count: 1
+    expected_sql_type: [INTEGER, INTEGER, INTEGER, INTEGER, INTEGER, INTEGER, INTEGER,
+                        INTEGER, INTEGER, INTEGER, INTEGER, INTEGER, INTEGER, INTEGER]
+    expected_catalog_name: ['', '', '', '', '', '', '', '', '', '', '', '', '', '']
+    expected_column_class_name: [int, int, int, int, int, int, int, int, int, int,
+                                 int, int, int, int]
+    expected_column_label: [A, B, C, _id, a, b, c, A, B, C, _id, a, b, c]
+    expected_column_display_size: [10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10,
+                                   10, 10]
+    expected_precision: [10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10]
+    expected_scale: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    expected_schema_name: ['', '', '', '', '', '', '', '', '', '', '', '', '', '']
+    expected_is_auto_increment: [false, false, false, false, false, false, false,
+                                 false, false, false, false, false, false, false]
+    expected_is_case_sensitive: [false, false, false, false, false, false, false,
+                                 false, false, false, false, false, false, false]
+    expected_is_currency: [false, false, false, false, false, false, false, false,
+                           false, false, false, false, false, false]
+    expected_is_definitely_writable: [false, false, false, false, false, false, false,
+                                      false, false, false, false, false, false, false]
+    expected_is_nullable: [columnNullable, columnNullable, columnNullable, columnNullable,
+                           columnNullable, columnNullable, columnNullable, columnNullable, columnNullable,
+                           columnNullable, columnNullable, columnNullable, columnNullable, columnNullable]
+    expected_is_read_only: [true, true, true, true, true, true, true, true, true,
+                            true, true, true, true, true]
+    expected_is_searchable: [true, true, true, true, true, true, true, true, true,
+                             true, true, true, true, true]
+    expected_is_signed: [true, true, true, true, true, true, true, true, true, true,
+                         true, true, true, true]
+    expected_is_writable: [false, false, false, false, false, false, false, false,
+                           false, false, false, false, false, false]
+
 

--- a/resources/integration_test/tests/query.yaml
+++ b/resources/integration_test/tests/query.yaml
@@ -5,7 +5,7 @@ tests:
     ordered: true
     skip_reason: SQL-659
 
-  - description: select_star_from_class_unordered
+  - description: select_star_unordered
     db: integration_test
     sql: SELECT * FROM class
     expected_result:

--- a/resources/integration_test/tests/query.yaml
+++ b/resources/integration_test/tests/query.yaml
@@ -1,5 +1,5 @@
 tests:
-  - description: select_star_from_grades_ordered
+  - description: select_star_ordered
     db: integration_test
     sql: SELECT * FROM grades ORDER BY _id
     ordered: true

--- a/resources/integration_test/tests/query.yaml
+++ b/resources/integration_test/tests/query.yaml
@@ -78,12 +78,6 @@ tests:
     ordered: false
     skip_reason: SQL-659
 
-  - description: count_and_group_by
-    db: integration_test
-    sql: SELECT COUNT(score), testid FROM grades WHERE score > 85 GROUP BY testid
-    ordered: false
-    skip_reason: SQL-658
-
   - description: driver_does_not_alter_result_set_row_order
     db: integration_test
     sql: SELECT grades.score AS score FROM grades ORDER BY score DESC
@@ -92,11 +86,12 @@ tests:
 
   - description: select_star_from_anyof
     db: integration_test
+    sql: SELECT * FROM anyof_collection
     skip_reason: SQL-668
 
   - description: select_star_from_any
     db: integration_test
-    sql: SELECT * from any
+    sql: SELECT * from any_collection
     skip_reason: SQL-696
 
   - description: select_polymorphic_field
@@ -127,71 +122,62 @@ tests:
     expected_is_signed: [ true ]
     expected_is_writable: [ false ]
 
-  - description: nonexist_field_return_null
+  - description: select_null_and_missing_field
     db: integration_test
-    sql: SELECT nonexist FROM class
+    sql: SELECT a FROM null_and_missing
     skip_reason: SQL-698
-
-  - description: select_null_field
-    db: integration_test
-    sql: SELECT a FROM null_field
     expected_result:
-      - [a]
-      - [null]
-    row_count: 2
-    expected_sql_type: [LONGVARCHAR]
-    expected_catalog_name: ['']
-    expected_column_class_name: [java.lang.String]
-    expected_column_label: [a]
-    expected_column_display_size: [0]
-    expected_precision: [0]
-    expected_scale: [0]
-    expected_schema_name: ['']
-    expected_is_auto_increment: [false]
-    expected_is_case_sensitive: [true]
-    expected_is_currency: [false]
-    expected_is_definitely_writable: [false]
-    expected_is_nullable: [columnNullable]
-    expected_is_read_only: [true]
-    expected_is_searchable: [true]
-    expected_is_signed: [false]
-    expected_is_writable: [false]
+      - - !!org.bson.BsonTimestamp 1
+      - - null
+      - - null
+    row_count: 1
+    expected_sql_type: [ OTHER ]
+    expected_catalog_name: [ '' ]
+    expected_column_class_name: [ org.bson.BsonValue ]
+    expected_column_label: [ a ]
+    expected_column_display_size: [ 0 ]
+    expected_precision: [ 0 ]
+    expected_scale: [ 0 ]
+    expected_schema_name: [ '' ]
+    expected_is_auto_increment: [ false ]
+    expected_is_case_sensitive: [ false ]
+    expected_is_currency: [ false ]
+    expected_is_definitely_writable: [ false ]
+    expected_is_nullable: [ columnNullable ]
+    expected_is_read_only: [ true ]
+    expected_is_searchable: [ true ]
+    expected_is_signed: [ false ]
+    expected_is_writable: [ false ]
 
   - description: lexicographical_column_ordering
     db: integration_test
-    sql: select * from b_column_order inner join a_column_order
+    sql: select * from b_non_lexicographic_field_order inner join a_non_lexicographic_field_order
     expected_result:
-      - [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
+      - [1, 2, 3, 4, 5, 6, 7, 8, 9]
     row_count: 1
     expected_sql_type: [INTEGER, INTEGER, INTEGER, INTEGER, INTEGER, INTEGER, INTEGER,
-                        INTEGER, INTEGER, INTEGER, INTEGER, INTEGER, INTEGER, INTEGER]
-    expected_catalog_name: ['', '', '', '', '', '', '', '', '', '', '', '', '', '']
-    expected_column_class_name: [int, int, int, int, int, int, int, int, int, int,
-                                 int, int, int, int]
-    expected_column_label: [A, B, C, _id, a, b, c, A, B, C, _id, a, b, c]
-    expected_column_display_size: [10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10,
-                                   10, 10]
-    expected_precision: [10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10]
-    expected_scale: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-    expected_schema_name: ['', '', '', '', '', '', '', '', '', '', '', '', '', '']
+                        INTEGER, INTEGER]
+    expected_catalog_name: ['', '', '', '', '', '', '', '', '']
+    expected_column_class_name: [int, int, int, int, int, int, int, int, int]
+    expected_column_label: [A, B, C, _id, a, b, c, _id, a]
+    expected_column_display_size: [10, 10, 10, 10, 10, 10, 10, 10, 10]
+    expected_precision: [10, 10, 10, 10, 10, 10, 10, 10, 10]
+    expected_scale: [0, 0, 0, 0, 0, 0, 0, 0, 0]
+    expected_schema_name: ['', '', '', '', '', '', '', '', '']
     expected_is_auto_increment: [false, false, false, false, false, false, false,
-                                 false, false, false, false, false, false, false]
+                                 false, false]
     expected_is_case_sensitive: [false, false, false, false, false, false, false,
-                                 false, false, false, false, false, false, false]
+                                 false, false]
     expected_is_currency: [false, false, false, false, false, false, false, false,
-                           false, false, false, false, false, false]
+                           false]
     expected_is_definitely_writable: [false, false, false, false, false, false, false,
-                                      false, false, false, false, false, false, false]
+                                      false, false]
     expected_is_nullable: [columnNullable, columnNullable, columnNullable, columnNullable,
-                           columnNullable, columnNullable, columnNullable, columnNullable, columnNullable,
                            columnNullable, columnNullable, columnNullable, columnNullable, columnNullable]
-    expected_is_read_only: [true, true, true, true, true, true, true, true, true,
-                            true, true, true, true, true]
-    expected_is_searchable: [true, true, true, true, true, true, true, true, true,
-                             true, true, true, true, true]
-    expected_is_signed: [true, true, true, true, true, true, true, true, true, true,
-                         true, true, true, true]
+    expected_is_read_only: [true, true, true, true, true, true, true, true, true]
+    expected_is_searchable: [true, true, true, true, true, true, true, true, true]
+    expected_is_signed: [true, true, true, true, true, true, true, true, true]
     expected_is_writable: [false, false, false, false, false, false, false, false,
-                           false, false, false, false, false, false]
+                           false]
 
 

--- a/resources/integration_test/tests/query.yaml
+++ b/resources/integration_test/tests/query.yaml
@@ -99,7 +99,7 @@ tests:
     sql: SELECT * from any
     skip_reason: SQL-696
 
-  - description: select_field_from_any
+  - description: select_polymorphic_field
     db: integration_test
     sql: SELECT b from any_collection
     expected_result:

--- a/resources/integration_test/tests/query.yaml
+++ b/resources/integration_test/tests/query.yaml
@@ -1,6 +1,7 @@
 tests:
   - description: select_star_from_grades_ordered
     sql: SELECT * FROM grades ORDER BY _id
+    ordered: true
     skip_reason: SQL-659
 
   - description: select_star_from_grades_unordered
@@ -37,6 +38,7 @@ tests:
 
   - description: select_star_from_class_ordered
     sql: SELECT * FROM class ORDER BY _id;
+    ordered: true
     skip_reason: SQL-659
 
   - description: select_star_from_class_unordered
@@ -129,25 +131,30 @@ tests:
 
   - description: limit_from_grades
     sql: SELECT studentid, score, testid FROM grades ORDER BY 1, 2, 3 DESC LIMIT 5
+    ordered: true
     skip_reason: SQL-659
 
   - description: limit_from_class
     sql: SELECT studentid, name FROM class ORDER BY 1, 2 ASC LIMIT 2
+    ordered: true
     skip_reason: SQL-659
 
   - description: inner_join
     sql: "SELECT class.name, grades.testid, grades.score FROM grades INNER JOIN class ON grades.studentid\
       = class.studentid"
+    ordered: false
     skip_reason: SQL-659
 
   - description: right_join
     sql: "SELECT class.name, grades.testid, grades.score FROM grades RIGHT JOIN class ON grades.studentid\
       = class.studentid"
+    ordered: false
     skip_reason: SQL-659
 
   - description: left_join
     sql: "SELECT class.name, grades.testid, grades.score FROM grades LEFT JOIN class ON grades.studentid\
       = class.studentid"
+    ordered: false
     skip_reason: SQL-659
 
   - description: cross_join
@@ -220,36 +227,45 @@ tests:
 
   - description: subquery
     sql: SELECT studentid FROM (SELECT * FROM class WHERE enrolled = TRUE) AS foo
+    ordered: false
     skip_reason: SQL-659
 
   - description: count_from_grades
     sql: SELECT COUNT(studentid) FROM grades
+    ordered: false
     skip_reason: SQL-658
 
   - description: count_star_from_grades
     sql: SELECT COUNT(*) As C FROM grades
+    ordered: false
     skip_reason: SQL-658
 
   - description: count_from_class
     sql: SELECT COUNT(studentid) FROM class
+    ordered: false
     skip_reason: SQL-658
 
   - description: average
     sql: SELECT avg(score) FROM grades where testid=5
+    ordered: false
     skip_reason: SQL-659
 
   - description: max
     sql: SELECT max(score) FROM grades
+    ordered: false
     skip_reason: SQL-659
 
   - description: group_by
     sql: SELECT COUNT(score), testid FROM grades WHERE score > 85 GROUP BY testid
+    ordered: false
     skip_reason: SQL-658
 
   - description: ascending
     sql: SELECT grades.score AS score FROM grades ORDER BY score ASC
+    ordered: true
     skip_reason: SQL-659
 
   - description: descending
     sql: SELECT grades.score AS score FROM grades ORDER BY score DESC
+    ordered: true
     skip_reason: SQL-659

--- a/src/integration-test/java/com/mongodb/jdbc/integration/testharness/DataLoader.java
+++ b/src/integration-test/java/com/mongodb/jdbc/integration/testharness/DataLoader.java
@@ -56,19 +56,6 @@ public class DataLoader {
         readDataFiles(dataDirectory);
     }
 
-    private void generateSchema() {
-        BsonDocument command = new BsonDocument();
-        command.put("sqlGenerateSchema", new BsonInt32(1));
-        command.put("setSchemas", new BsonBoolean(true));
-
-        try (MongoClient mongoClient = new MongoClient(adlUri)) {
-            for (String database : databases) {
-                MongoDatabase db = mongoClient.getDatabase(database);
-                db.runCommand(command);
-            }
-        }
-    }
-
     private void readDataFiles(String dataDirectory) throws IOException {
         File folder = new File(dataDirectory);
         for (final File fileEntry : Objects.requireNonNull(folder.listFiles())) {
@@ -118,7 +105,7 @@ public class DataLoader {
         }
     }
 
-    private void generateSchemaOne(String database, String collection) {
+    private void generateSchema(String database, String collection) {
         BsonDocument command = new BsonDocument();
         command.put("sqlGenerateSchema", new BsonInt32(1));
         command.put("setSchemas", new BsonBoolean(true));
@@ -169,7 +156,7 @@ public class DataLoader {
                         }
                     }
                     if (entry.schema == null) {
-                        generateSchemaOne(entry.db, entry.collection);
+                        generateSchema(entry.db, entry.collection);
                     }
                     if (entry.schema != null) {
                         setSchema(entry.db, entry.collection, entry.schema);

--- a/src/integration-test/java/com/mongodb/jdbc/integration/testharness/IntegrationTestUtils.java
+++ b/src/integration-test/java/com/mongodb/jdbc/integration/testharness/IntegrationTestUtils.java
@@ -418,6 +418,11 @@ public class IntegrationTestUtils {
                         return false;
                     }
                     break;
+                case Types.TIMESTAMP:
+                    if (!expectedRow.get(i).equals(actualRow.getDate(i + 1))) {
+                        return false;
+                    }
+                    break;
                     // TODO: SQL-632 Support Types.OTHER
                     // This comparison needs to be improved to correctly handle Types.OTHER
                     /*
@@ -426,6 +431,11 @@ public class IntegrationTestUtils {
                             return false;
                         }
                      */
+                case Types.OTHER:
+                    if (!expectedRow.get(i).equals(actualRow.getObject(i + 1))) {
+                        return false;
+                    }
+                    break;
                 default:
                     throw new IllegalArgumentException("unsupported column type:" + columnType);
             }

--- a/src/integration-test/java/com/mongodb/jdbc/integration/testharness/README.md
+++ b/src/integration-test/java/com/mongodb/jdbc/integration/testharness/README.md
@@ -1,0 +1,29 @@
+### Test Generator  
+Included in the test harness is a test generator that will generate baseline configurations for test cases based on
+the `description`, `db`, and either `query` or `meta_function` fields for all test cases in the 
+`resources/integration_test/tests` directory.
+#### Initial Tests
+Create a yaml file in the `resources/integration_test/tests` directory in the following format.  The required fields 
+are `description`, `db`, and one of either `sql` or `meta_function`.
+```
+# test.yaml
+tests:
+  - description: test_case_description
+    db: database_to_use
+    sql: SQL Query
+    
+  - description: test_case_description
+    db: database_to_use
+    # meta_function takes an array.  Function name followed by arguments.
+    meta_function: [meta_function, arg1, arg2, ..., argn]
+```
+#### Running  
+```
+./gradlew runTestGenerator  
+```
+Generated files will be written to the `resources/generated_test` directory with the description as the 
+filename prefix, one file per test case.  
+
+To test the generated test cases, copy the file(s) to the `resources/integration_test/tests` directory and verify it 
+passes the integration test.  Once verified, commit the file in the `resources/integration_test/tests` directory to 
+add it to the integration test.

--- a/src/integration-test/java/com/mongodb/jdbc/integration/testharness/README.md
+++ b/src/integration-test/java/com/mongodb/jdbc/integration/testharness/README.md
@@ -15,7 +15,7 @@ tests:
   - description: test_case_description
     db: database_to_use
     # meta_function takes an array.  Function name followed by arguments.
-    meta_function: [meta_function, arg1, arg2, ..., argn]
+    meta_function: [Function name, arg1, arg2, ..., argn]
 ```
 #### Running  
 ```

--- a/src/integration-test/java/com/mongodb/jdbc/integration/testharness/models/TestDataEntry.java
+++ b/src/integration-test/java/com/mongodb/jdbc/integration/testharness/models/TestDataEntry.java
@@ -7,4 +7,5 @@ public class TestDataEntry {
     public String db;
     public String collection;
     public List<Map<String, Object>> docs;
+    public Map<String, Object> schema;
 }

--- a/src/main/java/com/mongodb/jdbc/MongoSQLStatement.java
+++ b/src/main/java/com/mongodb/jdbc/MongoSQLStatement.java
@@ -13,6 +13,8 @@ import org.bson.BsonInt32;
 import org.bson.BsonString;
 
 public class MongoSQLStatement extends MongoStatement<BsonDocument> implements Statement {
+    private final BsonInt32 formatVersion = new BsonInt32(1);
+
     public MongoSQLStatement(MongoConnection conn, String databaseName) throws SQLException {
         super(conn, databaseName);
     }
@@ -22,7 +24,7 @@ public class MongoSQLStatement extends MongoStatement<BsonDocument> implements S
         checkClosed();
         closeExistingResultSet();
 
-        BsonDocument stage = constructQueryDocument(sql, "mongosql");
+        BsonDocument stage = constructQueryDocument(sql, "mongosql", formatVersion);
         BsonDocument getSchemaCmd = constructSQLGetResultSchemaDocument(sql);
         try {
             MongoIterable<BsonDocument> iterable =

--- a/src/main/java/com/mongodb/jdbc/MongoStatement.java
+++ b/src/main/java/com/mongodb/jdbc/MongoStatement.java
@@ -33,7 +33,8 @@ public abstract class MongoStatement<T> implements Statement {
         }
     }
 
-    protected BsonDocument constructQueryDocument(String sql, String dialect, BsonInt32 formatVersion) {
+    protected BsonDocument constructQueryDocument(
+            String sql, String dialect, BsonInt32 formatVersion) {
         BsonDocument stage = new BsonDocument();
         BsonDocument sqlDoc = new BsonDocument();
         sqlDoc.put("statement", new BsonString(sql));

--- a/src/main/java/com/mongodb/jdbc/MongoStatement.java
+++ b/src/main/java/com/mongodb/jdbc/MongoStatement.java
@@ -19,7 +19,6 @@ public abstract class MongoStatement<T> implements Statement {
     protected int fetchSize = 0;
     protected int maxQuerySec = 0;
     protected String currentDBName;
-    protected final BsonInt32 formatVersion = new BsonInt32(2);
 
     public MongoStatement(MongoConnection conn, String databaseName) throws SQLException {
         Preconditions.checkNotNull(conn);
@@ -34,7 +33,7 @@ public abstract class MongoStatement<T> implements Statement {
         }
     }
 
-    protected BsonDocument constructQueryDocument(String sql, String dialect) {
+    protected BsonDocument constructQueryDocument(String sql, String dialect, BsonInt32 formatVersion) {
         BsonDocument stage = new BsonDocument();
         BsonDocument sqlDoc = new BsonDocument();
         sqlDoc.put("statement", new BsonString(sql));

--- a/src/main/java/com/mongodb/jdbc/MySQLStatement.java
+++ b/src/main/java/com/mongodb/jdbc/MySQLStatement.java
@@ -9,9 +9,11 @@ import java.sql.Statement;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 import org.bson.BsonDocument;
+import org.bson.BsonInt32;
 
 public class MySQLStatement extends MongoStatement<MySQLResultDoc> implements Statement {
     private boolean relaxed;
+    private final BsonInt32 formatVersion = new BsonInt32(2);
 
     public MySQLStatement(MongoConnection conn, String databaseName, boolean relaxed)
             throws SQLException {
@@ -24,7 +26,7 @@ public class MySQLStatement extends MongoStatement<MySQLResultDoc> implements St
         checkClosed();
         closeExistingResultSet();
 
-        BsonDocument stage = constructQueryDocument(sql, "mysql");
+        BsonDocument stage = constructQueryDocument(sql, "mysql", formatVersion);
         try {
             MongoIterable<MySQLResultDoc> iterable =
                     currentDB


### PR DESCRIPTION
…aData methods

JIRA: https://jira.mongodb.org/browse/SQL-555

Adding queries to be run by the mongosql JDBC integration test.

Added change to expected formatVersion for mongosql. 
Added rows to dataset to return different rows for the different joins.
Many of the queries have a skip reason regarding the get namespace call returning an error: SQL-659 and SQL-658