### PR TITLE
SQL-567: Improve SQL-to-Java regex pattern method in MongoDatabaseMetaData class

### DIFF
--- a/src/main/java/com/mongodb/jdbc/MongoDatabaseMetaData.java
+++ b/src/main/java/com/mongodb/jdbc/MongoDatabaseMetaData.java
@@ -169,7 +169,11 @@ public abstract class MongoDatabaseMetaData implements DatabaseMetaData {
     public static Pattern toJavaPattern(String sqlPattern) {
         return sqlPattern == null
                 ? null
-                : Pattern.compile(sqlPattern.replaceAll("%", ".*").replaceAll("_", "."));
+                : Pattern.compile(
+                        sqlPattern
+                                .replaceAll("([.^$*+?(){}|\\[\\]\\\\])", "\\\\$1")
+                                .replaceAll("(?<!\\\\)%", ".*")
+                                .replaceAll("(?<!\\\\)_", "."));
     }
 
     // Actual max size is 16777216, we reserve 216 for other bits of encoding,

--- a/src/test/java/com/mongodb/jdbc/MongoDatabaseMetaDataTest.java
+++ b/src/test/java/com/mongodb/jdbc/MongoDatabaseMetaDataTest.java
@@ -510,13 +510,20 @@ class MongoSQLDatabaseMetaDataTest extends MongoDatabaseMetaDataTest {
 
     @Test
     void testToJavaPattern() throws SQLException {
-        final String originalString = ".^$*+?(){}|[]\\";
-        final String escapedString = "\\.\\^\\$\\*\\+\\?\\(\\)\\{\\}\\|\\[\\]\\\\";
+        final String specialCharacters = ".^$*+?(){}|[]\\";
+        final String escapedSpecialCharacters = "\\.\\^\\$\\*\\+\\?\\(\\)\\{\\}\\|\\[\\]\\\\";
 
-        assertEquals(escapedString, MongoDatabaseMetaData.toJavaPattern(originalString).toString());
+        assertEquals(
+                escapedSpecialCharacters,
+                MongoDatabaseMetaData.toJavaPattern(specialCharacters).toString());
         assertEquals("\\\\%", MongoDatabaseMetaData.toJavaPattern("\\%").toString());
         assertEquals(".*", MongoDatabaseMetaData.toJavaPattern("%").toString());
         assertEquals("\\\\_", MongoDatabaseMetaData.toJavaPattern("\\_").toString());
         assertEquals(".", MongoDatabaseMetaData.toJavaPattern("_").toString());
+        assertEquals(
+                "nothingToEscape",
+                MongoDatabaseMetaData.toJavaPattern("nothingToEscape").toString());
+        assertEquals(
+                "a\\\\_.b\\\\%.*", MongoDatabaseMetaData.toJavaPattern("a\\__b\\%%").toString());
     }
 }

--- a/src/test/java/com/mongodb/jdbc/MongoDatabaseMetaDataTest.java
+++ b/src/test/java/com/mongodb/jdbc/MongoDatabaseMetaDataTest.java
@@ -507,4 +507,16 @@ class MongoSQLDatabaseMetaDataTest extends MongoDatabaseMetaDataTest {
 
         assertEquals(expectedFunctions, databaseMetaData.getTimeDateFunctions());
     }
+
+    @Test
+    void testToJavaPattern() throws SQLException {
+        final String originalString = ".^$*+?(){}|[]\\";
+        final String escapedString = "\\.\\^\\$\\*\\+\\?\\(\\)\\{\\}\\|\\[\\]\\\\";
+
+        assertEquals(escapedString, MongoDatabaseMetaData.toJavaPattern(originalString).toString());
+        assertEquals("\\\\%", MongoDatabaseMetaData.toJavaPattern("\\%").toString());
+        assertEquals(".*", MongoDatabaseMetaData.toJavaPattern("%").toString());
+        assertEquals("\\\\_", MongoDatabaseMetaData.toJavaPattern("\\_").toString());
+        assertEquals(".", MongoDatabaseMetaData.toJavaPattern("_").toString());
+    }
 }


### PR DESCRIPTION
In the `toJavaPattern` method: 
- modified function to NOT replace escaped `_` or `%`
- escaped Java regex characters not escaped in SQL regex patterns 
  - these characters were taken from the BI connector: `.^$*+?(){}|[]\\`

Additionally, I created unit tests for these changes.
