### PR TITLE
SQL-721: Handle null value in getTables() for tableNamePattern

### DIFF
--- a/resources/integration_test/tests/dbmd_variable_result_sets_data_methods.yml
+++ b/resources/integration_test/tests/dbmd_variable_result_sets_data_methods.yml
@@ -26,6 +26,63 @@ tests:
     expected_is_writable: [false]
 
   # getTables(catalog, schemaPattern, tableNamePattern, types)
+  - description: getTables_null_parameters_returns_all_tables
+    db: integration_test
+    #skip_reason: "SQL-669, SQL-672: incorrect column nullability. also, using 'collection' instead of 'table'"
+    meta_function: [ getTables, null, null, null, null ]
+    #expected_result:
+    #  - [db2, null, foo, table, null, null, null, null, null, null]
+    #  - [integration_test, null, a_non_lexicographic_field_order, table, null,
+    #     null, null, null, null, null]
+    #  - [integration_test, null, any_collection, table, null, null, null, null,
+    #     null, null]
+    #  - [integration_test, null, anyof_collection, table, null, null, null, null,
+    #     null, null]
+    #  - [integration_test, null, b_non_lexicographic_field_order, table, null,
+    #     null, null, null, null, null]
+    #  - [integration_test, null, bar, table, null, null, null, null, null, null]
+    #  - [integration_test, null, class, table, null, null, null, null, null,
+    #     null]
+    #  - [integration_test, null, foo, table, null, null, null, null, null, null]
+    #  - [integration_test, null, grades, table, null, null, null, null, null,
+    #     null]
+    #  - [integration_test, null, null_and_missing, table, null, null, null, null,
+    #     null, null]
+    #  - [integration_test, null, types_other, table, null, null, null, null,
+    #     null, null]
+    #  - [integration_test, null, baz, view, null, null, null, null, null, null]
+    row_count: 12
+    expected_sql_type: [ LONGVARCHAR, LONGVARCHAR, LONGVARCHAR, LONGVARCHAR, LONGVARCHAR,
+                         LONGVARCHAR, LONGVARCHAR, LONGVARCHAR, LONGVARCHAR, LONGVARCHAR ]
+    expected_catalog_name: [ '', '', '', '', '', '', '', '', '', '' ]
+    expected_column_class_name: [ java.lang.String, java.lang.String, java.lang.String,
+                                  java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String,
+                                  java.lang.String, java.lang.String ]
+    expected_column_label: [ TABLE_CAT, TABLE_SCHEM, TABLE_NAME, TABLE_TYPE, REMARKS,
+                             TYPE_CAT, TYPE_SCHEM, TYPE_NAME, SELF_REFERENCING_COL_NAME, REF_GENERATION ]
+    expected_column_display_size: [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ]
+    expected_precision: [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ]
+    expected_scale: [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ]
+    expected_schema_name: [ '', '', '', '', '', '', '', '', '', '' ]
+    expected_is_auto_increment: [ false, false, false, false, false, false, false,
+                                  false, false, false ]
+    expected_is_case_sensitive: [ true, true, true, true, true, true, true, true, true,
+                                  true ]
+    expected_is_currency: [ false, false, false, false, false, false, false, false,
+                            false, false ]
+    expected_is_definitely_writable: [ false, false, false, false, false, false, false,
+                                       false, false, false ]
+    #expected_is_nullable: [ columnNullable, columnNullable, columnNullable, columnNoNulls,
+    #                        columnNoNulls, columnNullable, columnNoNulls, columnNullable, columnNullable, columnNullable ]
+    expected_is_read_only: [ true, true, true, true, true, true, true, true, true,
+                             true ]
+    expected_is_searchable: [ true, true, true, true, true, true, true, true, true,
+                              true ]
+    expected_is_signed: [ false, false, false, false, false, false, false, false, false,
+                          false ]
+    expected_is_writable: [ false, false, false, false, false, false, false, false,
+                            false, false ]
+
   - description: getTables_no_filters_returns_all_tables
     db: integration_test
     skip_reason: "SQL-669, SQL-672: incorrect column nullability. also, using 'collection' instead of 'table'"

--- a/resources/integration_test/tests/dbmd_variable_result_sets_data_methods.yml
+++ b/resources/integration_test/tests/dbmd_variable_result_sets_data_methods.yml
@@ -458,7 +458,7 @@ tests:
     expected_is_writable: [false, false, false, false, false, false, false]
 
   # getColumns(catalog, schemaPattern, tableNamePattern, columnNamePattern)
-  - description: getColumns null parameters returns all columns
+  - description: getColumns_null_parameters_returns_all_columns
     db: integration_test
     meta_function: [ "getColumns", null, null, null, null ]
     skip_reason: "SQL-668: fix MongoJsonSchema bsonType String/Array conflict"

--- a/resources/integration_test/tests/dbmd_variable_result_sets_data_methods.yml
+++ b/resources/integration_test/tests/dbmd_variable_result_sets_data_methods.yml
@@ -438,6 +438,11 @@ tests:
     expected_is_writable: [false, false, false, false, false, false, false]
 
   # getColumns(catalog, schemaPattern, tableNamePattern, columnNamePattern)
+  - description: getColumns null parameters returns all columns
+    db: integration_test
+    meta_function: [ "getColumns", null, null, null, null ]
+    skip_reason: "SQL-668: fix MongoJsonSchema bsonType String/Array conflict"
+
   - description: getColumns no filters returns all columns
     db: integration_test
     meta_function: ["getColumns", null, null, "%", "%"]

--- a/resources/integration_test/tests/dbmd_variable_result_sets_data_methods.yml
+++ b/resources/integration_test/tests/dbmd_variable_result_sets_data_methods.yml
@@ -48,10 +48,8 @@ tests:
     #     null]
     #  - [integration_test, null, null_and_missing, table, null, null, null, null,
     #     null, null]
