### PR TITLE
SQL-670: getTypeInfo does not return type info for type Null

### DIFF
--- a/resources/integration_test/tests/dbmd_constant_result_sets.yml
+++ b/resources/integration_test/tests/dbmd_constant_result_sets.yml
@@ -73,53 +73,93 @@ tests:
 
   - description: getTypeInfo_returns_constant_result_set
     db: integration_test
-    skip_reason: "SQL-670: missing null type info in actual result set."
     meta_function: [getTypeInfo]
     expected_result:
-      - [false, false, null, 1111, false, null, null, null, 0, 0, 1, 0, 0, 3, 0, 0,
-         array, false]
-      - [false, false, null, -2, false, null, null, null, 0, 0, 1, 0, 0, 0, 0, 0,
-         binData, false]
-      - [false, false, null, 16, false, null, null, null, 0, 0, 1, 0, 1, 3, 0, 0,
-         bool, false]
-      - [false, false, null, 1111, false, null, null, null, 0, 0, 1, 0, 0, 3, 0, 0,
-         bson, false]
-      - [false, false, null, 93, false, '''', '''', null, 3, 0, 1, 0, 24, 3, 0, 0,
-         date, false]
-      - [false, false, null, 1111, false, null, null, null, 0, 0, 1, 0, 0, 3, 0, 0,
-         dbPointer, false]
-      - [false, false, null, 3, false, null, null, null, 34, 34, 1, 10, 34, 3, 0,
-         0, decimal, false]
-      - [false, false, null, 8, false, null, null, null, 15, 15, 1, 2, 15, 3, 0, 0,
-         double, false]
-      - [false, false, null, 4, false, null, null, null, 0, 0, 1, 2, 10, 3, 0, 0,
-         int, false]
-      - [false, true, null, 1111, false, null, null, null, 0, 0, 1, 0, 0, 3, 0, 0,
-         javascript, false]
-      - [false, true, null, 1111, false, null, null, null, 0, 0, 1, 0, 0, 3, 0, 0,
-         javascriptWithScope, false]
-      - [false, false, null, -5, false, null, null, null, 0, 0, 1, 2, 19, 3, 0, 0,
-         long, false]
-      - [false, false, null, 1111, false, null, null, null, 0, 0, 1, 0, 0, 3, 0, 0,
-         maxKey, false]
-      - [false, false, null, 1111, false, null, null, null, 0, 0, 1, 0, 0, 3, 0, 0,
-         minKey, false]
-      - [false, false, null, 0, false, null, null, null, 0, 0, 1, 0, null, 3, 0, 0,
-         !!str "null", false]
-      - [false, false, null, 1111, false, null, null, null, 0, 0, 1, 0, 0, 3, 0, 0,
-         object, false]
-      - [false, false, null, 1111, false, null, null, null, 0, 0, 1, 0, 24, 3, 0,
-         0, objectId, false]
-      - [false, true, null, 1111, false, null, null, null, 0, 0, 1, 0, 0, 3, 0, 0,
-         regex, false]
-      - [false, true, null, -1, false, '''', '''', null, 0, 0, 1, 0, 0, 3, 0, 0, string,
-         false]
-      - [false, true, null, 1111, false, null, null, null, 0, 0, 1, 0, 0, 3, 0, 0,
-         symbol, false]
-      - [false, false, null, 1111, false, null, null, null, 0, 0, 1, 0, 0, 3, 0, 0,
-         timestamp, false]
-      - [false, false, null, 1111, false, null, null, null, 0, 0, 1, 0, 0, 3, 0, 0,
-         undefined, false]
+      - [binData, -2, null, null, null, null, 1, false, 0, false, null, false, null,
+         0, 0, 0, 0, 0]
+      - [bool, 16, 1, null, null, null, 1, false, 3, false, null, false, null, 0,
+         0, 0, 0, 0]
+      - [date, 93, 24, '''', '''', null, 1, false, 3, false, null, false, null, 0,
+         3, 0, 0, 0]
+      - [decimal, 3, 34, null, null, null, 1, false, 3, false, null, false, null,
+         34, 34, 0, 0, 10]
+      - [double, 8, 15, null, null, null, 1, false, 3, false, null, false, null, 15,
+         15, 0, 0, 2]
+      - [int, 4, 10, null, null, null, 1, false, 3, false, null, false, null, 0, 0,
+         0, 0, 2]
+      - [long, -5, 19, null, null, null, 1, false, 3, false, null, false, null, 0,
+         0, 0, 0, 2]
+      - [string, -1, null, '''', '''', null, 1, true, 3, false, null, false, null,
+         0, 0, 0, 0, 0]
+      - [array, 1111, null, null, null, null, 1, false, 3, false, null, false, null,
+         0, 0, 0, 0, 0]
+      - [object, 1111, null, null, null, null, 1, false, 3, false, null, false, null,
+         0, 0, 0, 0, 0]
+      - [objectId, 1111, 24, null, null, null, 1, false, 3, false, null, false, null,
+         0, 0, 0, 0, 0]
+      - [dbPointer, 1111, null, null, null, null, 1, false, 3, false, null, false,
+         null, 0, 0, 0, 0, 0]
+      - [javascript, 1111, null, null, null, null, 1, true, 3, false, null, false,
+         null, 0, 0, 0, 0, 0]
+      - [javascriptWithScope, 1111, null, null, null, null, 1, true, 3, false, null,
+         false, null, 0, 0, 0, 0, 0]
+      - [maxKey, 1111, null, null, null, null, 1, false, 3, false, null, false, null,
+         0, 0, 0, 0, 0]
+      - [minKey, 1111, null, null, null, null, 1, false, 3, false, null, false, null,
+         0, 0, 0, 0, 0]
+      - ['null', 0, null, null, null, null, 1, false, 3, false, null, false, null,
+         0, 0, 0, 0, 0]
+      - [regex, 1111, null, null, null, null, 1, true, 3, false, null, false, null,
+         0, 0, 0, 0, 0]
+      - [symbol, 1111, null, null, null, null, 1, true, 3, false, null, false, null,
+         0, 0, 0, 0, 0]
+      - [timestamp, 1111, null, null, null, null, 1, false, 3, false, null, false,
+         null, 0, 0, 0, 0, 0]
+      - [undefined, 1111, null, null, null, null, 1, false, 3, false, null, false,
+         null, 0, 0, 0, 0, 0]
+      - [bson, 1111, null, null, null, null, 1, false, 3, false, null, false, null,
+         0, 0, 0, 0, 0]
     row_count: 22
