### PR TITLE
SQL-563: Update integration tests and data loader to use db defined per test

### DIFF
--- a/src/integration-test/java/com/mongodb/jdbc/integration/MongoSQLIntegrationTest.java
+++ b/src/integration-test/java/com/mongodb/jdbc/integration/MongoSQLIntegrationTest.java
@@ -21,13 +21,13 @@ public class MongoSQLIntegrationTest {
     public static final String TEST_DIRECTORY = "resources/integration_test/tests";
     private List<TestEntry> testEntries;
 
-    public Connection getBasicConnection() throws SQLException {
+    public Connection getBasicConnection(String db) throws SQLException {
         java.util.Properties p = new java.util.Properties();
         p.setProperty("dialect", MONGOSQL);
         p.setProperty("user", System.getenv("ADL_TEST_LOCAL_USER"));
         p.setProperty("password", System.getenv("ADL_TEST_LOCAL_PWD"));
         p.setProperty("authSource", System.getenv("ADL_TEST_LOCAL_AUTH_DB"));
-        p.setProperty("database", "integration_test");
+        p.setProperty("database", db);
         p.setProperty("ssl", "false");
         return DriverManager.getConnection(URL, p);
     }
@@ -48,7 +48,7 @@ public class MongoSQLIntegrationTest {
                     DynamicTest.dynamicTest(
                             testEntry.description,
                             () -> {
-                                try (Connection conn = getBasicConnection()) {
+                                try (Connection conn = getBasicConnection(testEntry.db)) {
                                     IntegrationTestUtils.runTest(testEntry, conn, false);
                                 }
                             }));

--- a/src/integration-test/java/com/mongodb/jdbc/integration/testharness/TestGenerator.java
+++ b/src/integration-test/java/com/mongodb/jdbc/integration/testharness/TestGenerator.java
@@ -134,10 +134,10 @@ public class TestGenerator {
     public static void main(String[] args)
             throws SQLException, IOException, InvocationTargetException, IllegalAccessException {
         MongoSQLIntegrationTest integrationTest = new MongoSQLIntegrationTest();
-        try (Connection conn = integrationTest.getBasicConnection()) {
-            List<TestEntry> tests =
-                    IntegrationTestUtils.loadTestConfigs(MongoSQLIntegrationTest.TEST_DIRECTORY);
-            for (TestEntry testEntry : tests) {
+        List<TestEntry> tests =
+                IntegrationTestUtils.loadTestConfigs(MongoSQLIntegrationTest.TEST_DIRECTORY);
+        for (TestEntry testEntry : tests) {
+            try (Connection conn = integrationTest.getBasicConnection(testEntry.db)) {
                 if (testEntry.skip_reason != null) {
                     continue;
                 }

--- a/src/integration-test/java/com/mongodb/jdbc/integration/testharness/models/TestEntry.java
+++ b/src/integration-test/java/com/mongodb/jdbc/integration/testharness/models/TestEntry.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 public class TestEntry {
     public String description;
+    public String db;
     public String sql;
     public List<Object> meta_function;
     public String skip_reason;


### PR DESCRIPTION
This PR updates the `TestEntry` model to include the `db` keyword and updates the integration test and data loader codepaths to use that test-defined db when establishing a connection.