### PR TITLE
SQL-883: Adding ClientInfo property to include client name/version to…

### DIFF
--- a/src/main/java/com/mongodb/jdbc/MongoConnection.java
+++ b/src/main/java/com/mongodb/jdbc/MongoConnection.java
@@ -1,7 +1,6 @@
 package com.mongodb.jdbc;
 
 import com.google.common.base.Preconditions;
-import com.mongodb.ConnectionString;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoDriverInformation;
 import com.mongodb.client.MongoClient;
@@ -66,19 +65,15 @@ public abstract class MongoConnection implements Connection {
     private static Map<String, FileHandler> fileHandlers = new HashMap<String, FileHandler>();
     private String logDirPath;
 
-    public MongoConnection(
-            ConnectionString cs,
-            String database,
-            Level logLevel,
-            File logDir,
-            String[] clientInfo) {
-        Preconditions.checkNotNull(cs);
+    public MongoConnection(MongoConnectionProperties connectionProperties) {
+        Preconditions.checkNotNull(connectionProperties.getConnectionString());
         this.connectionId = connectionCounter.incrementAndGet();
         // Initializes a parent logger for the connection
-        initConnectionLogger(connectionId, logLevel, logDir);
-        this.url = cs.getConnectionString();
-        this.user = cs.getUsername();
-        this.currentDB = database;
+        initConnectionLogger(
+                connectionId, connectionProperties.getLogLevel(), connectionProperties.getLogDir());
+        this.url = connectionProperties.getConnectionString().getConnectionString();
+        this.user = connectionProperties.getConnectionString().getUsername();
+        this.currentDB = connectionProperties.getDatabase();
         String version =
                 MongoDriver.VERSION != null
                         ? MongoDriver.VERSION
@@ -87,32 +82,33 @@ public abstract class MongoConnection implements Connection {
                                 .append(".")
                                 .append(MongoDriver.MINOR_VERSION)
                                 .toString();
+        StringBuilder appName = new StringBuilder(MongoDriver.NAME);
 
         // Log the driver name and version
         logger.log(
                 Level.INFO, "Connecting using " + MongoDriver.MONGOSQL_DRIVER_NAME + " " + version);
 
-        MongoDriverInformation mongoDriverInformation;
-        if (clientInfo != null && clientInfo.length == 2) {
+        MongoDriverInformation.Builder mdiBuilder;
+        if (connectionProperties.getClientInfo() != null
+                && connectionProperties.getClientInfo().length == 2) {
+            appName.append('|').append(connectionProperties.getClientInfo()[0]);
             MongoDriverInformation driverInfoWithClientInfo =
                     MongoDriverInformation.builder()
-                            .driverName(clientInfo[0])
-                            .driverVersion(clientInfo[1])
+                            .driverName(connectionProperties.getClientInfo()[0])
+                            .driverVersion(connectionProperties.getClientInfo()[1])
                             .build();
-            mongoDriverInformation =
-                    MongoDriverInformation.builder(driverInfoWithClientInfo)
-                            .driverName(MongoDriver.NAME)
-                            .driverVersion(version)
-                            .build();
+            mdiBuilder = MongoDriverInformation.builder(driverInfoWithClientInfo);
         } else {
-            mongoDriverInformation =
-                    MongoDriverInformation.builder()
-                            .driverName(MongoDriver.NAME)
-                            .driverVersion(version)
-                            .build();
+            mdiBuilder = MongoDriverInformation.builder();
         }
+        MongoDriverInformation mongoDriverInformation =
+                mdiBuilder.driverName(MongoDriver.NAME).driverVersion(version).build();
 
-        this.mongoClientSettings = MongoClientSettings.builder().applyConnectionString(cs).build();
+        this.mongoClientSettings =
+                MongoClientSettings.builder()
+                        .applicationName(appName.toString())
+                        .applyConnectionString(connectionProperties.getConnectionString())
+                        .build();
         mongoClient = MongoClients.create(mongoClientSettings, mongoDriverInformation);
 
         isClosed = false;

--- a/src/main/java/com/mongodb/jdbc/MongoConnection.java
+++ b/src/main/java/com/mongodb/jdbc/MongoConnection.java
@@ -82,20 +82,20 @@ public abstract class MongoConnection implements Connection {
                                 .append(".")
                                 .append(MongoDriver.MINOR_VERSION)
                                 .toString();
-        StringBuilder appName = new StringBuilder(MongoDriver.NAME);
+        StringBuilder appName = new StringBuilder(MongoDriver.NAME).append("+").append(version);
 
         // Log the driver name and version
         logger.log(
                 Level.INFO, "Connecting using " + MongoDriver.MONGOSQL_DRIVER_NAME + " " + version);
 
         MongoDriverInformation.Builder mdiBuilder;
-        if (connectionProperties.getClientInfo() != null
-                && connectionProperties.getClientInfo().length == 2) {
-            appName.append('|').append(connectionProperties.getClientInfo()[0]);
+        String[] clientInfo = connectionProperties.getClientInfo();
+        if (clientInfo != null && clientInfo.length == 2) {
+            appName.append('|').append(clientInfo[0]).append("+").append(clientInfo[1]);
             MongoDriverInformation driverInfoWithClientInfo =
                     MongoDriverInformation.builder()
-                            .driverName(connectionProperties.getClientInfo()[0])
-                            .driverVersion(connectionProperties.getClientInfo()[1])
+                            .driverName(clientInfo[0])
+                            .driverVersion(clientInfo[1])
                             .build();
             mdiBuilder = MongoDriverInformation.builder(driverInfoWithClientInfo);
         } else {

--- a/src/main/java/com/mongodb/jdbc/MongoConnection.java
+++ b/src/main/java/com/mongodb/jdbc/MongoConnection.java
@@ -89,13 +89,14 @@ public abstract class MongoConnection implements Connection {
                 Level.INFO, "Connecting using " + MongoDriver.MONGOSQL_DRIVER_NAME + " " + version);
 
         MongoDriverInformation.Builder mdiBuilder;
-        String[] clientInfo = connectionProperties.getClientInfo();
-        if (clientInfo != null && clientInfo.length == 2) {
-            appName.append('|').append(clientInfo[0]).append("+").append(clientInfo[1]);
+        String clientInfo = connectionProperties.getClientInfo();
+        String[] clientInfoSplit = (clientInfo == null) ? null : clientInfo.split("\\+");
+        if (clientInfoSplit != null && clientInfoSplit.length == 2) {
+            appName.append('|').append(clientInfo);
             MongoDriverInformation driverInfoWithClientInfo =
                     MongoDriverInformation.builder()
-                            .driverName(clientInfo[0])
-                            .driverVersion(clientInfo[1])
+                            .driverName(clientInfoSplit[0])
+                            .driverVersion(clientInfoSplit[1])
                             .build();
             mdiBuilder = MongoDriverInformation.builder(driverInfoWithClientInfo);
         } else {

--- a/src/main/java/com/mongodb/jdbc/MongoConnectionProperties.java
+++ b/src/main/java/com/mongodb/jdbc/MongoConnectionProperties.java
@@ -1,0 +1,46 @@
+package com.mongodb.jdbc;
+
+import com.mongodb.ConnectionString;
+import java.io.File;
+import java.util.logging.Level;
+
+public class MongoConnectionProperties {
+    public ConnectionString connectionString;
+    public String database;
+    public Level logLevel;
+    public File logDir;
+    public String[] clientInfo;
+
+    public MongoConnectionProperties(
+            ConnectionString connectionString,
+            String database,
+            Level logLevel,
+            File logDir,
+            String[] clientInfo) {
+        this.connectionString = connectionString;
+        this.database = database;
+        this.logLevel = logLevel;
+        this.logDir = logDir;
+        this.clientInfo = clientInfo;
+    }
+
+    public ConnectionString getConnectionString() {
+        return connectionString;
+    }
+
+    public String getDatabase() {
+        return database;
+    }
+
+    public Level getLogLevel() {
+        return logLevel;
+    }
+
+    public File getLogDir() {
+        return logDir;
+    }
+
+    public String[] getClientInfo() {
+        return clientInfo;
+    }
+}

--- a/src/main/java/com/mongodb/jdbc/MongoConnectionProperties.java
+++ b/src/main/java/com/mongodb/jdbc/MongoConnectionProperties.java
@@ -5,18 +5,18 @@ import java.io.File;
 import java.util.logging.Level;
 
 public class MongoConnectionProperties {
-    protected ConnectionString connectionString;
-    protected String database;
-    protected Level logLevel;
-    protected File logDir;
-    protected String[] clientInfo;
+    private ConnectionString connectionString;
+    private String database;
+    private Level logLevel;
+    private File logDir;
+    private String clientInfo;
 
     public MongoConnectionProperties(
             ConnectionString connectionString,
             String database,
             Level logLevel,
             File logDir,
-            String[] clientInfo) {
+            String clientInfo) {
         this.connectionString = connectionString;
         this.database = database;
         this.logLevel = logLevel;
@@ -40,27 +40,7 @@ public class MongoConnectionProperties {
         return logDir;
     }
 
-    public String[] getClientInfo() {
+    public String getClientInfo() {
         return clientInfo;
-    }
-
-    public void setConnectionString(ConnectionString connectionString) {
-        this.connectionString = connectionString;
-    }
-
-    public void setDatabase(String database) {
-        this.database = database;
-    }
-
-    public void setLogLevel(Level logLevel) {
-        this.logLevel = logLevel;
-    }
-
-    public void setLogDir(File logDir) {
-        this.logDir = logDir;
-    }
-
-    public void setClientInfo(String[] clientInfo) {
-        this.clientInfo = clientInfo;
     }
 }

--- a/src/main/java/com/mongodb/jdbc/MongoConnectionProperties.java
+++ b/src/main/java/com/mongodb/jdbc/MongoConnectionProperties.java
@@ -5,11 +5,11 @@ import java.io.File;
 import java.util.logging.Level;
 
 public class MongoConnectionProperties {
-    public ConnectionString connectionString;
-    public String database;
-    public Level logLevel;
-    public File logDir;
-    public String[] clientInfo;
+    private ConnectionString connectionString;
+    private String database;
+    private Level logLevel;
+    private File logDir;
+    private String[] clientInfo;
 
     public MongoConnectionProperties(
             ConnectionString connectionString,
@@ -42,5 +42,25 @@ public class MongoConnectionProperties {
 
     public String[] getClientInfo() {
         return clientInfo;
+    }
+
+    public void setConnectionString(ConnectionString connectionString) {
+        this.connectionString = connectionString;
+    }
+
+    public void setDatabase(String database) {
+        this.database = database;
+    }
+
+    public void setLogLevel(Level logLevel) {
+        this.logLevel = logLevel;
+    }
+
+    public void setLogDir(File logDir) {
+        this.logDir = logDir;
+    }
+
+    public void setClientInfo(String[] clientInfo) {
+        this.clientInfo = clientInfo;
     }
 }

--- a/src/main/java/com/mongodb/jdbc/MongoConnectionProperties.java
+++ b/src/main/java/com/mongodb/jdbc/MongoConnectionProperties.java
@@ -5,11 +5,11 @@ import java.io.File;
 import java.util.logging.Level;
 
 public class MongoConnectionProperties {
-    private ConnectionString connectionString;
-    private String database;
-    private Level logLevel;
-    private File logDir;
-    private String[] clientInfo;
+    protected ConnectionString connectionString;
+    protected String database;
+    protected Level logLevel;
+    protected File logDir;
+    protected String[] clientInfo;
 
     public MongoConnectionProperties(
             ConnectionString connectionString,

--- a/src/main/java/com/mongodb/jdbc/MongoDriver.java
+++ b/src/main/java/com/mongodb/jdbc/MongoDriver.java
@@ -247,15 +247,14 @@ public class MongoDriver implements Driver {
                             + logDirVal
                             + ". It must be a directory.");
         }
-        String clientInfoVal = info.getProperty(CLIENT_INFO);
-        String[] clientInfo = (clientInfoVal == null) ? null : clientInfoVal.split("\\|");
-        if (clientInfo != null && clientInfo.length != 2) {
+        String clientInfo = info.getProperty(CLIENT_INFO);
+        if (clientInfo != null && clientInfo.split("\\+").length != 2) {
             throw new SQLException(
                     "Invalid "
                             + CLIENT_INFO
                             + " property value : "
-                            + clientInfoVal
-                            + ". Expected format <name>|<version>.");
+                            + clientInfo
+                            + ". Expected format <name>+<version>.");
         }
 
         MongoConnectionProperties mongoConnectionProperties =

--- a/src/main/java/com/mongodb/jdbc/MongoDriver.java
+++ b/src/main/java/com/mongodb/jdbc/MongoDriver.java
@@ -59,7 +59,7 @@ public class MongoDriver implements Driver {
     static final String MONGODB_SRV_URL_PREFIX = JDBC + "mongodb+srv:";
     public static final String USER = "user";
     public static final String PASSWORD = "password";
-    public static final String CLIENT_INFO = "ClientInfo";
+    public static final String CLIENT_INFO = "clientInfo";
     static final String CONVERSION_MODE = "conversionMode";
     // database is the database to switch to.
     public static final String DATABASE = "database";

--- a/src/main/java/com/mongodb/jdbc/MongoDriver.java
+++ b/src/main/java/com/mongodb/jdbc/MongoDriver.java
@@ -59,6 +59,7 @@ public class MongoDriver implements Driver {
     static final String MONGODB_SRV_URL_PREFIX = JDBC + "mongodb+srv:";
     public static final String USER = "user";
     public static final String PASSWORD = "password";
+    public static final String CLIENT_INFO = "ClientInfo";
     static final String CONVERSION_MODE = "conversionMode";
     // database is the database to switch to.
     public static final String DATABASE = "database";
@@ -246,10 +247,26 @@ public class MongoDriver implements Driver {
                             + logDirVal
                             + ". It must be a directory.");
         }
+        String clientInfoVal = info.getProperty(CLIENT_INFO);
+        String[] clientInfo = (clientInfoVal == null) ? null : clientInfoVal.split("\\|");
+        if (clientInfo != null && clientInfo.length != 2) {
+            throw new SQLException(
+                    "Invalid "
+                            + CLIENT_INFO
+                            + " property value : "
+                            + clientInfoVal
+                            + ". Expected format <name>|<version>.");
+        }
+
         switch (dialect.toLowerCase()) {
             case MYSQL_DIALECT:
                 return new MySQLConnection(
-                        cs, database, info.getProperty(CONVERSION_MODE), logLevel, logDir);
+                        cs,
+                        database,
+                        info.getProperty(CONVERSION_MODE),
+                        logLevel,
+                        logDir,
+                        clientInfo);
             case MONGOSQL_DIALECT:
                 if (info.containsKey(CONVERSION_MODE)) {
                     throw new SQLException(
@@ -260,7 +277,7 @@ public class MongoDriver implements Driver {
                                     + " is "
                                     + MONGOSQL_DIALECT);
                 }
-                return new MongoSQLConnection(cs, database, logLevel, logDir);
+                return new MongoSQLConnection(cs, database, logLevel, logDir, clientInfo);
             default:
                 throw new SQLException(
                         "Invalid dialect "

--- a/src/main/java/com/mongodb/jdbc/MongoDriver.java
+++ b/src/main/java/com/mongodb/jdbc/MongoDriver.java
@@ -258,15 +258,12 @@ public class MongoDriver implements Driver {
                             + ". Expected format <name>|<version>.");
         }
 
+        MongoConnectionProperties mongoConnectionProperties =
+                new MongoConnectionProperties(cs, database, logLevel, logDir, clientInfo);
         switch (dialect.toLowerCase()) {
             case MYSQL_DIALECT:
                 return new MySQLConnection(
-                        cs,
-                        database,
-                        info.getProperty(CONVERSION_MODE),
-                        logLevel,
-                        logDir,
-                        clientInfo);
+                        mongoConnectionProperties, info.getProperty(CONVERSION_MODE));
             case MONGOSQL_DIALECT:
                 if (info.containsKey(CONVERSION_MODE)) {
                     throw new SQLException(
@@ -277,7 +274,7 @@ public class MongoDriver implements Driver {
                                     + " is "
                                     + MONGOSQL_DIALECT);
                 }
-                return new MongoSQLConnection(cs, database, logLevel, logDir, clientInfo);
+                return new MongoSQLConnection(mongoConnectionProperties);
             default:
                 throw new SQLException(
                         "Invalid dialect "

--- a/src/main/java/com/mongodb/jdbc/MongoSQLConnection.java
+++ b/src/main/java/com/mongodb/jdbc/MongoSQLConnection.java
@@ -13,8 +13,13 @@ import java.util.logging.Level;
 @AutoLoggable
 public class MongoSQLConnection extends MongoConnection implements Connection {
 
-    public MongoSQLConnection(ConnectionString cs, String database, Level logLevel, File logDir) {
-        super(cs, database, logLevel, logDir);
+    public MongoSQLConnection(
+            ConnectionString cs,
+            String database,
+            Level logLevel,
+            File logDir,
+            String[] clientInfo) {
+        super(cs, database, logLevel, logDir, clientInfo);
         super.getLogger().log(Level.INFO, "Dialect is MongoSQL");
     }
 

--- a/src/main/java/com/mongodb/jdbc/MongoSQLConnection.java
+++ b/src/main/java/com/mongodb/jdbc/MongoSQLConnection.java
@@ -1,8 +1,6 @@
 package com.mongodb.jdbc;
 
-import com.mongodb.ConnectionString;
 import com.mongodb.jdbc.logging.AutoLoggable;
-import java.io.File;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
@@ -13,13 +11,8 @@ import java.util.logging.Level;
 @AutoLoggable
 public class MongoSQLConnection extends MongoConnection implements Connection {
 
-    public MongoSQLConnection(
-            ConnectionString cs,
-            String database,
-            Level logLevel,
-            File logDir,
-            String[] clientInfo) {
-        super(cs, database, logLevel, logDir, clientInfo);
+    public MongoSQLConnection(MongoConnectionProperties mongoConnectionProperties) {
+        super(mongoConnectionProperties);
         super.getLogger().log(Level.INFO, "Dialect is MongoSQL");
     }
 

--- a/src/main/java/com/mongodb/jdbc/MySQLConnection.java
+++ b/src/main/java/com/mongodb/jdbc/MySQLConnection.java
@@ -19,8 +19,9 @@ public class MySQLConnection extends MongoConnection implements Connection {
             String database,
             String conversionMode,
             Level logLevel,
-            File logDir) {
-        super(cs, database, logLevel, logDir);
+            File logDir,
+            String[] clientInfo) {
+        super(cs, database, logLevel, logDir, clientInfo);
         super.getLogger().log(Level.INFO, "Dialect is Mysql");
         relaxed = conversionMode == null || !conversionMode.equals("strict");
     }

--- a/src/main/java/com/mongodb/jdbc/MySQLConnection.java
+++ b/src/main/java/com/mongodb/jdbc/MySQLConnection.java
@@ -1,8 +1,6 @@
 package com.mongodb.jdbc;
 
-import com.mongodb.ConnectionString;
 import com.mongodb.jdbc.logging.AutoLoggable;
-import java.io.File;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
@@ -15,13 +13,8 @@ public class MySQLConnection extends MongoConnection implements Connection {
     private boolean relaxed;
 
     public MySQLConnection(
-            ConnectionString cs,
-            String database,
-            String conversionMode,
-            Level logLevel,
-            File logDir,
-            String[] clientInfo) {
-        super(cs, database, logLevel, logDir, clientInfo);
+            MongoConnectionProperties mongoConnectionProperties, String conversionMode) {
+        super(mongoConnectionProperties);
         super.getLogger().log(Level.INFO, "Dialect is Mysql");
         relaxed = conversionMode == null || !conversionMode.equals("strict");
     }

--- a/src/test/java/com/mongodb/jdbc/MongoDatabaseMetaDataTest.java
+++ b/src/test/java/com/mongodb/jdbc/MongoDatabaseMetaDataTest.java
@@ -316,7 +316,8 @@ abstract class MongoDatabaseMetaDataTest {
 class MySQLDatabaseMetaDataTest extends MongoDatabaseMetaDataTest {
     @Override
     protected DatabaseMetaData createDatabaseMetaData() {
-        return new MySQLDatabaseMetaData(new MySQLConnection(uri, database, null, null, null));
+        return new MySQLDatabaseMetaData(
+                new MySQLConnection(uri, database, null, null, null, null));
     }
 
     @Test
@@ -388,7 +389,8 @@ class MySQLDatabaseMetaDataTest extends MongoDatabaseMetaDataTest {
 class MongoSQLDatabaseMetaDataTest extends MongoDatabaseMetaDataTest {
     @Override
     protected DatabaseMetaData createDatabaseMetaData() {
-        return new MongoSQLDatabaseMetaData(new MongoSQLConnection(uri, database, null, null));
+        return new MongoSQLDatabaseMetaData(
+                new MongoSQLConnection(uri, database, null, null, null));
     }
 
     @Test

--- a/src/test/java/com/mongodb/jdbc/MongoDatabaseMetaDataTest.java
+++ b/src/test/java/com/mongodb/jdbc/MongoDatabaseMetaDataTest.java
@@ -317,7 +317,8 @@ class MySQLDatabaseMetaDataTest extends MongoDatabaseMetaDataTest {
     @Override
     protected DatabaseMetaData createDatabaseMetaData() {
         return new MySQLDatabaseMetaData(
-                new MySQLConnection(uri, database, null, null, null, null));
+                new MySQLConnection(
+                        new MongoConnectionProperties(uri, database, null, null, null), null));
     }
 
     @Test
@@ -390,7 +391,8 @@ class MongoSQLDatabaseMetaDataTest extends MongoDatabaseMetaDataTest {
     @Override
     protected DatabaseMetaData createDatabaseMetaData() {
         return new MongoSQLDatabaseMetaData(
-                new MongoSQLConnection(uri, database, null, null, null));
+                new MongoSQLConnection(
+                        new MongoConnectionProperties(uri, database, null, null, null)));
     }
 
     @Test

--- a/src/test/java/com/mongodb/jdbc/MongoDriverTest.java
+++ b/src/test/java/com/mongodb/jdbc/MongoDriverTest.java
@@ -611,4 +611,27 @@ class MongoDriverTest {
             // Ignore clean-up error if any
         }
     }
+
+    @Test
+    void testClientInfoProperty() throws Exception {
+        MongoDriver d = new MongoDriver();
+        Properties p = new Properties();
+        Connection c;
+        p.setProperty("database", "test");
+
+        // ClientInfo not set succeeds
+        c = d.getUnvalidatedConnection(basicURL, p);
+        assertNotNull(c);
+
+        // Invalid ClientInfo property results in Exception
+        p.setProperty(MongoDriver.CLIENT_INFO, "InvalidFormat");
+        assertThrows(
+                SQLException.class,
+                () -> d.getUnvalidatedConnection(basicURL, p),
+                "The connection should fail because expected format is <name>|<version>.");
+
+        p.setProperty(MongoDriver.CLIENT_INFO, "name|version");
+        c = d.getUnvalidatedConnection(basicURL, p);
+        assertNotNull(c);
+    }
 }

--- a/src/test/java/com/mongodb/jdbc/MongoDriverTest.java
+++ b/src/test/java/com/mongodb/jdbc/MongoDriverTest.java
@@ -628,9 +628,9 @@ class MongoDriverTest {
         assertThrows(
                 SQLException.class,
                 () -> d.getUnvalidatedConnection(basicURL, p),
-                "The connection should fail because expected format is <name>|<version>.");
+                "The connection should fail because expected format is <name>+<version>.");
 
-        p.setProperty(MongoDriver.CLIENT_INFO, "name|version");
+        p.setProperty(MongoDriver.CLIENT_INFO, "name+version");
         c = d.getUnvalidatedConnection(basicURL, p);
         assertNotNull(c);
     }

--- a/src/test/java/com/mongodb/jdbc/MongoSQLMock.java
+++ b/src/test/java/com/mongodb/jdbc/MongoSQLMock.java
@@ -137,7 +137,7 @@ public abstract class MongoSQLMock {
 
     @InjectMocks
     protected static MongoConnection mongoConnection =
-            new MongoSQLConnection(uri, database, null, null, null);
+            new MongoSQLConnection(new MongoConnectionProperties(uri, database, null, null, null));
 
     private static Field getDeclaredFieldFromClassOrSuperClass(Class c, String fieldName)
             throws NoSuchFieldException {

--- a/src/test/java/com/mongodb/jdbc/MongoSQLMock.java
+++ b/src/test/java/com/mongodb/jdbc/MongoSQLMock.java
@@ -137,7 +137,7 @@ public abstract class MongoSQLMock {
 
     @InjectMocks
     protected static MongoConnection mongoConnection =
-            new MongoSQLConnection(uri, database, null, null);
+            new MongoSQLConnection(uri, database, null, null, null);
 
     private static Field getDeclaredFieldFromClassOrSuperClass(Class c, String fieldName)
             throws NoSuchFieldException {

--- a/src/test/java/com/mongodb/jdbc/MySQLMock.java
+++ b/src/test/java/com/mongodb/jdbc/MySQLMock.java
@@ -28,7 +28,8 @@ public abstract class MySQLMock {
 
     @InjectMocks
     protected static MongoConnection mongoConnection =
-            new MySQLConnection(uri, database, null, null, null, null);
+            new MySQLConnection(
+                    new MongoConnectionProperties(uri, database, null, null, null), null);
 
     private static Field getDeclaredFieldFromClassOrSuperClass(Class c, String fieldName)
             throws NoSuchFieldException {

--- a/src/test/java/com/mongodb/jdbc/MySQLMock.java
+++ b/src/test/java/com/mongodb/jdbc/MySQLMock.java
@@ -28,7 +28,7 @@ public abstract class MySQLMock {
 
     @InjectMocks
     protected static MongoConnection mongoConnection =
-            new MySQLConnection(uri, database, null, null, null);
+            new MySQLConnection(uri, database, null, null, null, null);
 
     private static Field getDeclaredFieldFromClassOrSuperClass(Class c, String fieldName)
             throws NoSuchFieldException {


### PR DESCRIPTION
… driver info

`ClientInfo` is an optional property that users can add a client name and version to the mongoDriverInformation, which is used to provide additional client metadata for connections.
Format is:
property["ClientInfo"]="name|version";

The information logged for "tableau-connector|f8807d3" will look like:
```
"clientMetadata": {"driver":{"name":"mongo-java-driver|sync|mongodb-jdbc|tableau-connector","version":"3.12.11|2.0.0-beta-2-6-gc915429|f8807d3"}
```