+    row_count_gte: null
     ordered: true
-
+    expected_sql_type: [LONGVARCHAR, INTEGER, INTEGER, LONGVARCHAR, LONGVARCHAR, LONGVARCHAR,
+                        INTEGER, BOOLEAN, INTEGER, BOOLEAN, BOOLEAN, BOOLEAN, LONGVARCHAR, INTEGER,
+                        INTEGER, INTEGER, INTEGER, INTEGER]
+    expected_bson_type: [string, int, int, string, string, string, int, bool, int,
+                         bool, bool, bool, string, int, int, int, int, int]
+    expected_catalog_name: ['', '', '', '', '', '', '', '', '', '', '', '', '', '',
+                            '', '', '', '']
+    expected_column_class_name: [java.lang.String, int, int, java.lang.String, java.lang.String,
+                                 java.lang.String, int, boolean, int, boolean, boolean, boolean, java.lang.String,
+                                 int, int, int, int, int]
+    expected_column_label: [TYPE_NAME, DATA_TYPE, PRECISION, LITERAL_PREFIX, LITERAL_SUFFIX,
+                            CREATE_PARAMS, NULLABLE, CASE_SENSITIVE, SEARCHABLE, UNSIGNED_ATTRIBUTE, FIX_PREC_SCALE,
+                            AUTO_INCREMENT, LOCAL_TYPE_NAME, MINIMUM_SCALE, MAXIMUM_SCALE, SQL_DATA_TYPE,
+                            SQL_DATETIME_SUB, NUM_PREC_RADIX]
+    expected_column_display_size: [0, 10, 10, 0, 0, 0, 10, 1, 10, 1, 1, 1, 0, 10,
+                                   10, 10, 10, 10]
+    expected_precision: [0, 10, 10, 0, 0, 0, 10, 1, 10, 1, 1, 1, 0, 10, 10, 10, 10,
+                         10]
+    expected_scale: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    expected_schema_name: ['', '', '', '', '', '', '', '', '', '', '', '', '', '',
+                           '', '', '', '']
+    expected_is_auto_increment: [false, false, false, false, false, false, false,
+                                 false, false, false, false, false, false, false, false, false, false, false]
+    expected_is_case_sensitive: [true, false, false, true, true, true, false, false,
+                                 false, false, false, false, true, false, false, false, false, false]
+    expected_is_currency: [false, false, false, false, false, false, false, false,
+                           false, false, false, false, false, false, false, false, false, false]
+    expected_is_definitely_writable: [false, false, false, false, false, false, false,
+                                      false, false, false, false, false, false, false, false, false, false, false]
+    expected_is_nullable: [columnNoNulls, columnNoNulls, columnNoNulls, columnNullable,
+                           columnNullable, columnNullable, columnNoNulls, columnNoNulls, columnNoNulls,
+                           columnNoNulls, columnNoNulls, columnNoNulls, columnNullable, columnNoNulls,
+                           columnNoNulls, columnNoNulls, columnNoNulls, columnNoNulls]
+    expected_is_read_only: [true, true, true, true, true, true, true, true, true,
+                            true, true, true, true, true, true, true, true, true]
+    expected_is_searchable: [true, true, true, true, true, true, true, true, true,
+                             true, true, true, true, true, true, true, true, true]
+    expected_is_signed: [false, true, true, false, false, false, true, false, true,
+                         false, false, false, false, true, true, true, true, true]
+    expected_is_writable: [false, false, false, false, false, false, false, false,
+                           false, false, false, false, false, false, false, false, false, false]