-    #  - [integration_test, null, types_other, table, null, null, null, null,
-    #     null, null]
     #  - [integration_test, null, baz, view, null, null, null, null, null, null]
-    row_count: 12
+    row_count: 11
     expected_sql_type: [ LONGVARCHAR, LONGVARCHAR, LONGVARCHAR, LONGVARCHAR, LONGVARCHAR,
                          LONGVARCHAR, LONGVARCHAR, LONGVARCHAR, LONGVARCHAR, LONGVARCHAR ]
     expected_catalog_name: [ '', '', '', '', '', '', '', '', '', '' ]

--- a/resources/integration_test/tests/dbmd_variable_result_sets_data_methods.yml
+++ b/resources/integration_test/tests/dbmd_variable_result_sets_data_methods.yml
@@ -50,9 +50,13 @@ tests:
     #  - [integration_test, null, null_and_missing, table, null, null, null, null,
     #     null, null]
     #  - [integration_test, null, baz, view, null, null, null, null, null, null]
-    row_count: 11
+    #  - [ integration_test, null, types_other, collection, null, null, null, null,
+    #      null, null ]
+    row_count: 12
     expected_sql_type: [ LONGVARCHAR, LONGVARCHAR, LONGVARCHAR, LONGVARCHAR, LONGVARCHAR,
                          LONGVARCHAR, LONGVARCHAR, LONGVARCHAR, LONGVARCHAR, LONGVARCHAR ]
+    expected_bson_type: [ string, string, string, string, string, string, string, string,
+                          string, string ]
     expected_catalog_name: [ '', '', '', '', '', '', '', '', '', '' ]
     expected_column_class_name: [ java.lang.String, java.lang.String, java.lang.String,
                                   java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String,

--- a/src/main/java/com/mongodb/jdbc/MongoDatabaseMetaData.java
+++ b/src/main/java/com/mongodb/jdbc/MongoDatabaseMetaData.java
@@ -138,7 +138,9 @@ public abstract class MongoDatabaseMetaData implements DatabaseMetaData {
     }
 
     public static Pattern toJavaPattern(String sqlPattern) {
-        return Pattern.compile(sqlPattern.replaceAll("%", ".*").replaceAll("_", "."));
+        return sqlPattern == null
+                ? null
+                : Pattern.compile(sqlPattern.replaceAll("%", ".*").replaceAll("_", "."));
     }
 
     // Actual max size is 16777216, we reserve 216 for other bits of encoding,

--- a/src/main/java/com/mongodb/jdbc/MongoSQLDatabaseMetaData.java
+++ b/src/main/java/com/mongodb/jdbc/MongoSQLDatabaseMetaData.java
@@ -306,7 +306,8 @@ public class MongoSQLDatabaseMetaData extends MongoDatabaseMetaData implements D
         return this.getTableDataFromDB(
                         dbName,
                         res ->
-                                tableNamePatternRE.matcher(res.name).matches()
+                                (tableNamePatternRE == null
+                                                || tableNamePatternRE.matcher(res.name).matches())
                                         && (types == null
                                                 || types.contains(res.type.toLowerCase())))
                 .map(res -> bsonSerializer.apply(dbName, res));

--- a/src/main/java/com/mongodb/jdbc/MongoSQLDatabaseMetaData.java
+++ b/src/main/java/com/mongodb/jdbc/MongoSQLDatabaseMetaData.java
@@ -542,7 +542,7 @@ public class MongoSQLDatabaseMetaData extends MongoDatabaseMetaData implements D
                 .stream()
 
                 // filter only for collections matching the pattern
-                .filter(tableName -> tableNamePatternRE.matcher(tableName).matches())
+                .filter(tableName -> tableNamePatternRE == null || tableNamePatternRE.matcher(tableName).matches())
 
                 // map the collection names into triples of (dbName, tableName, tableSchema)
                 .map(
@@ -572,6 +572,7 @@ public class MongoSQLDatabaseMetaData extends MongoDatabaseMetaData implements D
                                     // filter only for columns matching the pattern
                                     .filter(
                                             entry ->
+                                                    columnNamePatternRE == null ||
                                                     columnNamePatternRE
                                                             .matcher(entry.getKey())
                                                             .matches())

--- a/src/main/java/com/mongodb/jdbc/MongoSQLDatabaseMetaData.java
+++ b/src/main/java/com/mongodb/jdbc/MongoSQLDatabaseMetaData.java
@@ -542,7 +542,10 @@ public class MongoSQLDatabaseMetaData extends MongoDatabaseMetaData implements D
                 .stream()
 
                 // filter only for collections matching the pattern
-                .filter(tableName -> tableNamePatternRE == null || tableNamePatternRE.matcher(tableName).matches())
+                .filter(
+                        tableName ->
+                                tableNamePatternRE == null
+                                        || tableNamePatternRE.matcher(tableName).matches())
 
                 // map the collection names into triples of (dbName, tableName, tableSchema)
                 .map(
@@ -572,10 +575,10 @@ public class MongoSQLDatabaseMetaData extends MongoDatabaseMetaData implements D
                                     // filter only for columns matching the pattern
                                     .filter(
                                             entry ->
-                                                    columnNamePatternRE == null ||
-                                                    columnNamePatternRE
-                                                            .matcher(entry.getKey())
-                                                            .matches())
+                                                    columnNamePatternRE == null
+                                                            || columnNamePatternRE
+                                                                    .matcher(entry.getKey())
+                                                                    .matches())
 
                                     // sort by column name since ordinal position is
                                     // based on column sort order


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/SQL-721

When tableNamePattern is null then table name will not be used to narrow the search.  Added test for getTables with tableNamePattern as `null`.