### PR TITLE
SQL-800: Implemented getString for Document and Array columns

### DIFF
--- a/resources/integration_test/testdata/integration.yml
+++ b/resources/integration_test/testdata/integration.yml
@@ -91,13 +91,14 @@ dataset:
     docsExtJson:
       - {
         _id: 0,
-        array: [1,2,3],
+        array: [1,2,3,"$oid": "000000000000000000000003", "$timestamp": {"t":200, "i":0}],
         dbPointer: { "$dbPointer": { "$ref": "namespace", "$id": { "$oid": "000000000000000000000001" } } },
         javascript: {"$code": "function(){ }"},
         javascriptWithScope: {"$code": "function(){ }", "$scope": {"foo":"bar"}},
         maxKey: {"$maxKey": 1},
         minKey: {"$minKey": 1},
-        object: {"foo":"bar"},
+        object: {"foo":"bar", "objId": {"$oid": "000000000000000000000002"}, "value": 3,
+                 "time": {"$timestamp": {"t":200, "i":0}}},
         objectId: { "$oid": "000000000000000000000001" },
         regularExpression: {"$regularExpression": {pattern: "a(bc)*", "options": ""}},
         symbol: { "$symbol": "symbol" },

--- a/resources/integration_test/testdata/integration.yml
+++ b/resources/integration_test/testdata/integration.yml
@@ -91,18 +91,18 @@ dataset:
     docsExtJson:
       - {
         _id: 0,
-        array: [ 1, 2, 3, "$oid": "000000000000000000000003", "$timestamp": {"t":200, "i":0}],
-        dbPointer: { "$dbPointer": { "$ref": "namespace", "$id": {"$oid": "000000000000000000000001" }}},
-        javascript: {"$code": "function(){ }"},
-        javascriptWithScope: {"$code": "function(){ }", "$scope": {"foo":"bar"}},
-        maxKey: {"$maxKey": 1},
-        minKey: {"$minKey": 1},
-        object: {"foo":"bar", "objId": {"$oid": "000000000000000000000002"}, "value": 3,
-                 "time": {"$timestamp": {"t":200, "i":0}}},
+        array: [ 1, 2, 3, "$oid": "000000000000000000000003", "$timestamp": { "t": 200, "i": 0 }],
+        dbPointer: { "$dbPointer": { "$ref": "namespace", "$id": { "$oid": "000000000000000000000001" }}},
+        javascript: { "$code": "function(){ }" },
+        javascriptWithScope: { "$code": "function(){ }", "$scope": { "foo": "bar" }},
+        maxKey: { "$maxKey": 1 },
+        minKey: { "$minKey": 1 },
+        object: { "foo": "bar", "objId": { "$oid": "000000000000000000000002" }, "value": 3,
+                 "time": { "$timestamp": { "t": 200, "i": 0 }}},
         objectId: { "$oid": "000000000000000000000001" },
-        regularExpression: {"$regularExpression": {pattern: "a(bc)*", "options": ""}},
+        regularExpression: { "$regularExpression": { pattern: "a(bc)*", "options": "" }},
         symbol: { "$symbol": "symbol" },
-        timestamp: {"$timestamp": {"t":100, "i":0}}
+        timestamp: { "$timestamp": { "t": 100, "i": 0 }}
         # Skip reason: SQL-395
         # undefined: {"$undefined":true},
       }

--- a/resources/integration_test/testdata/integration.yml
+++ b/resources/integration_test/testdata/integration.yml
@@ -91,10 +91,10 @@ dataset:
     docsExtJson:
       - {
         _id: 0,
-        array: [1,2,3,"$oid": "000000000000000000000003", "$timestamp": {"t":200, "i":0}],
-        dbPointer: { "$dbPointer": { "$ref": "namespace", "$id": { "$oid": "000000000000000000000001" } } },
+        array: [1,2,3,{"$oid": "000000000000000000000003"}, {"$timestamp": {"t":200, "i":0}}],
+        dbPointer: { "$dbPointer": { "$ref": "namespace", {"$id": { "$oid": "000000000000000000000001" }}}},
         javascript: {"$code": "function(){ }"},
-        javascriptWithScope: {"$code": "function(){ }", "$scope": {"foo":"bar"}},
+        javascriptWithScope: {"$code": "function(){ }", {"$scope": {"foo":"bar"}}},
         maxKey: {"$maxKey": 1},
         minKey: {"$minKey": 1},
         object: {"foo":"bar", "objId": {"$oid": "000000000000000000000002"}, "value": 3,

--- a/resources/integration_test/testdata/integration.yml
+++ b/resources/integration_test/testdata/integration.yml
@@ -92,9 +92,9 @@ dataset:
       - {
         _id: 0,
         array: [1,2,3,{"$oid": "000000000000000000000003"}, {"$timestamp": {"t":200, "i":0}}],
-        dbPointer: { "$dbPointer": { "$ref": "namespace", {"$id": { "$oid": "000000000000000000000001" }}}},
+        dbPointer: { "$dbPointer": { "$ref": "namespace", "$id": {"$oid": "000000000000000000000001" }}},
         javascript: {"$code": "function(){ }"},
-        javascriptWithScope: {"$code": "function(){ }", {"$scope": {"foo":"bar"}}},
+        javascriptWithScope: {"$code": "function(){ }", "$scope": {"foo":"bar"}},
         maxKey: {"$maxKey": 1},
         minKey: {"$minKey": 1},
         object: {"foo":"bar", "objId": {"$oid": "000000000000000000000002"}, "value": 3,

--- a/resources/integration_test/testdata/integration.yml
+++ b/resources/integration_test/testdata/integration.yml
@@ -91,6 +91,7 @@ dataset:
     docsExtJson:
       - {
         _id: 0,
+        array: [1,2,3],
         dbPointer: { "$dbPointer": { "$ref": "namespace", "$id": { "$oid": "000000000000000000000001" } } },
         javascript: {"$code": "function(){ }"},
         javascriptWithScope: {"$code": "function(){ }", "$scope": {"foo":"bar"}},
@@ -103,6 +104,4 @@ dataset:
         timestamp: {"$timestamp": {"t":100, "i":0}}
         # Skip reason: SQL-395
         # undefined: {"$undefined":true},
-        # Skip reason: SQL-697
-        # array: [1,2,3]
       }

--- a/resources/integration_test/testdata/integration.yml
+++ b/resources/integration_test/testdata/integration.yml
@@ -91,7 +91,7 @@ dataset:
     docsExtJson:
       - {
         _id: 0,
-        array: [1,2,3,{"$oid": "000000000000000000000003"}, {"$timestamp": {"t":200, "i":0}}],
+        array: [ 1, 2, 3, "$oid": "000000000000000000000003", "$timestamp": {"t":200, "i":0}],
         dbPointer: { "$dbPointer": { "$ref": "namespace", "$id": {"$oid": "000000000000000000000001" }}},
         javascript: {"$code": "function(){ }"},
         javascriptWithScope: {"$code": "function(){ }", "$scope": {"foo":"bar"}},

--- a/resources/integration_test/tests/query.yaml
+++ b/resources/integration_test/tests/query.yaml
@@ -243,9 +243,8 @@ tests:
     db: integration_test
     sql: SELECT `array`, `object` FROM types_other
     expected_result:
-      - ["[{\"$numberInt\": \"1\"}, {\"$numberInt\": \"2\"}, {\"$numberInt\": \"3\"}, \
-          {\"$oid\": \"000000000000000000000003\"}, {\"$timestamp\": {\"t\": 200, \"i\": 0}}]",
-         "{\"foo\": \"bar\", \"objId\": {\"$oid\": \"000000000000000000000002\"}, \
-          \"value\": {\"$numberInt\": \"3\"}, \"time\": {\"$timestamp\": {\"t\": 200, \"i\": 0}}}"]
+      - ["[1, 2, 3, {\"$oid\": \"000000000000000000000003\"}, {\"$timestamp\": {\"t\": 200, \"i\": 0}}]",
+         "{\"foo\": \"bar\", \"objId\": {\"$oid\": \"000000000000000000000002\"}, \"value\": 3, \
+         \"time\": {\"$timestamp\": {\"t\": 200, \"i\": 0}}}"]
     row_count: 1
 

--- a/resources/integration_test/tests/query.yaml
+++ b/resources/integration_test/tests/query.yaml
@@ -188,53 +188,59 @@ tests:
     sql: SELECT * FROM types_other
     expected_result_extended_json: [ {
       "0": 0,
-      "1": { "$dbPointer": { "$ref": "namespace", "$id": { "$oid": "000000000000000000000001" } } },
-      "2": {"$code": "function(){ }"},
-      "3": {"$code": "function(){ }", "$scope": {"foo":"bar"}},
-      "4": {"$maxKey": 1},
-      "5": {"$minKey": 1},
-      "6": {"foo":"bar"},
-      "7": { "$oid": "000000000000000000000001" },
-      "8": {"$regularExpression": {pattern: "a(bc)*", "options": ""}},
-      "9": { "$symbol": "symbol" },
-      "10": {"$timestamp": {"t":100, "i":0}}
-      # Skip reason: SQL-395
-      # 11: {"$undefined":true},
-      # Skip reason: SQL-697
-      # 12: [1,2,3]
+      "1": [1,2,3],
+      "2": { "$dbPointer": { "$ref": "namespace", "$id": { "$oid": "000000000000000000000001" } } },
+      "3": {"$code": "function(){ }"},
+      "4": {"$code": "function(){ }", "$scope": {"foo":"bar"}},
+      "5": {"$maxKey": 1},
+      "6": {"$minKey": 1},
+      "7": {"foo":"bar"},
+      "8": { "$oid": "000000000000000000000001" },
+      "9": {"$regularExpression": {pattern: "a(bc)*", "options": ""}},
+      "10": { "$symbol": "symbol" },
+      "11": {"$timestamp": {"t":100, "i":0}}
+        # Skip reason: SQL-395
+        # 11: {"$undefined":true},
     } ]
     row_count: 1
     expected_sql_type: [INTEGER, OTHER, OTHER, OTHER, OTHER, OTHER, OTHER, OTHER,
-                        OTHER, OTHER, OTHER]
-    expected_bson_type: [int, dbPointer, javascript, javascriptWithScope, maxKey,
+                        OTHER, OTHER, OTHER, OTHER]
+    expected_bson_type: [int, array, dbPointer, javascript, javascriptWithScope, maxKey,
                          minKey, object, objectId, regex, symbol, timestamp]
-    expected_catalog_name: ['', '', '', '', '', '', '', '', '', '', '']
+    expected_catalog_name: ['', '', '', '', '', '', '', '', '', '', '', '']
     expected_column_class_name: [int, org.bson.BsonValue, org.bson.BsonValue, org.bson.BsonValue,
                                  org.bson.BsonValue, org.bson.BsonValue, org.bson.BsonValue, org.bson.BsonValue,
-                                 org.bson.BsonValue, org.bson.BsonValue, org.bson.BsonValue]
-    expected_column_label: [_id, dbPointer, javascript, javascriptWithScope, maxKey,
-                            minKey, object, objectId, regularExpression, symbol, timestamp]
-    expected_column_display_size: [10, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0]
-    expected_precision: [10, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0]
-    expected_scale: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-    expected_schema_name: ['', '', '', '', '', '', '', '', '', '', '']
+                                 org.bson.BsonValue, org.bson.BsonValue, org.bson.BsonValue, org.bson.BsonValue]
+    expected_column_label: [_id, array, dbPointer, javascript, javascriptWithScope,
+                            maxKey, minKey, object, objectId, regularExpression, symbol, timestamp]
+    expected_column_display_size: [10, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0]
+    expected_precision: [10, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0]
+    expected_scale: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    expected_schema_name: ['', '', '', '', '', '', '', '', '', '', '', '']
     expected_is_auto_increment: [false, false, false, false, false, false, false,
-                                 false, false, false, false]
-    expected_is_case_sensitive: [false, false, true, true, false, false, false, false,
-                                 true, true, false]
+                                 false, false, false, false, false]
+    expected_is_case_sensitive: [false, false, false, true, true, false, false, false,
+                                 false, true, true, false]
     expected_is_currency: [false, false, false, false, false, false, false, false,
-                           false, false, false]
+                           false, false, false, false]
     expected_is_definitely_writable: [false, false, false, false, false, false, false,
-                                      false, false, false, false]
+                                      false, false, false, false, false]
     expected_is_nullable: [columnNullable, columnNullable, columnNullable, columnNullable,
                            columnNullable, columnNullable, columnNullable, columnNullable, columnNullable,
-                           columnNullable, columnNullable]
+                           columnNullable, columnNullable, columnNullable]
     expected_is_read_only: [true, true, true, true, true, true, true, true, true,
-                            true, true]
+                            true, true, true]
     expected_is_searchable: [true, true, true, true, true, true, true, true, true,
-                             true, true]
+                             true, true, true]
     expected_is_signed: [true, false, false, false, false, false, false, false, false,
-                         false, false]
+                         false, false, false]
     expected_is_writable: [false, false, false, false, false, false, false, false,
-                           false, false, false]
+                           false, false, false, false]
+
+  - description: query_array_and_document_as_string
+    db: integration_test
+    sql: SELECT `array`, `object` FROM types_other
+    expected_result:
+      - [ "[BsonInt32{value=1}, BsonInt32{value=2}, BsonInt32{value=3}]", "{\"foo\": \"bar\"}" ]
+    row_count: 1
 