--- a/src/main/java/com/mongodb/jdbc/MongoSQLDatabaseMetaData.java
+++ b/src/main/java/com/mongodb/jdbc/MongoSQLDatabaseMetaData.java
@@ -1148,7 +1148,7 @@ public class MongoSQLDatabaseMetaData extends MongoDatabaseMetaData implements D
         docs.add(
                 createBottomBson(
                         new BsonElement(TYPE_NAME, new BsonString(BSON_BOOL.getBsonName())),
-                        new BsonElement(DATA_TYPE, new BsonInt32(Types.BIT)),
+                        new BsonElement(DATA_TYPE, new BsonInt32(BSON_BOOL.getJdbcType())),
                         new BsonElement(PRECISION, asBsonIntOrNull(BSON_BOOL.getPrecision())),
                         new BsonElement(LITERAL_PREFIX, BsonNull.VALUE),
                         new BsonElement(LITERAL_SUFFIX, BsonNull.VALUE),
@@ -1503,6 +1503,29 @@ public class MongoSQLDatabaseMetaData extends MongoDatabaseMetaData implements D
                         new BsonElement(SQL_DATETIME_SUB, BSON_ZERO_INT_VALUE),
                         new BsonElement(
                                 NUM_PREC_RADIX, new BsonInt32(BSON_MINKEY.getNumPrecRadix()))));
+
+        docs.add(
+                createBottomBson(
+                        new BsonElement(TYPE_NAME, new BsonString(BSON_NULL.getBsonName())),
+                        new BsonElement(DATA_TYPE, new BsonInt32(BSON_NULL.getJdbcType())),
+                        new BsonElement(PRECISION, asBsonIntOrNull(BSON_NULL.getPrecision())),
+                        new BsonElement(LITERAL_PREFIX, BsonNull.VALUE),
+                        new BsonElement(LITERAL_SUFFIX, BsonNull.VALUE),
+                        new BsonElement(CREATE_PARAMS, BsonNull.VALUE),
+                        new BsonElement(NULLABLE, BSON_COLUMN_NULLABLE_INT_VALUE),
+                        new BsonElement(
+                                CASE_SENSITIVE, new BsonBoolean(BSON_NULL.getCaseSensitivity())),
+                        new BsonElement(SEARCHABLE, BSON_TYPE_SEARCHABLE_INT_VALUE),
+                        new BsonElement(UNSIGNED_ATTRIBUTE, BsonBoolean.FALSE),
+                        new BsonElement(FIXED_PREC_SCALE, BsonBoolean.FALSE),
+                        new BsonElement(AUTO_INCREMENT, BsonBoolean.FALSE),
+                        new BsonElement(LOCAL_TYPE_NAME, BsonNull.VALUE),
+                        new BsonElement(MINIMUM_SCALE, new BsonInt32(BSON_NULL.getMinScale())),
+                        new BsonElement(MAXIMUM_SCALE, new BsonInt32(BSON_NULL.getMaxScale())),
+                        new BsonElement(SQL_DATA_TYPE, BSON_ZERO_INT_VALUE),
+                        new BsonElement(SQL_DATETIME_SUB, BSON_ZERO_INT_VALUE),
+                        new BsonElement(
+                                NUM_PREC_RADIX, new BsonInt32(BSON_NULL.getNumPrecRadix()))));
 
         docs.add(
                 createBottomBson(


### PR DESCRIPTION
I modified the getTypeInfo() method in MongoSQLDatabaseMetaData.java so that the type info for type null can now be returned. 