### PR TITLE
SQL-916: ResultSet.close fails when calling Statement.close if Statement.closeOnClompetion is true

### DIFF
--- a/src/main/java/com/mongodb/jdbc/MongoResultSet.java
+++ b/src/main/java/com/mongodb/jdbc/MongoResultSet.java
@@ -159,7 +159,7 @@ public abstract class MongoResultSet<T> implements ResultSet {
         }
         cursor.close();
         closed = true;
-        if (statement != null && statement.isCloseOnCompletion()) {
+        if (statement != null && !statement.isClosed && statement.isCloseOnCompletion()) {
             statement.close();
         }
     }

--- a/src/test/java/com/mongodb/jdbc/MongoSQLStatementTest.java
+++ b/src/test/java/com/mongodb/jdbc/MongoSQLStatementTest.java
@@ -182,6 +182,26 @@ class MongoSQLStatementTest extends MongoSQLMock {
     }
 
     @Test
+    void testCloseOnCompletion() throws SQLException {
+        when(mongoCursor.hasNext()).thenReturn(true);
+        when(mongoCursor.next()).thenReturn(generateRow());
+        when(mongoDatabase.runCommand(any(), eq(MongoJsonSchemaResult.class)))
+                .thenReturn(generateSchema());
+
+        assertFalse(mongoStatement.isClosed());
+        mongoStatement.closeOnCompletion = true;
+        ResultSet rs = mongoStatement.executeQuery("select * from test");
+        rs.close();
+        assertTrue(rs.isClosed());
+        assertTrue(mongoStatement.isClosed());
+
+        // No-op since the statement has been closed
+        // automatically when closing the resutlset
+        mongoStatement.close();
+        assertTrue(mongoStatement.isClosed());
+    }
+
+    @Test
     void testGetMaxFieldSize() throws SQLException {
         assertEquals(0, mongoStatement.getMaxFieldSize());
         testExceptionAfterConnectionClosed(() -> mongoStatement.setMaxFieldSize(0));


### PR DESCRIPTION
A simple fix I had shelved for a long time now.