### PR TITLE
SQL-589: Use validateConn after connecting

### DIFF
--- a/src/main/java/com/mongodb/jdbc/MongoConnection.java
+++ b/src/main/java/com/mongodb/jdbc/MongoConnection.java
@@ -347,15 +347,6 @@ public abstract class MongoConnection implements Connection {
                 Thread.currentThread().getStackTrace()[1].toString());
     }
 
-    private void validateConn() throws SQLException {
-        Statement statement = createStatement();
-        boolean resultExists = statement.execute("SELECT 1");
-        if (!resultExists) {
-            // no resultSet returned
-            throw new SQLException("Connection error");
-        }
-    }
-
     class ConnValidation implements Callable<Object> {
         @Override
         public Object call() throws SQLException {

--- a/src/main/java/com/mongodb/jdbc/MongoConnection.java
+++ b/src/main/java/com/mongodb/jdbc/MongoConnection.java
@@ -2,6 +2,7 @@ package com.mongodb.jdbc;
 
 import com.google.common.base.Preconditions;
 import com.mongodb.ConnectionString;
+import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoDriverInformation;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
@@ -36,6 +37,7 @@ import org.bson.BsonInt32;
 import org.bson.Document;
 
 public abstract class MongoConnection implements Connection {
+    private MongoClientSettings mongoClientSettings;
     protected MongoClient mongoClient;
     protected String currentDB;
     protected String url;
@@ -56,9 +58,10 @@ public abstract class MongoConnection implements Connection {
                                 .append(MongoDriver.MINOR_VERSION)
                                 .toString();
 
+        this.mongoClientSettings = MongoClientSettings.builder().applyConnectionString(cs).build();
         mongoClient =
                 MongoClients.create(
-                        cs,
+                        mongoClientSettings,
                         MongoDriverInformation.builder()
                                 .driverName(MongoDriver.NAME)
                                 .driverVersion(version)
@@ -70,6 +73,10 @@ public abstract class MongoConnection implements Connection {
         if (isClosed()) {
             throw new SQLException("Connection is closed.");
         }
+    }
+
+    protected int getDefaultConnectionValidationTimeoutSeconds() {
+        return this.mongoClientSettings.getSocketSettings().getConnectTimeout(TimeUnit.SECONDS);
     }
 
     String getURL() {

--- a/src/main/java/com/mongodb/jdbc/MongoConnection.java
+++ b/src/main/java/com/mongodb/jdbc/MongoConnection.java
@@ -347,9 +347,9 @@ public abstract class MongoConnection implements Connection {
                 Thread.currentThread().getStackTrace()[1].toString());
     }
 
-    class ConnValidation implements Callable<Object> {
+    class ConnValidation implements Callable<Void> {
         @Override
-        public Object call() throws SQLException {
+        public Void call() throws SQLException {
             Statement statement = createStatement();
             boolean resultExists = statement.execute("SELECT 1 from DUAL");
             if (!resultExists) {
@@ -373,7 +373,7 @@ public abstract class MongoConnection implements Connection {
         // to set the timeout adhoc on the calls, we use Executor to run a blocked call with timeout.
         ExecutorService executor = Executors.newCachedThreadPool();
 
-        Future<Object> future = executor.submit(new ConnValidation());
+        Future<Void> future = executor.submit(new ConnValidation());
         try {
             if (timeout > 0) {
                 future.get(timeout, TimeUnit.SECONDS);

--- a/src/main/java/com/mongodb/jdbc/MongoDriver.java
+++ b/src/main/java/com/mongodb/jdbc/MongoDriver.java
@@ -105,7 +105,7 @@ public class MongoDriver implements Driver {
         return conn;
     }
 
-    public MongoConnection createUnvalidatedConnection(String url, Properties info)
+    protected MongoConnection createUnvalidatedConnection(String url, Properties info)
         throws SQLException {
         return getUnvalidatedConnectionAndTimeout(url, info).left();
     }

--- a/src/main/java/com/mongodb/jdbc/MongoDriver.java
+++ b/src/main/java/com/mongodb/jdbc/MongoDriver.java
@@ -99,7 +99,7 @@ public class MongoDriver implements Driver {
 
     @Override
     public Connection connect(String url, Properties info) throws SQLException {
-        Pair<MongoConnection, Integer> p = createUnvalidatedConnectionAndTimeout(url, info);
+        Pair<MongoConnection, Integer> p = getUnvalidatedConnectionAndTimeout(url, info);
         Connection conn = p.left();
         conn.isValid(p.right());
         return conn;
@@ -107,10 +107,10 @@ public class MongoDriver implements Driver {
 
     public MongoConnection createUnvalidatedConnection(String url, Properties info)
         throws SQLException {
-        return createUnvalidatedConnectionAndTimeout(url, info).left();
+        return getUnvalidatedConnectionAndTimeout(url, info).left();
     }
 
-    private Pair<MongoConnection, Integer> createUnvalidatedConnectionAndTimeout(String url, Properties info)
+    private Pair<MongoConnection, Integer> getUnvalidatedConnectionAndTimeout(String url, Properties info)
         throws SQLException {
         if (!acceptsURL(url)) {
             return null;

--- a/src/main/java/com/mongodb/jdbc/MongoDriver.java
+++ b/src/main/java/com/mongodb/jdbc/MongoDriver.java
@@ -101,7 +101,12 @@ public class MongoDriver implements Driver {
     public Connection connect(String url, Properties info) throws SQLException {
         Pair<MongoConnection, Integer> p = getUnvalidatedConnectionAndTimeout(url, info);
         Connection conn = p.left();
-        conn.isValid(p.right());
+        // the jdbc spec requires that null be returned if a Driver cannot handle the specified URL
+        // (cases where multiple jdbc drivers are present and the program is checking which driver
+        // to use), so it is possible for conn to be null at this point.
+        if (conn != null) {
+            conn.isValid(p.right());
+        }
         return conn;
     }
 

--- a/src/main/java/com/mongodb/jdbc/MongoDriver.java
+++ b/src/main/java/com/mongodb/jdbc/MongoDriver.java
@@ -127,7 +127,6 @@ public class MongoDriver implements Driver {
 
         ConnectionString cs = p.left();
         Connection ret = createDialectConnection(cs, info);
-        System.out.println(cs);
         // use a timeout of 5s if no timeout is specified in the URL.
         int timeout = 5;
         try {

--- a/src/main/java/com/mongodb/jdbc/MongoDriver.java
+++ b/src/main/java/com/mongodb/jdbc/MongoDriver.java
@@ -131,7 +131,8 @@ public class MongoDriver implements Driver {
         // use a timeout of 5s if no timeout is specified in the URL.
         int timeout = 5;
         try {
-            timeout = cs.getConnectTimeout();
+            // mongo connect timeoutes are in MS, so divide by 1000.
+            timeout = cs.getConnectTimeout() / 1000;
         } catch (NullPointerException e) {
             // timeout not specified.
             // this is an unfortunate reality of the Java driver, it throws NPE if

--- a/src/main/java/com/mongodb/jdbc/MongoDriver.java
+++ b/src/main/java/com/mongodb/jdbc/MongoDriver.java
@@ -126,18 +126,18 @@ public class MongoDriver implements Driver {
         reconcileProperties(p.right(), info);
 
         ConnectionString cs = p.left();
-        Connection ret = createDialectConnection(cs, info);
-        // use a timeout of 5s if no timeout is specified in the URL.
-        int timeout = 5;
+        Connection ret = createConnection(cs, info);
+        // use a timeout of 30s, if no timeout is specified in the URL.
+        int timeout = 30;
         try {
-            // mongo connect timeoutes are in MS, so divide by 1000.
+            // mongo connect timeouts are in MS, so divide by 1000.
             timeout = cs.getConnectTimeout() / 1000;
         } catch (NullPointerException e) {
             // timeout not specified.
-            // this is an unfortunate reality of the Java driver, it throws NPE if
+            // this is an unfortunate reality of the Java driver, it throws NPE, if
             // the option is not specified.
         }
-        return new Pair<>(createDialectConnection(cs, info), timeout);
+        return new Pair<>(createConnection(cs, info), timeout);
     }
 
     private void reconcileProperties(DriverPropertyInfo[] driverPropertyInfo, Properties info) throws SQLException {
@@ -160,7 +160,7 @@ public class MongoDriver implements Driver {
         }
     }
 
-    private MongoConnection createDialectConnection(ConnectionString cs, Properties info)
+    private MongoConnection createConnection(ConnectionString cs, Properties info)
             throws SQLException {
         // attempt to get DIALECT property, and default to "mysql" if none is present
         String dialect = info.getProperty(DIALECT, MYSQL_DIALECT);

--- a/src/main/java/com/mongodb/jdbc/MongoVersionedJsonSchema.java
+++ b/src/main/java/com/mongodb/jdbc/MongoVersionedJsonSchema.java
@@ -21,7 +21,6 @@ public class MongoVersionedJsonSchema {
             @BsonProperty("version") final int version,
             @BsonProperty("jsonSchema") JsonSchema schema) {
         this.version = version;
-        System.out.println(schema);
         this.mongoJsonSchema = MongoJsonSchema.toSimplifiedMongoJsonSchema(schema);
     }
 }

--- a/src/test/java/com/mongodb/jdbc/MongoDriverTest.java
+++ b/src/test/java/com/mongodb/jdbc/MongoDriverTest.java
@@ -61,16 +61,16 @@ class MongoDriverTest {
     void testDBURL() throws SQLException {
         MongoDriver d = new MongoDriver();
         // Should not return null or throw, even with null properties.
-        assertNotNull(d.connect(authDBURL, null));
+        assertNotNull(d.createUnvalidatedConnection(authDBURL, null));
 
         Properties p = new Properties();
-        assertNotNull(d.connect(authDBURL, p));
+        assertNotNull(d.createUnvalidatedConnection(authDBURL, p));
 
         p.setProperty("database", "admin2");
 
         // Database is not the same as the authDatabase in the uri.
         // So this is safe and should not throw.
-        assertNotNull(d.connect(authDBURL, p));
+        assertNotNull(d.createUnvalidatedConnection(authDBURL, p));
     }
 
     @Test
@@ -210,19 +210,19 @@ class MongoDriverTest {
         Connection c;
 
         // dialect not set defaults to MySQLConnection
-        c = d.connect(basicURL, p);
+        c = d.createUnvalidatedConnection(basicURL, p);
         assertNotNull(c);
         assertTrue(c instanceof MySQLConnection);
 
         // dialect set to "mysql" results in MySQLConnection
         p.setProperty("dialect", "MySQL");
-        c = d.connect(basicURL, p);
+        c = d.createUnvalidatedConnection(basicURL, p);
         assertNotNull(c);
         assertTrue(c instanceof MySQLConnection);
 
         // dialect set to "mongosql" results in MongoSQLConnection
         p.setProperty("dialect", "MongoSQL");
-        c = d.connect(basicURL, p);
+        c = d.createUnvalidatedConnection(basicURL, p);
         assertNotNull(c);
         assertTrue(c instanceof MongoSQLConnection);
 

--- a/src/test/java/com/mongodb/jdbc/MongoDriverTest.java
+++ b/src/test/java/com/mongodb/jdbc/MongoDriverTest.java
@@ -61,16 +61,16 @@ class MongoDriverTest {
     void testDBURL() throws SQLException {
         MongoDriver d = new MongoDriver();
         // Should not return null or throw, even with null properties.
-        assertNotNull(d.createUnvalidatedConnection(authDBURL, null));
+        assertNotNull(d.getUnvalidatedConnection(authDBURL, null));
 
         Properties p = new Properties();
-        assertNotNull(d.createUnvalidatedConnection(authDBURL, p));
+        assertNotNull(d.getUnvalidatedConnection(authDBURL, p));
 
         p.setProperty("database", "admin2");
 
         // Database is not the same as the authDatabase in the uri.
         // So this is safe and should not throw.
-        assertNotNull(d.createUnvalidatedConnection(authDBURL, p));
+        assertNotNull(d.getUnvalidatedConnection(authDBURL, p));
     }
 
     @Test
@@ -210,19 +210,19 @@ class MongoDriverTest {
         Connection c;
 
         // dialect not set defaults to MySQLConnection
-        c = d.createUnvalidatedConnection(basicURL, p);
+        c = d.getUnvalidatedConnection(basicURL, p);
         assertNotNull(c);
         assertTrue(c instanceof MySQLConnection);
 
         // dialect set to "mysql" results in MySQLConnection
         p.setProperty("dialect", "MySQL");
-        c = d.createUnvalidatedConnection(basicURL, p);
+        c = d.getUnvalidatedConnection(basicURL, p);
         assertNotNull(c);
         assertTrue(c instanceof MySQLConnection);
 
         // dialect set to "mongosql" results in MongoSQLConnection
         p.setProperty("dialect", "MongoSQL");
-        c = d.createUnvalidatedConnection(basicURL, p);
+        c = d.getUnvalidatedConnection(basicURL, p);
         assertNotNull(c);
         assertTrue(c instanceof MongoSQLConnection);
 


### PR DESCRIPTION
This patch just changes the visibility of `validateConn` to package level and calls it after creating a connection.