### PR TITLE
SQL-573: Add Apache 2.0 license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ ext {
 spotless {
     java {
         googleJavaFormat('1.1').aosp()
+        licenseHeaderFile('resources/license_header.txt')
     }
 }
 

--- a/resources/license_header.txt
+++ b/resources/license_header.txt
@@ -1,0 +1,16 @@
+/*
+ * Copyright $YEAR-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+

--- a/src/integration-test/java/com/mongodb/jdbc/integration/MongoIntegrationTest.java
+++ b/src/integration-test/java/com/mongodb/jdbc/integration/MongoIntegrationTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc.integration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/integration-test/java/com/mongodb/jdbc/integration/MongoSQLIntegrationTest.java
+++ b/src/integration-test/java/com/mongodb/jdbc/integration/MongoSQLIntegrationTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc.integration;
 
 import com.mongodb.jdbc.MongoConnection;

--- a/src/integration-test/java/com/mongodb/jdbc/integration/testharness/DataLoader.java
+++ b/src/integration-test/java/com/mongodb/jdbc/integration/testharness/DataLoader.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc.integration.testharness;
 
 import com.mongodb.MongoClient;

--- a/src/integration-test/java/com/mongodb/jdbc/integration/testharness/IntegrationTestUtils.java
+++ b/src/integration-test/java/com/mongodb/jdbc/integration/testharness/IntegrationTestUtils.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc.integration.testharness;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/integration-test/java/com/mongodb/jdbc/integration/testharness/TestGenerator.java
+++ b/src/integration-test/java/com/mongodb/jdbc/integration/testharness/TestGenerator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc.integration.testharness;
 
 import com.mongodb.jdbc.MongoSQLResultSetMetaData;

--- a/src/integration-test/java/com/mongodb/jdbc/integration/testharness/TestTypeInfo.java
+++ b/src/integration-test/java/com/mongodb/jdbc/integration/testharness/TestTypeInfo.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc.integration.testharness;
 
 import java.lang.reflect.Field;

--- a/src/integration-test/java/com/mongodb/jdbc/integration/testharness/models/TestData.java
+++ b/src/integration-test/java/com/mongodb/jdbc/integration/testharness/models/TestData.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc.integration.testharness.models;
 
 import java.util.List;

--- a/src/integration-test/java/com/mongodb/jdbc/integration/testharness/models/TestDataEntry.java
+++ b/src/integration-test/java/com/mongodb/jdbc/integration/testharness/models/TestDataEntry.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc.integration.testharness.models;
 
 import java.util.List;

--- a/src/integration-test/java/com/mongodb/jdbc/integration/testharness/models/TestEntry.java
+++ b/src/integration-test/java/com/mongodb/jdbc/integration/testharness/models/TestEntry.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc.integration.testharness.models;
 
 import java.util.List;

--- a/src/integration-test/java/com/mongodb/jdbc/integration/testharness/models/Tests.java
+++ b/src/integration-test/java/com/mongodb/jdbc/integration/testharness/models/Tests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc.integration.testharness.models;
 
 import java.util.List;

--- a/src/main/java/com/mongodb/jdbc/BsonExplicitCursor.java
+++ b/src/main/java/com/mongodb/jdbc/BsonExplicitCursor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import com.mongodb.ServerAddress;

--- a/src/main/java/com/mongodb/jdbc/BsonTypeInfo.java
+++ b/src/main/java/com/mongodb/jdbc/BsonTypeInfo.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import java.sql.SQLException;

--- a/src/main/java/com/mongodb/jdbc/JsonSchema.java
+++ b/src/main/java/com/mongodb/jdbc/JsonSchema.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import java.util.Map;

--- a/src/main/java/com/mongodb/jdbc/MongoColumnInfo.java
+++ b/src/main/java/com/mongodb/jdbc/MongoColumnInfo.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import org.bson.BsonType;

--- a/src/main/java/com/mongodb/jdbc/MongoConnection.java
+++ b/src/main/java/com/mongodb/jdbc/MongoConnection.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import com.google.common.base.Preconditions;

--- a/src/main/java/com/mongodb/jdbc/MongoConnectionProperties.java
+++ b/src/main/java/com/mongodb/jdbc/MongoConnectionProperties.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import com.mongodb.ConnectionString;

--- a/src/main/java/com/mongodb/jdbc/MongoDatabaseMetaData.java
+++ b/src/main/java/com/mongodb/jdbc/MongoDatabaseMetaData.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import static com.mongodb.jdbc.BsonTypeInfo.BSON_UNDEFINED;

--- a/src/main/java/com/mongodb/jdbc/MongoFunctions.java
+++ b/src/main/java/com/mongodb/jdbc/MongoFunctions.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 public abstract class MongoFunctions {

--- a/src/main/java/com/mongodb/jdbc/MongoJsonSchema.java
+++ b/src/main/java/com/mongodb/jdbc/MongoJsonSchema.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import static com.mongodb.jdbc.BsonTypeInfo.*;

--- a/src/main/java/com/mongodb/jdbc/MongoJsonSchemaResult.java
+++ b/src/main/java/com/mongodb/jdbc/MongoJsonSchemaResult.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import java.util.Map;

--- a/src/main/java/com/mongodb/jdbc/MongoListTablesResult.java
+++ b/src/main/java/com/mongodb/jdbc/MongoListTablesResult.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 public class MongoListTablesResult {

--- a/src/main/java/com/mongodb/jdbc/MongoPreparedStatement.java
+++ b/src/main/java/com/mongodb/jdbc/MongoPreparedStatement.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import com.mongodb.jdbc.logging.AutoLoggable;

--- a/src/main/java/com/mongodb/jdbc/MongoResultSet.java
+++ b/src/main/java/com/mongodb/jdbc/MongoResultSet.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import com.google.common.base.Preconditions;

--- a/src/main/java/com/mongodb/jdbc/MongoResultSetMetaData.java
+++ b/src/main/java/com/mongodb/jdbc/MongoResultSetMetaData.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import com.mongodb.jdbc.logging.AutoLoggable;

--- a/src/main/java/com/mongodb/jdbc/MongoSQLBsonValue.java
+++ b/src/main/java/com/mongodb/jdbc/MongoSQLBsonValue.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import java.io.StringWriter;

--- a/src/main/java/com/mongodb/jdbc/MongoSQLColumnInfo.java
+++ b/src/main/java/com/mongodb/jdbc/MongoSQLColumnInfo.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;

--- a/src/main/java/com/mongodb/jdbc/MongoSQLConnection.java
+++ b/src/main/java/com/mongodb/jdbc/MongoSQLConnection.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import com.mongodb.jdbc.logging.AutoLoggable;

--- a/src/main/java/com/mongodb/jdbc/MongoSQLDatabaseMetaData.java
+++ b/src/main/java/com/mongodb/jdbc/MongoSQLDatabaseMetaData.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import static com.mongodb.jdbc.BsonTypeInfo.*;

--- a/src/main/java/com/mongodb/jdbc/MongoSQLFunctions.java
+++ b/src/main/java/com/mongodb/jdbc/MongoSQLFunctions.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 public class MongoSQLFunctions extends MongoFunctions {

--- a/src/main/java/com/mongodb/jdbc/MongoSQLResultSet.java
+++ b/src/main/java/com/mongodb/jdbc/MongoSQLResultSet.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import com.google.common.base.Preconditions;

--- a/src/main/java/com/mongodb/jdbc/MongoSQLResultSetMetaData.java
+++ b/src/main/java/com/mongodb/jdbc/MongoSQLResultSetMetaData.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import com.mongodb.jdbc.logging.AutoLoggable;

--- a/src/main/java/com/mongodb/jdbc/MongoSQLStatement.java
+++ b/src/main/java/com/mongodb/jdbc/MongoSQLStatement.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import com.mongodb.MongoExecutionTimeoutException;

--- a/src/main/java/com/mongodb/jdbc/MongoStatement.java
+++ b/src/main/java/com/mongodb/jdbc/MongoStatement.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import com.google.common.base.Preconditions;

--- a/src/main/java/com/mongodb/jdbc/MongoVersionedJsonSchema.java
+++ b/src/main/java/com/mongodb/jdbc/MongoVersionedJsonSchema.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import org.bson.codecs.pojo.annotations.BsonCreator;

--- a/src/main/java/com/mongodb/jdbc/MySQLColumnInfo.java
+++ b/src/main/java/com/mongodb/jdbc/MySQLColumnInfo.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import java.sql.ResultSetMetaData;

--- a/src/main/java/com/mongodb/jdbc/MySQLConnection.java
+++ b/src/main/java/com/mongodb/jdbc/MySQLConnection.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import com.mongodb.jdbc.logging.AutoLoggable;

--- a/src/main/java/com/mongodb/jdbc/MySQLDatabaseMetaData.java
+++ b/src/main/java/com/mongodb/jdbc/MySQLDatabaseMetaData.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import static com.mongodb.jdbc.BsonTypeInfo.*;

--- a/src/main/java/com/mongodb/jdbc/MySQLExplicitCursor.java
+++ b/src/main/java/com/mongodb/jdbc/MySQLExplicitCursor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import com.mongodb.ServerAddress;

--- a/src/main/java/com/mongodb/jdbc/MySQLFunctions.java
+++ b/src/main/java/com/mongodb/jdbc/MySQLFunctions.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 public class MySQLFunctions extends MongoFunctions {

--- a/src/main/java/com/mongodb/jdbc/MySQLResultDoc.java
+++ b/src/main/java/com/mongodb/jdbc/MySQLResultDoc.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import java.util.List;

--- a/src/main/java/com/mongodb/jdbc/MySQLResultSet.java
+++ b/src/main/java/com/mongodb/jdbc/MySQLResultSet.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import com.google.common.base.Preconditions;

--- a/src/main/java/com/mongodb/jdbc/MySQLResultSetMetaData.java
+++ b/src/main/java/com/mongodb/jdbc/MySQLResultSetMetaData.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import com.mongodb.jdbc.logging.AutoLoggable;

--- a/src/main/java/com/mongodb/jdbc/MySQLStatement.java
+++ b/src/main/java/com/mongodb/jdbc/MySQLStatement.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import com.mongodb.MongoExecutionTimeoutException;

--- a/src/main/java/com/mongodb/jdbc/NoCheckStateJsonWriter.java
+++ b/src/main/java/com/mongodb/jdbc/NoCheckStateJsonWriter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import java.io.Writer;

--- a/src/main/java/com/mongodb/jdbc/Pair.java
+++ b/src/main/java/com/mongodb/jdbc/Pair.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import java.util.Objects;

--- a/src/main/java/com/mongodb/jdbc/SortableBsonDocument.java
+++ b/src/main/java/com/mongodb/jdbc/SortableBsonDocument.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import java.util.List;

--- a/src/main/java/com/mongodb/jdbc/logging/AutoLoggable.java
+++ b/src/main/java/com/mongodb/jdbc/logging/AutoLoggable.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc.logging;
 
 import java.lang.annotation.ElementType;

--- a/src/main/java/com/mongodb/jdbc/logging/DisableAutoLogging.java
+++ b/src/main/java/com/mongodb/jdbc/logging/DisableAutoLogging.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc.logging;
 
 import java.lang.annotation.ElementType;

--- a/src/main/java/com/mongodb/jdbc/logging/MongoLogger.java
+++ b/src/main/java/com/mongodb/jdbc/logging/MongoLogger.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc.logging;
 
 import java.util.logging.Level;

--- a/src/tdvt/java/com/mongodb/jdbc/tdvt/TDVTTest.java
+++ b/src/tdvt/java/com/mongodb/jdbc/tdvt/TDVTTest.java
@@ -1,4 +1,18 @@
-
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.mongodb.jdbc.tdvt;
 

--- a/src/test/java/com/mongodb/jdbc/BsonTypeInfoTest.java
+++ b/src/test/java/com/mongodb/jdbc/BsonTypeInfoTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import static com.mongodb.jdbc.BsonTypeInfo.*;

--- a/src/test/java/com/mongodb/jdbc/MongoConnectionTest.java
+++ b/src/test/java/com/mongodb/jdbc/MongoConnectionTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/com/mongodb/jdbc/MongoDatabaseMetaDataTest.java
+++ b/src/test/java/com/mongodb/jdbc/MongoDatabaseMetaDataTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/com/mongodb/jdbc/MongoDriverTest.java
+++ b/src/test/java/com/mongodb/jdbc/MongoDriverTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/com/mongodb/jdbc/MongoJsonSchemaTest.java
+++ b/src/test/java/com/mongodb/jdbc/MongoJsonSchemaTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import static org.bson.codecs.configuration.CodecRegistries.fromProviders;

--- a/src/test/java/com/mongodb/jdbc/MongoSQLConnectionTest.java
+++ b/src/test/java/com/mongodb/jdbc/MongoSQLConnectionTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/com/mongodb/jdbc/MongoSQLMock.java
+++ b/src/test/java/com/mongodb/jdbc/MongoSQLMock.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import static org.mockito.ArgumentMatchers.*;

--- a/src/test/java/com/mongodb/jdbc/MongoSQLResultSetMetaDataTest.java
+++ b/src/test/java/com/mongodb/jdbc/MongoSQLResultSetMetaDataTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/com/mongodb/jdbc/MongoSQLResultSetTest.java
+++ b/src/test/java/com/mongodb/jdbc/MongoSQLResultSetTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/com/mongodb/jdbc/MongoSQLStatementTest.java
+++ b/src/test/java/com/mongodb/jdbc/MongoSQLStatementTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import static java.sql.Statement.CLOSE_CURRENT_RESULT;

--- a/src/test/java/com/mongodb/jdbc/MySQLConnectionTest.java
+++ b/src/test/java/com/mongodb/jdbc/MySQLConnectionTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/com/mongodb/jdbc/MySQLMock.java
+++ b/src/test/java/com/mongodb/jdbc/MySQLMock.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import static org.mockito.ArgumentMatchers.*;

--- a/src/test/java/com/mongodb/jdbc/MySQLResultSetMetaDataTest.java
+++ b/src/test/java/com/mongodb/jdbc/MySQLResultSetMetaDataTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/com/mongodb/jdbc/MySQLResultSetTest.java
+++ b/src/test/java/com/mongodb/jdbc/MySQLResultSetTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/com/mongodb/jdbc/MySQLStatementTest.java
+++ b/src/test/java/com/mongodb/jdbc/MySQLStatementTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
 import static java.sql.Statement.CLOSE_CURRENT_RESULT;


### PR DESCRIPTION
This PR adds the apache 2.0 license to the repo, along with copyright headers to all source code files. It looks like the release already includes the license. I updated `spotless` to handle this for us. Now, `spotlessCheck` will fail if a source file does not start with a license header, and `spotlessApply` will write the header for us whenever it is missing.

**Open Question**
Should the header be added to the java files in `demo` and `smoketest`? If so, should that also be done through `spotless`? Right now, those directories are _not_ inspected by `spotless`, so I think I'd have to update their `gradle.build` files and probably update the evergreen task to check those as well.