### PR TITLE
SQL-775: Handle all JsonSchema polymorphic fields

### DIFF
--- a/src/main/java/com/mongodb/jdbc/JsonSchema.java
+++ b/src/main/java/com/mongodb/jdbc/JsonSchema.java
@@ -6,14 +6,15 @@ import java.util.Set;
 import org.bson.BsonValue;
 
 // Simple POJO for deserializing jsonschema.
+// For more details on jsonSchema, see https://docs.mongodb.com/manual/reference/operator/query/jsonSchema/.
 public class JsonSchema {
 
     public BsonValue bsonType;
     public Map<String, JsonSchema> properties;
     public Set<JsonSchema> anyOf;
     public Set<String> required;
-    public JsonSchema items;
-    public boolean additionalProperties;
+    public BsonValue items;
+    public BsonValue additionalProperties;
 
     @Override
     public boolean equals(Object obj) {
@@ -26,7 +27,7 @@ public class JsonSchema {
                 && Objects.equals(anyOf, other.anyOf)
                 && Objects.equals(required, other.required)
                 && Objects.equals(items, other.items)
-                && additionalProperties == other.additionalProperties;
+                && Objects.equals(additionalProperties, other.additionalProperties);
     }
 
     @Override

--- a/src/test/java/com/mongodb/jdbc/MongoSQLMock.java
+++ b/src/test/java/com/mongodb/jdbc/MongoSQLMock.java
@@ -195,8 +195,10 @@ public abstract class MongoSQLMock {
 
         MongoJsonSchema vecSchema = new MongoJsonSchema();
         vecSchema.bsonType = "array";
-        vecSchema.items = new MongoJsonSchema();
-        vecSchema.items.bsonType = "int";
+        vecSchema.items = new HashSet<MongoJsonSchema>();
+        MongoJsonSchema item = new MongoJsonSchema();
+        item.bsonType = "int";
+        vecSchema.items.add(item);
 
         MongoJsonSchema nullSchema = new MongoJsonSchema();
         nullSchema.bsonType = "null";

--- a/src/test/java/com/mongodb/jdbc/MongoSQLMock.java
+++ b/src/test/java/com/mongodb/jdbc/MongoSQLMock.java
@@ -195,10 +195,8 @@ public abstract class MongoSQLMock {
 
         MongoJsonSchema vecSchema = new MongoJsonSchema();
         vecSchema.bsonType = "array";
-        vecSchema.items = new HashSet<MongoJsonSchema>();
-        MongoJsonSchema item = new MongoJsonSchema();
-        item.bsonType = "int";
-        vecSchema.items.add(item);
+        vecSchema.items = new MongoJsonSchema();
+        vecSchema.items.bsonType = "int";
 
         MongoJsonSchema nullSchema = new MongoJsonSchema();
         nullSchema.bsonType = "null";

--- a/src/test/resources/mongoJsonSchemaTest/expectedOutput/flattenedAnyOfReducedToOneType.json
+++ b/src/test/resources/mongoJsonSchemaTest/expectedOutput/flattenedAnyOfReducedToOneType.json
@@ -3,9 +3,11 @@
   "properties": {
     "bar": {
       "bsonType": "array",
-      "items": {
-        "bsonType": "int"
-      },
+      "items": [
+        {
+          "bsonType": "int"
+        }
+      ],
       "additionalProperties": true
     }
   }

--- a/src/test/resources/mongoJsonSchemaTest/expectedOutput/flattenedAnyOfReducedToOneType.json
+++ b/src/test/resources/mongoJsonSchemaTest/expectedOutput/flattenedAnyOfReducedToOneType.json
@@ -3,9 +3,7 @@
   "properties": {
     "bar": {
       "bsonType": "array",
-      "items": {
-        "bsonType": "int"
-      },
+      "items":{},
       "additionalProperties": true
     }
   }

--- a/src/test/resources/mongoJsonSchemaTest/expectedOutput/flattenedAnyOfReducedToOneType.json
+++ b/src/test/resources/mongoJsonSchemaTest/expectedOutput/flattenedAnyOfReducedToOneType.json
@@ -3,11 +3,9 @@
   "properties": {
     "bar": {
       "bsonType": "array",
-      "items": [
-        {
-          "bsonType": "int"
-        }
-      ],
+      "items": {
+        "bsonType": "int"
+      },
       "additionalProperties": true
     }
   }

--- a/src/test/resources/mongoJsonSchemaTest/expectedOutput/polymorphicAdditionalProperties.json
+++ b/src/test/resources/mongoJsonSchemaTest/expectedOutput/polymorphicAdditionalProperties.json
@@ -1,0 +1,24 @@
+{"bsonType": "object",
+  "properties": {
+    "bar": {
+      "bsonType": "object",
+      "properties": {
+        "a": {
+          "bsonType": "object",
+          "additionalProperties": true
+        },
+        "b": {
+          "bsonType": "boolean",
+          "additionalProperties": false
+        },
+        "c": {
+          "bsonType": "string",
+          "additionalProperties": true
+        },
+        "d": {
+          "bsonType": "date"
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/mongoJsonSchemaTest/expectedOutput/polymorphicItems.json
+++ b/src/test/resources/mongoJsonSchemaTest/expectedOutput/polymorphicItems.json
@@ -1,32 +1,39 @@
-{"bsonType": "object",
-  "properties": {
-    "bar": {
-      "bsonType": "object",
-      "properties": {
-        "a": {
-          "bsonType": "array",
-          "items": [{"bsonType":  "date"}]
+{
+  "bsonType":"object",
+  "properties":{
+    "bar":{
+      "bsonType":"object",
+      "properties":{
+        "a":{
+          "bsonType":"array",
+          "items":{
+            "bsonType":"date"
+          }
         },
-        "b": {
-          "bsonType": "array",
-          "items": [
-            {
-              "anyOf": [
-                {
-                  "bsonType": "string"
-                },
-                {
-                  "bsonType": "null"
-                }
-              ]
-            },
-            {
-              "bsonType": "boolean"
-            }
-          ],
-          "additionalProperties": false
+        "b":{
+          "bsonType":"array",
+          "items":{
+            "anyOf":[
+              {
+                "anyOf":[
+                  {
+                    "bsonType":"string"
+                  },
+                  {
+                    "bsonType":"null"
+                  }
+                ]
+              },
+              {
+                "bsonType":"boolean"
+              }
+            ]
+          },
+          "additionalProperties":false
         },
-        "c": {"bsonType": "objectId"}
+        "c":{
+          "bsonType":"objectId"
+        }
       }
     }
   }

--- a/src/test/resources/mongoJsonSchemaTest/expectedOutput/polymorphicItems.json
+++ b/src/test/resources/mongoJsonSchemaTest/expectedOutput/polymorphicItems.json
@@ -1,0 +1,33 @@
+{"bsonType": "object",
+  "properties": {
+    "bar": {
+      "bsonType": "object",
+      "properties": {
+        "a": {
+          "bsonType": "array",
+          "items": [{"bsonType":  "date"}]
+        },
+        "b": {
+          "bsonType": "array",
+          "items": [
+            {
+              "anyOf": [
+                {
+                  "bsonType": "string"
+                },
+                {
+                  "bsonType": "null"
+                }
+              ]
+            },
+            {
+              "bsonType": "boolean"
+            }
+          ],
+          "additionalProperties": false
+        },
+        "c": {"bsonType": "objectId"}
+      }
+    }
+  }
+}

--- a/src/test/resources/mongoJsonSchemaTest/expectedOutput/polymorphicItems.json
+++ b/src/test/resources/mongoJsonSchemaTest/expectedOutput/polymorphicItems.json
@@ -6,29 +6,11 @@
       "properties":{
         "a":{
           "bsonType":"array",
-          "items":{
-            "bsonType":"date"
-          }
+          "items":{}
         },
         "b":{
           "bsonType":"array",
-          "items":{
-            "anyOf":[
-              {
-                "anyOf":[
-                  {
-                    "bsonType":"string"
-                  },
-                  {
-                    "bsonType":"null"
-                  }
-                ]
-              },
-              {
-                "bsonType":"boolean"
-              }
-            ]
-          },
+          "items":{},
           "additionalProperties":false
         },
         "c":{

--- a/src/test/resources/mongoJsonSchemaTest/expectedOutput/simpleSchema.json
+++ b/src/test/resources/mongoJsonSchemaTest/expectedOutput/simpleSchema.json
@@ -25,14 +25,13 @@
         "u": {"bsonType":  "maxKey"},
         "v": {
           "bsonType": "array",
-          "items": [
+          "items":
             {
             "anyOf": [
               {"bsonType":  "string"},
               {"bsonType":  "null"}
             ]
           }
-          ]
         },
         "w": {
           "anyOf": [

--- a/src/test/resources/mongoJsonSchemaTest/expectedOutput/simpleSchema.json
+++ b/src/test/resources/mongoJsonSchemaTest/expectedOutput/simpleSchema.json
@@ -25,13 +25,7 @@
         "u": {"bsonType":  "maxKey"},
         "v": {
           "bsonType": "array",
-          "items":
-            {
-            "anyOf": [
-              {"bsonType":  "string"},
-              {"bsonType":  "null"}
-            ]
-          }
+          "items":{}
         },
         "w": {
           "anyOf": [

--- a/src/test/resources/mongoJsonSchemaTest/expectedOutput/simpleSchema.json
+++ b/src/test/resources/mongoJsonSchemaTest/expectedOutput/simpleSchema.json
@@ -25,12 +25,14 @@
         "u": {"bsonType":  "maxKey"},
         "v": {
           "bsonType": "array",
-          "items": {
+          "items": [
+            {
             "anyOf": [
               {"bsonType":  "string"},
               {"bsonType":  "null"}
             ]
           }
+          ]
         },
         "w": {
           "anyOf": [

--- a/src/test/resources/mongoJsonSchemaTest/input/polymorphicAdditionalProperties.json
+++ b/src/test/resources/mongoJsonSchemaTest/input/polymorphicAdditionalProperties.json
@@ -1,0 +1,26 @@
+{"bsonType": "object",
+  "properties": {
+    "bar": {
+      "bsonType": "object",
+      "properties": {
+        "a": {
+          "bsonType": "object",
+          "additionalProperties": {
+            "props": "val"
+            }
+        },
+        "b": {
+          "bsonType": "boolean",
+          "additionalProperties": false
+        },
+        "c": {
+          "bsonType": "string",
+          "additionalProperties": true
+        },
+        "d": {
+          "bsonType": "date"
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/mongoJsonSchemaTest/input/polymorphicItems.json
+++ b/src/test/resources/mongoJsonSchemaTest/input/polymorphicItems.json
@@ -1,0 +1,33 @@
+{"bsonType": "object",
+  "properties": {
+    "bar": {
+      "bsonType": "object",
+      "properties": {
+        "a": {
+          "bsonType": "array",
+          "items": {"bsonType":  "date"}
+        },
+        "b": {
+          "bsonType": "array",
+          "items": [
+            {
+              "anyOf": [
+                {
+                  "bsonType": "string"
+                },
+                {
+                  "bsonType": "null"
+                }
+              ]
+            },
+            {
+              "bsonType": "boolean"
+            }
+          ],
+          "additionalProperties": false
+        },
+        "c": {"bsonType": "objectId"}
+      }
+    }
+  }
+}


### PR DESCRIPTION
Transform "items" field values to a set of MongoJsonSchema and "additionalProperties" to a boolean value.

@rychipman, @bucaojit :  It seems that "items" is only used to know if isAny should return true or false. And, even there, the only information used is whether "items" is null or not.
I am not sure if we need to convert "items" to a set of MongoJsonSchema or if we could not simply convert it to a boolean value (tracking if items is null or not) and use the boolean value in isAny.