### PR TITLE
SQL-774: Use the MongoSQL dialect by default

### DIFF
--- a/src/main/java/com/mongodb/jdbc/MongoDriver.java
+++ b/src/main/java/com/mongodb/jdbc/MongoDriver.java
@@ -155,7 +155,7 @@ public class MongoDriver implements Driver {
 
     private MongoConnection createConnection(ConnectionString cs, Properties info)
             throws SQLException {
-        // attempt to get DIALECT property, and default to "mysql" if none is present
+        // attempt to get DIALECT property, and default to "mongosql" if none is present
         String dialect = info.getProperty(DIALECT, MONGOSQL_DIALECT);
         switch (dialect.toLowerCase()) {
             case MYSQL_DIALECT:

--- a/src/main/java/com/mongodb/jdbc/MongoDriver.java
+++ b/src/main/java/com/mongodb/jdbc/MongoDriver.java
@@ -61,7 +61,8 @@ public class MongoDriver implements Driver {
     static final String MYSQL_DIALECT = "mysql";
     static final String MONGOSQL_DIALECT = "mongosql";
     static final String MONGOSQL_DB_PRODUCT_NAME = "MongoDB Atlas";
-    static final String MONGOSQL_DRIVER_NAME = MONGOSQL_DB_PRODUCT_NAME + " SQL interface JDBC Driver";
+    static final String MONGOSQL_DRIVER_NAME =
+            MONGOSQL_DB_PRODUCT_NAME + " SQL interface JDBC Driver";
 
     static final String NAME;
     static final String VERSION;
@@ -113,7 +114,7 @@ public class MongoDriver implements Driver {
     }
 
     protected MongoConnection getUnvalidatedConnection(String url, Properties info)
-        throws SQLException {
+            throws SQLException {
         if (!acceptsURL(url)) {
             return null;
         }
@@ -131,7 +132,8 @@ public class MongoDriver implements Driver {
         return createConnection(cs, info);
     }
 
-    private void reconcileProperties(DriverPropertyInfo[] driverPropertyInfo, Properties info) throws SQLException {
+    private void reconcileProperties(DriverPropertyInfo[] driverPropertyInfo, Properties info)
+            throws SQLException {
         // since the user is calling connect, we should throw an SQLException if we get
         // a prompt back. Inspect the return value to format the SQLException.
         if (driverPropertyInfo.length != 0) {

--- a/src/main/java/com/mongodb/jdbc/MongoDriver.java
+++ b/src/main/java/com/mongodb/jdbc/MongoDriver.java
@@ -154,7 +154,7 @@ public class MongoDriver implements Driver {
     private MongoConnection createConnection(ConnectionString cs, Properties info)
             throws SQLException {
         // attempt to get DIALECT property, and default to "mysql" if none is present
-        String dialect = info.getProperty(DIALECT, MYSQL_DIALECT);
+        String dialect = info.getProperty(DIALECT, MONGOSQL_DIALECT);
         switch (dialect.toLowerCase()) {
             case MYSQL_DIALECT:
                 return new MySQLConnection(

--- a/src/test/java/com/mongodb/jdbc/MongoDriverTest.java
+++ b/src/test/java/com/mongodb/jdbc/MongoDriverTest.java
@@ -209,10 +209,10 @@ class MongoDriverTest {
         Properties p = new Properties();
         Connection c;
 
-        // dialect not set defaults to MySQLConnection
+        // dialect not set defaults to MongoSQLConnection
         c = d.getUnvalidatedConnection(basicURL, p);
         assertNotNull(c);
-        assertTrue(c instanceof MySQLConnection);
+        assertTrue(c instanceof MongoSQLConnection);
 
         // dialect set to "mysql" results in MySQLConnection
         p.setProperty("dialect", "MySQL");


### PR DESCRIPTION
As discussed in standup today, a small change to switch the default dialect from "mysql" to "mongosql"