--- a/resources/integration_test/tests/query.yaml
+++ b/resources/integration_test/tests/query.yaml
@@ -188,13 +188,15 @@ tests:
     sql: SELECT * FROM types_other
     expected_result_extended_json: [ {
       "0": 0,
-      "1": [1,2,3],
+      "1": [{"$numberInt": "1"}, {"$numberInt": "2"}, {"$numberInt": "3"},
+            {"$oid": "000000000000000000000003"}, {"$timestamp": {"t": 200, "i": 0}}],
       "2": { "$dbPointer": { "$ref": "namespace", "$id": { "$oid": "000000000000000000000001" } } },
       "3": {"$code": "function(){ }"},
       "4": {"$code": "function(){ }", "$scope": {"foo":"bar"}},
       "5": {"$maxKey": 1},
       "6": {"$minKey": 1},
-      "7": {"foo":"bar"},
+      "7": {"foo": "bar", "objId": {"$oid": "000000000000000000000002"},
+            "value": 3, "time": {"$timestamp": {"t": 200, "i": 0}}},
       "8": { "$oid": "000000000000000000000001" },
       "9": {"$regularExpression": {pattern: "a(bc)*", "options": ""}},
       "10": { "$symbol": "symbol" },
@@ -241,6 +243,9 @@ tests:
     db: integration_test
     sql: SELECT `array`, `object` FROM types_other
     expected_result:
-      - [ "[BsonInt32{value=1}, BsonInt32{value=2}, BsonInt32{value=3}]", "{\"foo\": \"bar\"}" ]
+      - ["[{\"$numberInt\": \"1\"}, {\"$numberInt\": \"2\"}, {\"$numberInt\": \"3\"}, \
+          {\"$oid\": \"000000000000000000000003\"}, {\"$timestamp\": {\"t\": 200, \"i\": 0}}]",
+         "{\"foo\": \"bar\", \"objId\": {\"$oid\": \"000000000000000000000002\"}, \
+          \"value\": {\"$numberInt\": \"3\"}, \"time\": {\"$timestamp\": {\"t\": 200, \"i\": 0}}}"]
     row_count: 1
 

--- a/resources/integration_test/tests/query.yaml
+++ b/resources/integration_test/tests/query.yaml
@@ -243,8 +243,7 @@ tests:
     db: integration_test
     sql: SELECT `array`, `object` FROM types_other
     expected_result:
-      - ["[1, 2, 3, {\"$oid\": \"000000000000000000000003\"}, {\"$timestamp\": {\"t\": 200, \"i\": 0}}]",
-         "{\"foo\": \"bar\", \"objId\": {\"$oid\": \"000000000000000000000002\"}, \"value\": 3, \
-         \"time\": {\"$timestamp\": {\"t\": 200, \"i\": 0}}}"]
+      - ['[1, 2, 3, {"$oid": "000000000000000000000003"}, {"$timestamp": {"t": 200, "i": 0}}]',
+         '{"foo": "bar", "objId": {"$oid": "000000000000000000000002"}, "value": 3, "time": {"$timestamp": {"t": 200, "i": 0}}}']
     row_count: 1
 

--- a/src/integration-test/java/com/mongodb/jdbc/integration/testharness/IntegrationTestUtils.java
+++ b/src/integration-test/java/com/mongodb/jdbc/integration/testharness/IntegrationTestUtils.java
@@ -673,8 +673,7 @@ public class IntegrationTestUtils {
                                             + (i + 1));
                             return false;
                         }
-                    }
-                    else {
+                    } else {
                         Object actual_obj = actualRow.getObject(i + 1);
                         if (!expected_obj.equals(actual_obj)) {
                             System.err.println(

--- a/src/integration-test/java/com/mongodb/jdbc/integration/testharness/IntegrationTestUtils.java
+++ b/src/integration-test/java/com/mongodb/jdbc/integration/testharness/IntegrationTestUtils.java
@@ -661,16 +661,31 @@ public class IntegrationTestUtils {
                     break;
                 case Types.OTHER:
                     Object expected_obj = expectedRow.get(i);
-                    Object actual_obj = actualRow.getObject(i + 1);
-                    if (!expected_obj.equals(actual_obj)) {
-                        System.err.println(
-                                "Expected Bson Other value "
-                                        + expected_obj
-                                        + " but is "
-                                        + actual_obj
-                                        + " for column "
-                                        + (i + 1));
-                        return false;
+                    if (expected_obj instanceof String) {
+                        String actual_obj = actualRow.getString(i + 1);
+                        if (!expected_obj.equals(actual_obj)) {
+                            System.err.println(
+                                    "Expected Bson Other String value "
+                                            + expected_obj
+                                            + " but is "
+                                            + actual_obj
+                                            + " for column "
+                                            + (i + 1));
+                            return false;
+                        }
+                    }
+                    else {
+                        Object actual_obj = actualRow.getObject(i + 1);
+                        if (!expected_obj.equals(actual_obj)) {
+                            System.err.println(
+                                    "Expected Bson Other Object value "
+                                            + expected_obj
+                                            + " but is "
+                                            + actual_obj
+                                            + " for column "
+                                            + (i + 1));
+                            return false;
+                        }
                     }
                     break;
                 default:

--- a/src/main/java/com/mongodb/jdbc/MongoSQLResultSet.java
+++ b/src/main/java/com/mongodb/jdbc/MongoSQLResultSet.java
@@ -391,7 +391,7 @@ public class MongoSQLResultSet extends MongoResultSet<BsonDocument> implements R
             case ARRAY:
                 Codec codec = registry.get(BsonArray.class);
                 StringWriter writer = new StringWriter();
-                codec.encode(new NoCheckStateJsonWriter(writer, settings), o, EncoderContext.builder().build());
+                codec.encode(new NoCheckStateJsonWriter(writer, settings), o.asArray(), EncoderContext.builder().build());
                 writer.flush();
                 return writer.toString();
             case BINARY:

--- a/src/main/java/com/mongodb/jdbc/MongoSQLResultSet.java
+++ b/src/main/java/com/mongodb/jdbc/MongoSQLResultSet.java
@@ -375,7 +375,7 @@ public class MongoSQLResultSet extends MongoResultSet<BsonDocument> implements R
         }
         switch (o.getBsonType()) {
             case ARRAY:
-                return handleStringConversionFailure(ARRAY);
+                return o.asArray().getValues().toString();
             case BINARY:
                 return handleStringConversionFailure(BINARY);
             case BOOLEAN:
@@ -388,7 +388,7 @@ public class MongoSQLResultSet extends MongoResultSet<BsonDocument> implements R
             case DECIMAL128:
                 return o.asDecimal128().getValue().toString();
             case DOCUMENT:
-                return handleStringConversionFailure(DOCUMENT);
+                return o.asDocument().toString();
             case DOUBLE:
                 return Double.toString(o.asDouble().getValue());
             case END_OF_DOCUMENT:

--- a/src/main/java/com/mongodb/jdbc/MongoSQLResultSet.java
+++ b/src/main/java/com/mongodb/jdbc/MongoSQLResultSet.java
@@ -1,10 +1,11 @@
 package com.mongodb.jdbc;
 
+import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
+
 import com.google.common.base.Preconditions;
 import com.mongodb.client.MongoCursor;
 import com.mongodb.jdbc.logging.AutoLoggable;
 import com.mongodb.jdbc.logging.MongoLogger;
-
 import java.io.StringWriter;
 import java.math.BigDecimal;
 import java.sql.Date;
@@ -12,7 +13,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.text.ParseException;
-
 import org.bson.BsonArray;
 import org.bson.BsonDocument;
 import org.bson.BsonMaxKey;
@@ -28,8 +28,6 @@ import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.json.JsonMode;
 import org.bson.json.JsonWriterSettings;
 import org.bson.types.Decimal128;
-
-import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
 
 @AutoLoggable
 public class MongoSQLResultSet extends MongoResultSet<BsonDocument> implements ResultSet {
@@ -385,13 +383,17 @@ public class MongoSQLResultSet extends MongoResultSet<BsonDocument> implements R
         if (checkNull(o)) {
             return null;
         }
-        JsonWriterSettings settings = JsonWriterSettings.builder().outputMode(JsonMode.EXTENDED).build();
+        JsonWriterSettings settings =
+                JsonWriterSettings.builder().outputMode(JsonMode.EXTENDED).build();
         CodecRegistry registry = fromProviders(new BsonValueCodecProvider());
         switch (o.getBsonType()) {
             case ARRAY:
                 Codec codec = registry.get(BsonArray.class);
                 StringWriter writer = new StringWriter();
-                codec.encode(new NoCheckStateJsonWriter(writer, settings), o.asArray(), EncoderContext.builder().build());
+                codec.encode(
+                        new NoCheckStateJsonWriter(writer, settings),
+                        o.asArray(),
+                        EncoderContext.builder().build());
                 writer.flush();
                 return writer.toString();
             case BINARY:

--- a/src/main/java/com/mongodb/jdbc/NoCheckStateJsonWriter.java
+++ b/src/main/java/com/mongodb/jdbc/NoCheckStateJsonWriter.java
@@ -1,0 +1,17 @@
+package com.mongodb.jdbc;
+
+import java.io.Writer;
+import org.bson.json.JsonWriter;
+import org.bson.json.JsonWriterSettings;
+
+public class NoCheckStateJsonWriter extends JsonWriter {
+
+    public NoCheckStateJsonWriter(Writer writer, JsonWriterSettings settings) {
+        super(writer, settings);
+    }
+
+    @Override
+    protected boolean checkState(State[] validStates) {
+        return true;
+    }
+}

--- a/src/main/java/com/mongodb/jdbc/NoCheckStateJsonWriter.java
+++ b/src/main/java/com/mongodb/jdbc/NoCheckStateJsonWriter.java
@@ -4,6 +4,10 @@ import java.io.Writer;
 import org.bson.json.JsonWriter;
 import org.bson.json.JsonWriterSettings;
 
+/**
+ * NoCheckStateJsonWriter will allow writing of any Json value. It does not validate it is
+ * constructing a valid document. Useful for writing Bson Values such as a BsonArray.
+ */
 public class NoCheckStateJsonWriter extends JsonWriter {
 
     public NoCheckStateJsonWriter(Writer writer, JsonWriterSettings settings) {


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/SQL-800

getString() for Document and Array columns return extJSON string.

Added array value to the row in `types_other` collection.   Added integration test to query array and document values as string.  