### PR TITLE
SQL-791: Adding smoke test for built artifacts

### DIFF
--- a/.evg.yml
+++ b/.evg.yml
@@ -127,7 +127,7 @@ functions:
         ./resources/run_adl.sh start &&
         ./gradlew runDataLoader &&
         ./gradlew clean shadowJar &&
-        ./gradlew :smoketest:test
+        ./gradlew :smoketest:test -Psmoketest
         EXITCODE=$?
         ./resources/run_adl.sh stop
         exit $EXITCODE

--- a/.evg.yml
+++ b/.evg.yml
@@ -36,12 +36,14 @@ buildvariants:
       - name: "build"
       - name: "test-unit"
       - name: "test-integration"
+
   - name: release
     display_name: "Release"
     expansions:
       _platform: ubuntu1804-64-jdk-8
     run_on: ubuntu1804-build
     tasks:
+      - name: "test-smoke"
       - name: "publish-maven"
 
 tasks:
@@ -57,7 +59,14 @@ tasks:
     commands:
       - func: "run integration test"
 
+  - name: "test-smoke"
+    commands:
+      - func: "run smoke test"
+
   - name: "publish-maven"
+    depends_on:
+      - name: "test-smoke"
+        variant: "release"
     commands:
       - func: "publish maven"
 
@@ -107,6 +116,21 @@ functions:
           EXITCODE=$?
           ./resources/run_adl.sh stop
           exit $EXITCODE
+
+  "run smoke test":
+    command: shell.exec
+    type: test
+    params:
+      working_dir: mongo-jdbc-driver
+      script: |
+        ${PREPARE_SHELL}
+        ./resources/run_adl.sh start &&
+        ./gradlew runDataLoader &&
+        ./gradlew clean shadowJar &&
+        ./gradlew :smoketest:run
+        EXITCODE=$?
+        ./resources/run_adl.sh stop
+        exit $EXITCODE
 
   "export variables":
     - command: shell.exec

--- a/.evg.yml
+++ b/.evg.yml
@@ -127,7 +127,7 @@ functions:
         ./resources/run_adl.sh start &&
         ./gradlew runDataLoader &&
         ./gradlew clean shadowJar &&
-        ./gradlew :smoketest:run
+        ./gradlew :smoketest:test
         EXITCODE=$?
         ./resources/run_adl.sh stop
         exit $EXITCODE

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -59,8 +59,6 @@ Wait for the evergreen version to finish, and ensure that the release task compl
 
 #### Verify release artifacts
 Check that the version just released is available in the [Sonatype Nexus Repo Manager](https://oss.sonatype.org/#nexus-search;quick~mongodb-jdbc).  
-It is also a good idea to download the released artifacts mongodb-jdbc-x.x.x.jar and mongodb-jdbc-x.x.x-all.jar and verify that they are correctly 
-loading and the simple operations connecting, retrieving metadata and executing a query are all working.
 The release artifacts should appear on [Maven Central](https://search.maven.org/search?q=g:org.mongodb%20AND%20a:mongodb-jdbc) after a while.
 
 #### Close Release Ticket

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,5 +9,6 @@
 
 rootProject.name = 'mongodb-jdbc'
 
-
 include 'demo'
+include 'smoketest'
+

--- a/smoketest/build.gradle
+++ b/smoketest/build.gradle
@@ -7,6 +7,6 @@ application {
 }
 
 dependencies {
-    implementation files('../build/libs/'+rootProject.name+'-'+getReleaseVersion()+'-all.jar')
+    runtimeOnly files('../build/libs/'+rootProject.name+'-'+getReleaseVersion()+'-all.jar')
 }
 

--- a/smoketest/build.gradle
+++ b/smoketest/build.gradle
@@ -10,4 +10,4 @@ dependencies {
 test {
     useJUnitPlatform()
 }
-
+test.onlyIf { project.hasProperty("smoketest") }

--- a/smoketest/build.gradle
+++ b/smoketest/build.gradle
@@ -1,0 +1,12 @@
+plugins {
+    id 'application'
+}
+
+application {
+    mainClassName = 'com.mongodb.jdbc.smoketest.SmokeTest'
+}
+
+dependencies {
+    implementation files('../build/libs/'+rootProject.name+'-'+getReleaseVersion()+'-all.jar')
+}
+

--- a/smoketest/build.gradle
+++ b/smoketest/build.gradle
@@ -1,12 +1,13 @@
 plugins {
-    id 'application'
-}
-
-application {
-    mainClassName = 'com.mongodb.jdbc.smoketest.SmokeTest'
+    id 'java'
 }
 
 dependencies {
     runtimeOnly files('../build/libs/'+rootProject.name+'-'+getReleaseVersion()+'-all.jar')
+    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: junitJupiterVersion
+}
+
+test {
+    useJUnitPlatform()
 }
 

--- a/smoketest/src/main/java/com/mongodb/jdbc/smoketest/SmokeTest.java
+++ b/smoketest/src/main/java/com/mongodb/jdbc/smoketest/SmokeTest.java
@@ -1,0 +1,70 @@
+package com.mongodb.jdbc.smoketest;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+
+/**
+ * SmokeTest runs a test on built artifacts to verify that connection,
+ * metadata retrieval, and querying is successful
+ */
+public class SmokeTest {
+    static final String URL = "jdbc:mongodb://localhost";
+    static final String DB = "integration_test";
+    public static final String MONGOSQL = "mongosql";
+
+    public static Connection getBasicConnection(String url, String db)
+            throws SQLException {
+        Properties p = new java.util.Properties();
+        p.setProperty("dialect", MONGOSQL);
+        p.setProperty("user", System.getenv("ADL_TEST_LOCAL_USER"));
+        p.setProperty("password", System.getenv("ADL_TEST_LOCAL_PWD"));
+        p.setProperty("authSource", System.getenv("ADL_TEST_LOCAL_AUTH_DB"));
+        p.setProperty("ssl", "false");
+        p.setProperty("database", db);
+        return DriverManager.getConnection(URL, p);
+    }
+
+    public static void databaseMetadataTest(DatabaseMetaData dbMetadata) throws SQLException {
+        ResultSet rs = dbMetadata.getColumns(null, "%", "%", "%");
+        rowCountCheck(rs, 47);
+    }
+
+    public static void queryTest(Connection conn) throws SQLException {
+        try (Statement stmt = conn.createStatement()) {
+            String query = "SELECT * from class";
+            ResultSet rs = stmt.executeQuery(query);
+            rowCountCheck(rs, 5);
+        }
+    }
+
+    public static void rowCountCheck(ResultSet rs, int expectedCount) throws SQLException {
+        int actualCount = 0;
+        while (rs.next()) {
+            actualCount++;
+        }
+
+        if (expectedCount != actualCount) {
+            throw new RuntimeException("Incorrect row count, expected: " + expectedCount + " actual: " + actualCount);
+        }
+    }
+
+    public static void main(String[] args) throws SQLException {
+        try (Connection conn = getBasicConnection(URL, DB)) {
+            DatabaseMetaData dbMetadata = conn.getMetaData();
+            System.out.println(dbMetadata.getDriverName());
+            System.out.println(dbMetadata.getDriverVersion());
+
+            databaseMetadataTest(dbMetadata);
+            queryTest(conn);
+
+        } catch( Exception e) {
+            System.err.println(e);
+            throw(e);
+        }
+    }
+}


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/SQL-791

Added a smoke test that will block the publish-maven task if it fails.
Starts a local ADL to connect to, retrieve metadata, and run a query.
Smoke test uses the built shadowJar  `mongodb-jdbc-'+getReleaseVersion()+'-all.jar` as its dependency.