### PR TITLE
SQL-707: Update getTypeInfo() result set to be ordered according to the specification

### DIFF
--- a/resources/integration_test/tests/dbmd_constant_result_sets.yml
+++ b/resources/integration_test/tests/dbmd_constant_result_sets.yml
@@ -32,94 +32,94 @@ tests:
     db: integration_test
     meta_function: [ getTypeInfo ]
     expected_sql_type: [ LONGVARCHAR, INTEGER, INTEGER, LONGVARCHAR, LONGVARCHAR, LONGVARCHAR,
-                         INTEGER, BOOLEAN, INTEGER, BOOLEAN, BOOLEAN, BOOLEAN, LONGVARCHAR, INTEGER, INTEGER, INTEGER,
-                         INTEGER, INTEGER ]
+                          INTEGER, BOOLEAN, INTEGER, BOOLEAN, BOOLEAN, BOOLEAN, LONGVARCHAR, INTEGER,
+                          INTEGER, INTEGER, INTEGER, INTEGER ]
     expected_bson_type: [ string, int, int, string, string, string, int, bool, int,
-                          bool, bool, bool, string, int, int, int, int, int ]
+                            bool, bool, bool, string, int, int, int, int, int ]
     expected_catalog_name: [ '', '', '', '', '', '', '', '', '', '', '', '', '', '',
-                             '', '', '', '' ]
+                               '', '', '', '' ]
     expected_column_class_name: [ java.lang.String, int, int, java.lang.String, java.lang.String,
-                                  java.lang.String, int, boolean, int, boolean, boolean, boolean, java.lang.String,
-                                  int, int, int, int, int ]
+                                    java.lang.String, int, boolean, int, boolean, boolean, boolean, java.lang.String,
+                                    int, int, int, int, int ]
     expected_column_label: [ TYPE_NAME, DATA_TYPE, PRECISION, LITERAL_PREFIX, LITERAL_SUFFIX,
-                             CREATE_PARAMS, NULLABLE, CASE_SENSITIVE, SEARCHABLE, UNSIGNED_ATTRIBUTE, FIX_PREC_SCALE,
-                             AUTO_INCREMENT, LOCAL_TYPE_NAME, MINIMUM_SCALE, MAXIMUM_SCALE, SQL_DATA_TYPE,
-                             SQL_DATETIME_SUB, NUM_PREC_RADIX ]
+                               CREATE_PARAMS, NULLABLE, CASE_SENSITIVE, SEARCHABLE, UNSIGNED_ATTRIBUTE, FIX_PREC_SCALE,
+                               AUTO_INCREMENT, LOCAL_TYPE_NAME, MINIMUM_SCALE, MAXIMUM_SCALE, SQL_DATA_TYPE,
+                               SQL_DATETIME_SUB, NUM_PREC_RADIX ]
     expected_column_display_size: [ 0, 10, 10, 0, 0, 0, 10, 1, 10, 1, 1, 1, 0, 10,
-                                    10, 10, 10, 10 ]
+                                      10, 10, 10, 10 ]
     expected_precision: [ 0, 10, 10, 0, 0, 0, 10, 1, 10, 1, 1, 1, 0, 10, 10, 10, 10,
-                          10 ]
+                            10 ]
     expected_scale: [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ]
     expected_schema_name: [ '', '', '', '', '', '', '', '', '', '', '', '', '', '',
-                            '', '', '', '' ]
+                              '', '', '', '' ]
     expected_is_auto_increment: [ false, false, false, false, false, false, false,
-                                  false, false, false, false, false, false, false, false, false, false, false ]
+                                    false, false, false, false, false, false, false, false, false, false, false ]
     expected_is_case_sensitive: [ true, false, false, true, true, true, false, false,
-                                  false, false, false, false, true, false, false, false, false, false ]
+                                    false, false, false, false, true, false, false, false, false, false ]
     expected_is_currency: [ false, false, false, false, false, false, false, false,
-                            false, false, false, false, false, false, false, false, false, false ]
+                              false, false, false, false, false, false, false, false, false, false ]
     expected_is_definitely_writable: [ false, false, false, false, false, false, false,
-                                       false, false, false, false, false, false, false, false, false, false, false ]
+                                         false, false, false, false, false, false, false, false, false, false, false ]
     expected_is_nullable: [ columnNoNulls, columnNoNulls, columnNoNulls, columnNullable,
-                            columnNullable, columnNullable, columnNoNulls, columnNoNulls, columnNoNulls, columnNoNulls,
-                            columnNoNulls, columnNoNulls, columnNullable, columnNoNulls, columnNoNulls, columnNoNulls,
-                            columnNoNulls, columnNoNulls ]
+                              columnNullable, columnNullable, columnNoNulls, columnNoNulls, columnNoNulls,
+                              columnNoNulls, columnNoNulls, columnNoNulls, columnNullable, columnNoNulls,
+                              columnNoNulls, columnNoNulls, columnNoNulls, columnNoNulls ]
     expected_is_read_only: [ true, true, true, true, true, true, true, true, true,
-                             true, true, true, true, true, true, true, true, true ]
+                               true, true, true, true, true, true, true, true, true ]
     expected_is_searchable: [ true, true, true, true, true, true, true, true, true,
-                              true, true, true, true, true, true, true, true, true ]
+                                true, true, true, true, true, true, true, true, true ]
     expected_is_signed: [ false, true, true, false, false, false, true, false, true,
-                          false, false, false, false, true, true, true, true, true ]
+                            false, false, false, false, true, true, true, true, true ]
     expected_is_writable: [ false, false, false, false, false, false, false, false,
-                            false, false, false, false, false, false, false, false, false, false ]
+                              false, false, false, false, false, false, false, false, false, false ]
 
   - description: getTypeInfo_returns_constant_result_set
     db: integration_test
-    meta_function: [getTypeInfo]
+    meta_function: [ getTypeInfo ]
     expected_result:
-      - [binData, -2, null, null, null, null, 1, false, 0, false, null, false, null,
-         0, 0, 0, 0, 0]
-      - [bool, 16, 1, null, null, null, 1, false, 3, false, null, false, null, 0,
-         0, 0, 0, 0]
-      - [date, 93, 24, '''', '''', null, 1, false, 3, false, null, false, null, 0,
-         3, 0, 0, 0]
-      - [decimal, 3, 34, null, null, null, 1, false, 3, false, null, false, null,
-         34, 34, 0, 0, 10]
-      - [double, 8, 15, null, null, null, 1, false, 3, false, null, false, null, 15,
-         15, 0, 0, 2]
-      - [int, 4, 10, null, null, null, 1, false, 3, false, null, false, null, 0, 0,
-         0, 0, 2]
-      - [long, -5, 19, null, null, null, 1, false, 3, false, null, false, null, 0,
-         0, 0, 0, 2]
-      - [string, -1, null, '''', '''', null, 1, true, 3, false, null, false, null,
-         0, 0, 0, 0, 0]
-      - [array, 1111, null, null, null, null, 1, false, 3, false, null, false, null,
-         0, 0, 0, 0, 0]
-      - [object, 1111, null, null, null, null, 1, false, 3, false, null, false, null,
-         0, 0, 0, 0, 0]
-      - [objectId, 1111, 24, null, null, null, 1, false, 3, false, null, false, null,
-         0, 0, 0, 0, 0]
-      - [dbPointer, 1111, null, null, null, null, 1, false, 3, false, null, false,
-         null, 0, 0, 0, 0, 0]
-      - [javascript, 1111, null, null, null, null, 1, true, 3, false, null, false,
-         null, 0, 0, 0, 0, 0]
-      - [javascriptWithScope, 1111, null, null, null, null, 1, true, 3, false, null,
-         false, null, 0, 0, 0, 0, 0]
-      - [maxKey, 1111, null, null, null, null, 1, false, 3, false, null, false, null,
-         0, 0, 0, 0, 0]
-      - [minKey, 1111, null, null, null, null, 1, false, 3, false, null, false, null,
-         0, 0, 0, 0, 0]
-      - ['null', 0, null, null, null, null, 1, false, 3, false, null, false, null,
-         0, 0, 0, 0, 0]
-      - [regex, 1111, null, null, null, null, 1, true, 3, false, null, false, null,
-         0, 0, 0, 0, 0]
-      - [symbol, 1111, null, null, null, null, 1, true, 3, false, null, false, null,
-         0, 0, 0, 0, 0]
-      - [timestamp, 1111, null, null, null, null, 1, false, 3, false, null, false,
-         null, 0, 0, 0, 0, 0]
-      - [undefined, 1111, null, null, null, null, 1, false, 3, false, null, false,
-         null, 0, 0, 0, 0, 0]
-      - [bson, 1111, null, null, null, null, 1, false, 3, false, null, false, null,
-         0, 0, 0, 0, 0]
+      - [ long, -5, 19, null, null, null, 1, false, 3, false, null, false, null, 0,
+            0, 0, 0, 2 ]
+      - [ binData, -2, null, null, null, null, 1, false, 0, false, null, false, null,
+            0, 0, 0, 0, 0 ]
+      - [ string, -1, null, '''', '''', null, 1, true, 3, false, null, false, null,
+            0, 0, 0, 0, 0 ]
+      - [ 'null', 0, null, null, null, null, 1, false, 3, false, null, false, null,
+              0, 0, 0, 0, 0 ]
+      - [ decimal, 3, 34, null, null, null, 1, false, 3, false, null, false, null,
+              34, 34, 0, 0, 10 ]
+      - [ int, 4, 10, null, null, null, 1, false, 3, false, null, false, null, 0, 0,
+              0, 0, 2 ]
+      - [ double, 8, 15, null, null, null, 1, false, 3, false, null, false, null, 15,
+              15, 0, 0, 2 ]
+      - [ bool, 16, 1, null, null, null, 1, false, 3, false, null, false, null, 0,
+              0, 0, 0, 0 ]
+      - [ date, 93, 24, '''', '''', null, 1, false, 3, false, null, false, null, 0,
+              3, 0, 0, 0 ]
+      - [ array, 1111, null, null, null, null, 1, false, 3, false, null, false, null,
+              0, 0, 0, 0, 0 ]
+      - [ bson, 1111, null, null, null, null, 1, false, 3, false, null, false, null,
+              0, 0, 0, 0, 0 ]
+      - [ dbPointer, 1111, null, null, null, null, 1, false, 3, false, null, false,
+              null, 0, 0, 0, 0, 0 ]
+      - [ javascript, 1111, null, null, null, null, 1, true, 3, false, null, false,
+              null, 0, 0, 0, 0, 0 ]
+      - [ javascriptWithScope, 1111, null, null, null, null, 1, true, 3, false, null,
+              false, null, 0, 0, 0, 0, 0 ]
+      - [ maxKey, 1111, null, null, null, null, 1, false, 3, false, null, false, null,
+              0, 0, 0, 0, 0 ]
+      - [ minKey, 1111, null, null, null, null, 1, false, 3, false, null, false, null,
+              0, 0, 0, 0, 0 ]
+      - [ object, 1111, null, null, null, null, 1, false, 3, false, null, false, null,
+              0, 0, 0, 0, 0 ]
+      - [ objectId, 1111, 24, null, null, null, 1, false, 3, false, null, false, null,
+              0, 0, 0, 0, 0 ]
+      - [ regex, 1111, null, null, null, null, 1, true, 3, false, null, false, null,
+              0, 0, 0, 0, 0 ]
+      - [ symbol, 1111, null, null, null, null, 1, true, 3, false, null, false, null,
+              0, 0, 0, 0, 0 ]
+      - [ timestamp, 1111, null, null, null, null, 1, false, 3, false, null, false,
+              null, 0, 0, 0, 0, 0 ]
+      - [ undefined, 1111, null, null, null, null, 1, false, 3, false, null, false,
+              null, 0, 0, 0, 0, 0 ]
     row_count: 22
     ordered: true

--- a/src/main/java/com/mongodb/jdbc/MongoSQLDatabaseMetaData.java
+++ b/src/main/java/com/mongodb/jdbc/MongoSQLDatabaseMetaData.java
@@ -1550,7 +1550,6 @@ public class MongoSQLDatabaseMetaData extends MongoDatabaseMetaData implements D
                         new BsonElement(
                                 NUM_PREC_RADIX, new BsonInt32(BSON_OBJECTID.getNumPrecRadix()))));
 
-
         docs.add(
                 createBottomBson(
                         new BsonElement(TYPE_NAME, new BsonString(BSON_REGEX.getBsonName())),

--- a/src/main/java/com/mongodb/jdbc/MongoSQLDatabaseMetaData.java
+++ b/src/main/java/com/mongodb/jdbc/MongoSQLDatabaseMetaData.java
@@ -1124,6 +1124,29 @@ public class MongoSQLDatabaseMetaData extends MongoDatabaseMetaData implements D
 
         docs.add(
                 createBottomBson(
+                        new BsonElement(TYPE_NAME, new BsonString(BSON_LONG.getBsonName())),
+                        new BsonElement(DATA_TYPE, new BsonInt32(Types.BIGINT)),
+                        new BsonElement(PRECISION, asBsonIntOrNull(BSON_LONG.getPrecision())),
+                        new BsonElement(LITERAL_PREFIX, BsonNull.VALUE),
+                        new BsonElement(LITERAL_SUFFIX, BsonNull.VALUE),
+                        new BsonElement(CREATE_PARAMS, BsonNull.VALUE),
+                        new BsonElement(NULLABLE, BSON_COLUMN_NULLABLE_INT_VALUE),
+                        new BsonElement(
+                                CASE_SENSITIVE, new BsonBoolean(BSON_LONG.getCaseSensitivity())),
+                        new BsonElement(SEARCHABLE, BSON_TYPE_SEARCHABLE_INT_VALUE),
+                        new BsonElement(UNSIGNED_ATTRIBUTE, BsonBoolean.FALSE),
+                        new BsonElement(FIXED_PREC_SCALE, BsonBoolean.FALSE),
+                        new BsonElement(AUTO_INCREMENT, BsonBoolean.FALSE),
+                        new BsonElement(LOCAL_TYPE_NAME, BsonNull.VALUE),
+                        new BsonElement(MINIMUM_SCALE, new BsonInt32(BSON_LONG.getMinScale())),
+                        new BsonElement(MAXIMUM_SCALE, new BsonInt32(BSON_LONG.getMaxScale())),
+                        new BsonElement(SQL_DATA_TYPE, BSON_ZERO_INT_VALUE),
+                        new BsonElement(SQL_DATETIME_SUB, BSON_ZERO_INT_VALUE),
+                        new BsonElement(
+                                NUM_PREC_RADIX, new BsonInt32(BSON_LONG.getNumPrecRadix()))));
+
+        docs.add(
+                createBottomBson(
                         new BsonElement(TYPE_NAME, new BsonString(BSON_BINDATA.getBsonName())),
                         new BsonElement(DATA_TYPE, new BsonInt32(Types.BINARY)),
                         new BsonElement(PRECISION, asBsonIntOrNull(BSON_BINDATA.getPrecision())),
@@ -1144,6 +1167,121 @@ public class MongoSQLDatabaseMetaData extends MongoDatabaseMetaData implements D
                         new BsonElement(SQL_DATETIME_SUB, BSON_ZERO_INT_VALUE),
                         new BsonElement(
                                 NUM_PREC_RADIX, new BsonInt32(BSON_BINDATA.getNumPrecRadix()))));
+
+        docs.add(
+                createBottomBson(
+                        new BsonElement(TYPE_NAME, new BsonString(BSON_STRING.getBsonName())),
+                        new BsonElement(DATA_TYPE, new BsonInt32(Types.LONGVARCHAR)),
+                        new BsonElement(PRECISION, asBsonIntOrNull(BSON_STRING.getPrecision())),
+                        new BsonElement(LITERAL_PREFIX, new BsonString("'")),
+                        new BsonElement(LITERAL_SUFFIX, new BsonString("'")),
+                        new BsonElement(CREATE_PARAMS, BsonNull.VALUE),
+                        new BsonElement(NULLABLE, BSON_COLUMN_NULLABLE_INT_VALUE),
+                        new BsonElement(
+                                CASE_SENSITIVE, new BsonBoolean(BSON_STRING.getCaseSensitivity())),
+                        new BsonElement(SEARCHABLE, BSON_TYPE_SEARCHABLE_INT_VALUE),
+                        new BsonElement(UNSIGNED_ATTRIBUTE, BsonBoolean.FALSE),
+                        new BsonElement(FIXED_PREC_SCALE, BsonBoolean.FALSE),
+                        new BsonElement(AUTO_INCREMENT, BsonBoolean.FALSE),
+                        new BsonElement(LOCAL_TYPE_NAME, BsonNull.VALUE),
+                        new BsonElement(MINIMUM_SCALE, new BsonInt32(BSON_STRING.getMinScale())),
+                        new BsonElement(MAXIMUM_SCALE, new BsonInt32(BSON_STRING.getMaxScale())),
+                        new BsonElement(SQL_DATA_TYPE, BSON_ZERO_INT_VALUE),
+                        new BsonElement(SQL_DATETIME_SUB, BSON_ZERO_INT_VALUE),
+                        new BsonElement(
+                                NUM_PREC_RADIX, new BsonInt32(BSON_STRING.getNumPrecRadix()))));
+
+        docs.add(
+                createBottomBson(
+                        new BsonElement(TYPE_NAME, new BsonString(BSON_NULL.getBsonName())),
+                        new BsonElement(DATA_TYPE, new BsonInt32(BSON_NULL.getJdbcType())),
+                        new BsonElement(PRECISION, asBsonIntOrNull(BSON_NULL.getPrecision())),
+                        new BsonElement(LITERAL_PREFIX, BsonNull.VALUE),
+                        new BsonElement(LITERAL_SUFFIX, BsonNull.VALUE),
+                        new BsonElement(CREATE_PARAMS, BsonNull.VALUE),
+                        new BsonElement(NULLABLE, BSON_COLUMN_NULLABLE_INT_VALUE),
+                        new BsonElement(
+                                CASE_SENSITIVE, new BsonBoolean(BSON_NULL.getCaseSensitivity())),
+                        new BsonElement(SEARCHABLE, BSON_TYPE_SEARCHABLE_INT_VALUE),
+                        new BsonElement(UNSIGNED_ATTRIBUTE, BsonBoolean.FALSE),
+                        new BsonElement(FIXED_PREC_SCALE, BsonBoolean.FALSE),
+                        new BsonElement(AUTO_INCREMENT, BsonBoolean.FALSE),
+                        new BsonElement(LOCAL_TYPE_NAME, BsonNull.VALUE),
+                        new BsonElement(MINIMUM_SCALE, new BsonInt32(BSON_NULL.getMinScale())),
+                        new BsonElement(MAXIMUM_SCALE, new BsonInt32(BSON_NULL.getMaxScale())),
+                        new BsonElement(SQL_DATA_TYPE, BSON_ZERO_INT_VALUE),
+                        new BsonElement(SQL_DATETIME_SUB, BSON_ZERO_INT_VALUE),
+                        new BsonElement(
+                                NUM_PREC_RADIX, new BsonInt32(BSON_NULL.getNumPrecRadix()))));
+
+        docs.add(
+                createBottomBson(
+                        new BsonElement(TYPE_NAME, new BsonString(BSON_DECIMAL.getBsonName())),
+                        new BsonElement(DATA_TYPE, new BsonInt32(Types.DECIMAL)),
+                        new BsonElement(PRECISION, asBsonIntOrNull(BSON_DECIMAL.getPrecision())),
+                        new BsonElement(LITERAL_PREFIX, BsonNull.VALUE),
+                        new BsonElement(LITERAL_SUFFIX, BsonNull.VALUE),
+                        new BsonElement(CREATE_PARAMS, BsonNull.VALUE),
+                        new BsonElement(NULLABLE, BSON_COLUMN_NULLABLE_INT_VALUE),
+                        new BsonElement(
+                                CASE_SENSITIVE, new BsonBoolean(BSON_DECIMAL.getCaseSensitivity())),
+                        new BsonElement(SEARCHABLE, BSON_TYPE_SEARCHABLE_INT_VALUE),
+                        new BsonElement(UNSIGNED_ATTRIBUTE, BsonBoolean.FALSE),
+                        new BsonElement(FIXED_PREC_SCALE, BsonBoolean.FALSE),
+                        new BsonElement(AUTO_INCREMENT, BsonBoolean.FALSE),
+                        new BsonElement(LOCAL_TYPE_NAME, BsonNull.VALUE),
+                        new BsonElement(MINIMUM_SCALE, new BsonInt32(BSON_DECIMAL.getMinScale())),
+                        new BsonElement(MAXIMUM_SCALE, new BsonInt32(BSON_DECIMAL.getMaxScale())),
+                        new BsonElement(SQL_DATA_TYPE, BSON_ZERO_INT_VALUE),
+                        new BsonElement(SQL_DATETIME_SUB, BSON_ZERO_INT_VALUE),
+                        new BsonElement(
+                                NUM_PREC_RADIX, new BsonInt32(BSON_DECIMAL.getNumPrecRadix()))));
+
+        docs.add(
+                createBottomBson(
+                        new BsonElement(TYPE_NAME, new BsonString(BSON_INT.getBsonName())),
+                        new BsonElement(DATA_TYPE, new BsonInt32(Types.INTEGER)),
+                        new BsonElement(PRECISION, asBsonIntOrNull(BSON_INT.getPrecision())),
+                        new BsonElement(LITERAL_PREFIX, BsonNull.VALUE),
+                        new BsonElement(LITERAL_SUFFIX, BsonNull.VALUE),
+                        new BsonElement(CREATE_PARAMS, BsonNull.VALUE),
+                        new BsonElement(NULLABLE, BSON_COLUMN_NULLABLE_INT_VALUE),
+                        new BsonElement(
+                                CASE_SENSITIVE, new BsonBoolean(BSON_INT.getCaseSensitivity())),
+                        new BsonElement(SEARCHABLE, BSON_TYPE_SEARCHABLE_INT_VALUE),
+                        new BsonElement(UNSIGNED_ATTRIBUTE, BsonBoolean.FALSE),
+                        new BsonElement(FIXED_PREC_SCALE, BsonBoolean.FALSE),
+                        new BsonElement(AUTO_INCREMENT, BsonBoolean.FALSE),
+                        new BsonElement(LOCAL_TYPE_NAME, BsonNull.VALUE),
+                        new BsonElement(MINIMUM_SCALE, new BsonInt32(BSON_INT.getMinScale())),
+                        new BsonElement(MAXIMUM_SCALE, new BsonInt32(BSON_INT.getMaxScale())),
+                        new BsonElement(SQL_DATA_TYPE, BSON_ZERO_INT_VALUE),
+                        new BsonElement(SQL_DATETIME_SUB, BSON_ZERO_INT_VALUE),
+                        new BsonElement(
+                                NUM_PREC_RADIX, new BsonInt32(BSON_INT.getNumPrecRadix()))));
+
+        docs.add(
+                createBottomBson(
+                        new BsonElement(TYPE_NAME, new BsonString(BSON_DOUBLE.getBsonName())),
+                        new BsonElement(DATA_TYPE, new BsonInt32(Types.DOUBLE)),
+                        new BsonElement(PRECISION, asBsonIntOrNull(BSON_DOUBLE.getPrecision())),
+                        new BsonElement(LITERAL_PREFIX, BsonNull.VALUE),
+                        new BsonElement(LITERAL_SUFFIX, BsonNull.VALUE),
+                        new BsonElement(CREATE_PARAMS, BsonNull.VALUE),
+                        new BsonElement(NULLABLE, BSON_COLUMN_NULLABLE_INT_VALUE),
+                        new BsonElement(
+                                CASE_SENSITIVE, new BsonBoolean(BSON_DOUBLE.getCaseSensitivity())),
+                        new BsonElement(SEARCHABLE, BSON_TYPE_SEARCHABLE_INT_VALUE),
+                        new BsonElement(UNSIGNED_ATTRIBUTE, BsonBoolean.FALSE),
+                        new BsonElement(FIXED_PREC_SCALE, BsonBoolean.FALSE),
+                        new BsonElement(AUTO_INCREMENT, BsonBoolean.FALSE),
+                        new BsonElement(LOCAL_TYPE_NAME, BsonNull.VALUE),
+                        new BsonElement(MINIMUM_SCALE, new BsonInt32(BSON_DOUBLE.getMinScale())),
+                        new BsonElement(MAXIMUM_SCALE, new BsonInt32(BSON_DOUBLE.getMaxScale())),
+                        new BsonElement(SQL_DATA_TYPE, BSON_ZERO_INT_VALUE),
+                        new BsonElement(SQL_DATETIME_SUB, BSON_ZERO_INT_VALUE),
+                        new BsonElement(
+                                NUM_PREC_RADIX, new BsonInt32(BSON_DOUBLE.getNumPrecRadix()))));
 
         docs.add(
                 createBottomBson(
@@ -1193,121 +1331,6 @@ public class MongoSQLDatabaseMetaData extends MongoDatabaseMetaData implements D
 
         docs.add(
                 createBottomBson(
-                        new BsonElement(TYPE_NAME, new BsonString(BSON_DECIMAL.getBsonName())),
-                        new BsonElement(DATA_TYPE, new BsonInt32(Types.DECIMAL)),
-                        new BsonElement(PRECISION, asBsonIntOrNull(BSON_DECIMAL.getPrecision())),
-                        new BsonElement(LITERAL_PREFIX, BsonNull.VALUE),
-                        new BsonElement(LITERAL_SUFFIX, BsonNull.VALUE),
-                        new BsonElement(CREATE_PARAMS, BsonNull.VALUE),
-                        new BsonElement(NULLABLE, BSON_COLUMN_NULLABLE_INT_VALUE),
-                        new BsonElement(
-                                CASE_SENSITIVE, new BsonBoolean(BSON_DECIMAL.getCaseSensitivity())),
-                        new BsonElement(SEARCHABLE, BSON_TYPE_SEARCHABLE_INT_VALUE),
-                        new BsonElement(UNSIGNED_ATTRIBUTE, BsonBoolean.FALSE),
-                        new BsonElement(FIXED_PREC_SCALE, BsonBoolean.FALSE),
-                        new BsonElement(AUTO_INCREMENT, BsonBoolean.FALSE),
-                        new BsonElement(LOCAL_TYPE_NAME, BsonNull.VALUE),
-                        new BsonElement(MINIMUM_SCALE, new BsonInt32(BSON_DECIMAL.getMinScale())),
-                        new BsonElement(MAXIMUM_SCALE, new BsonInt32(BSON_DECIMAL.getMaxScale())),
-                        new BsonElement(SQL_DATA_TYPE, BSON_ZERO_INT_VALUE),
-                        new BsonElement(SQL_DATETIME_SUB, BSON_ZERO_INT_VALUE),
-                        new BsonElement(
-                                NUM_PREC_RADIX, new BsonInt32(BSON_DECIMAL.getNumPrecRadix()))));
-
-        docs.add(
-                createBottomBson(
-                        new BsonElement(TYPE_NAME, new BsonString(BSON_DOUBLE.getBsonName())),
-                        new BsonElement(DATA_TYPE, new BsonInt32(Types.DOUBLE)),
-                        new BsonElement(PRECISION, asBsonIntOrNull(BSON_DOUBLE.getPrecision())),
-                        new BsonElement(LITERAL_PREFIX, BsonNull.VALUE),
-                        new BsonElement(LITERAL_SUFFIX, BsonNull.VALUE),
-                        new BsonElement(CREATE_PARAMS, BsonNull.VALUE),
-                        new BsonElement(NULLABLE, BSON_COLUMN_NULLABLE_INT_VALUE),
-                        new BsonElement(
-                                CASE_SENSITIVE, new BsonBoolean(BSON_DOUBLE.getCaseSensitivity())),
-                        new BsonElement(SEARCHABLE, BSON_TYPE_SEARCHABLE_INT_VALUE),
-                        new BsonElement(UNSIGNED_ATTRIBUTE, BsonBoolean.FALSE),
-                        new BsonElement(FIXED_PREC_SCALE, BsonBoolean.FALSE),
-                        new BsonElement(AUTO_INCREMENT, BsonBoolean.FALSE),
-                        new BsonElement(LOCAL_TYPE_NAME, BsonNull.VALUE),
-                        new BsonElement(MINIMUM_SCALE, new BsonInt32(BSON_DOUBLE.getMinScale())),
-                        new BsonElement(MAXIMUM_SCALE, new BsonInt32(BSON_DOUBLE.getMaxScale())),
-                        new BsonElement(SQL_DATA_TYPE, BSON_ZERO_INT_VALUE),
-                        new BsonElement(SQL_DATETIME_SUB, BSON_ZERO_INT_VALUE),
-                        new BsonElement(
-                                NUM_PREC_RADIX, new BsonInt32(BSON_DOUBLE.getNumPrecRadix()))));
-
-        docs.add(
-                createBottomBson(
-                        new BsonElement(TYPE_NAME, new BsonString(BSON_INT.getBsonName())),
-                        new BsonElement(DATA_TYPE, new BsonInt32(Types.INTEGER)),
-                        new BsonElement(PRECISION, asBsonIntOrNull(BSON_INT.getPrecision())),
-                        new BsonElement(LITERAL_PREFIX, BsonNull.VALUE),
-                        new BsonElement(LITERAL_SUFFIX, BsonNull.VALUE),
-                        new BsonElement(CREATE_PARAMS, BsonNull.VALUE),
-                        new BsonElement(NULLABLE, BSON_COLUMN_NULLABLE_INT_VALUE),
-                        new BsonElement(
-                                CASE_SENSITIVE, new BsonBoolean(BSON_INT.getCaseSensitivity())),
-                        new BsonElement(SEARCHABLE, BSON_TYPE_SEARCHABLE_INT_VALUE),
-                        new BsonElement(UNSIGNED_ATTRIBUTE, BsonBoolean.FALSE),
-                        new BsonElement(FIXED_PREC_SCALE, BsonBoolean.FALSE),
-                        new BsonElement(AUTO_INCREMENT, BsonBoolean.FALSE),
-                        new BsonElement(LOCAL_TYPE_NAME, BsonNull.VALUE),
-                        new BsonElement(MINIMUM_SCALE, new BsonInt32(BSON_INT.getMinScale())),
-                        new BsonElement(MAXIMUM_SCALE, new BsonInt32(BSON_INT.getMaxScale())),
-                        new BsonElement(SQL_DATA_TYPE, BSON_ZERO_INT_VALUE),
-                        new BsonElement(SQL_DATETIME_SUB, BSON_ZERO_INT_VALUE),
-                        new BsonElement(
-                                NUM_PREC_RADIX, new BsonInt32(BSON_INT.getNumPrecRadix()))));
-
-        docs.add(
-                createBottomBson(
-                        new BsonElement(TYPE_NAME, new BsonString(BSON_LONG.getBsonName())),
-                        new BsonElement(DATA_TYPE, new BsonInt32(Types.BIGINT)),
-                        new BsonElement(PRECISION, asBsonIntOrNull(BSON_LONG.getPrecision())),
-                        new BsonElement(LITERAL_PREFIX, BsonNull.VALUE),
-                        new BsonElement(LITERAL_SUFFIX, BsonNull.VALUE),
-                        new BsonElement(CREATE_PARAMS, BsonNull.VALUE),
-                        new BsonElement(NULLABLE, BSON_COLUMN_NULLABLE_INT_VALUE),
-                        new BsonElement(
-                                CASE_SENSITIVE, new BsonBoolean(BSON_LONG.getCaseSensitivity())),
-                        new BsonElement(SEARCHABLE, BSON_TYPE_SEARCHABLE_INT_VALUE),
-                        new BsonElement(UNSIGNED_ATTRIBUTE, BsonBoolean.FALSE),
-                        new BsonElement(FIXED_PREC_SCALE, BsonBoolean.FALSE),
-                        new BsonElement(AUTO_INCREMENT, BsonBoolean.FALSE),
-                        new BsonElement(LOCAL_TYPE_NAME, BsonNull.VALUE),
-                        new BsonElement(MINIMUM_SCALE, new BsonInt32(BSON_LONG.getMinScale())),
-                        new BsonElement(MAXIMUM_SCALE, new BsonInt32(BSON_LONG.getMaxScale())),
-                        new BsonElement(SQL_DATA_TYPE, BSON_ZERO_INT_VALUE),
-                        new BsonElement(SQL_DATETIME_SUB, BSON_ZERO_INT_VALUE),
-                        new BsonElement(
-                                NUM_PREC_RADIX, new BsonInt32(BSON_LONG.getNumPrecRadix()))));
-
-        docs.add(
-                createBottomBson(
-                        new BsonElement(TYPE_NAME, new BsonString(BSON_STRING.getBsonName())),
-                        new BsonElement(DATA_TYPE, new BsonInt32(Types.LONGVARCHAR)),
-                        new BsonElement(PRECISION, asBsonIntOrNull(BSON_STRING.getPrecision())),
-                        new BsonElement(LITERAL_PREFIX, new BsonString("'")),
-                        new BsonElement(LITERAL_SUFFIX, new BsonString("'")),
-                        new BsonElement(CREATE_PARAMS, BsonNull.VALUE),
-                        new BsonElement(NULLABLE, BSON_COLUMN_NULLABLE_INT_VALUE),
-                        new BsonElement(
-                                CASE_SENSITIVE, new BsonBoolean(BSON_STRING.getCaseSensitivity())),
-                        new BsonElement(SEARCHABLE, BSON_TYPE_SEARCHABLE_INT_VALUE),
-                        new BsonElement(UNSIGNED_ATTRIBUTE, BsonBoolean.FALSE),
-                        new BsonElement(FIXED_PREC_SCALE, BsonBoolean.FALSE),
-                        new BsonElement(AUTO_INCREMENT, BsonBoolean.FALSE),
-                        new BsonElement(LOCAL_TYPE_NAME, BsonNull.VALUE),
-                        new BsonElement(MINIMUM_SCALE, new BsonInt32(BSON_STRING.getMinScale())),
-                        new BsonElement(MAXIMUM_SCALE, new BsonInt32(BSON_STRING.getMaxScale())),
-                        new BsonElement(SQL_DATA_TYPE, BSON_ZERO_INT_VALUE),
-                        new BsonElement(SQL_DATETIME_SUB, BSON_ZERO_INT_VALUE),
-                        new BsonElement(
-                                NUM_PREC_RADIX, new BsonInt32(BSON_STRING.getNumPrecRadix()))));
-
-        docs.add(
-                createBottomBson(
                         new BsonElement(TYPE_NAME, new BsonString(BSON_ARRAY.getBsonName())),
                         new BsonElement(DATA_TYPE, BSON_OTHER_INT_VALUE),
                         new BsonElement(PRECISION, asBsonIntOrNull(BSON_ARRAY.getPrecision())),
@@ -1331,50 +1354,26 @@ public class MongoSQLDatabaseMetaData extends MongoDatabaseMetaData implements D
 
         docs.add(
                 createBottomBson(
-                        new BsonElement(TYPE_NAME, new BsonString(BSON_OBJECT.getBsonName())),
+                        new BsonElement(TYPE_NAME, new BsonString(BSON_BSON.getBsonName())),
                         new BsonElement(DATA_TYPE, BSON_OTHER_INT_VALUE),
-                        new BsonElement(PRECISION, asBsonIntOrNull(BSON_OBJECT.getPrecision())),
+                        new BsonElement(PRECISION, asBsonIntOrNull(BSON_BSON.getPrecision())),
                         new BsonElement(LITERAL_PREFIX, BsonNull.VALUE),
                         new BsonElement(LITERAL_SUFFIX, BsonNull.VALUE),
                         new BsonElement(CREATE_PARAMS, BsonNull.VALUE),
                         new BsonElement(NULLABLE, BSON_COLUMN_NULLABLE_INT_VALUE),
                         new BsonElement(
-                                CASE_SENSITIVE, new BsonBoolean(BSON_OBJECT.getCaseSensitivity())),
+                                CASE_SENSITIVE, new BsonBoolean(BSON_BSON.getCaseSensitivity())),
                         new BsonElement(SEARCHABLE, BSON_TYPE_SEARCHABLE_INT_VALUE),
                         new BsonElement(UNSIGNED_ATTRIBUTE, BsonBoolean.FALSE),
                         new BsonElement(FIXED_PREC_SCALE, BsonBoolean.FALSE),
                         new BsonElement(AUTO_INCREMENT, BsonBoolean.FALSE),
                         new BsonElement(LOCAL_TYPE_NAME, BsonNull.VALUE),
-                        new BsonElement(MINIMUM_SCALE, new BsonInt32(BSON_OBJECT.getMinScale())),
-                        new BsonElement(MAXIMUM_SCALE, new BsonInt32(BSON_OBJECT.getMaxScale())),
+                        new BsonElement(MINIMUM_SCALE, new BsonInt32(BSON_BSON.getMinScale())),
+                        new BsonElement(MAXIMUM_SCALE, new BsonInt32(BSON_BSON.getMaxScale())),
                         new BsonElement(SQL_DATA_TYPE, BSON_ZERO_INT_VALUE),
                         new BsonElement(SQL_DATETIME_SUB, BSON_ZERO_INT_VALUE),
                         new BsonElement(
-                                NUM_PREC_RADIX, new BsonInt32(BSON_OBJECT.getNumPrecRadix()))));
-
-        docs.add(
-                createBottomBson(
-                        new BsonElement(TYPE_NAME, new BsonString(BSON_OBJECTID.getBsonName())),
-                        new BsonElement(DATA_TYPE, BSON_OTHER_INT_VALUE),
-                        new BsonElement(PRECISION, asBsonIntOrNull(BSON_OBJECTID.getPrecision())),
-                        new BsonElement(LITERAL_PREFIX, BsonNull.VALUE),
-                        new BsonElement(LITERAL_SUFFIX, BsonNull.VALUE),
-                        new BsonElement(CREATE_PARAMS, BsonNull.VALUE),
-                        new BsonElement(NULLABLE, BSON_COLUMN_NULLABLE_INT_VALUE),
-                        new BsonElement(
-                                CASE_SENSITIVE,
-                                new BsonBoolean(BSON_OBJECTID.getCaseSensitivity())),
-                        new BsonElement(SEARCHABLE, BSON_TYPE_SEARCHABLE_INT_VALUE),
-                        new BsonElement(UNSIGNED_ATTRIBUTE, BsonBoolean.FALSE),
-                        new BsonElement(FIXED_PREC_SCALE, BsonBoolean.FALSE),
-                        new BsonElement(AUTO_INCREMENT, BsonBoolean.FALSE),
-                        new BsonElement(LOCAL_TYPE_NAME, BsonNull.VALUE),
-                        new BsonElement(MINIMUM_SCALE, new BsonInt32(BSON_OBJECTID.getMinScale())),
-                        new BsonElement(MAXIMUM_SCALE, new BsonInt32(BSON_OBJECTID.getMaxScale())),
-                        new BsonElement(SQL_DATA_TYPE, BSON_ZERO_INT_VALUE),
-                        new BsonElement(SQL_DATETIME_SUB, BSON_ZERO_INT_VALUE),
-                        new BsonElement(
-                                NUM_PREC_RADIX, new BsonInt32(BSON_OBJECTID.getNumPrecRadix()))));
+                                NUM_PREC_RADIX, new BsonInt32(BSON_BSON.getNumPrecRadix()))));
 
         docs.add(
                 createBottomBson(
@@ -1506,26 +1505,51 @@ public class MongoSQLDatabaseMetaData extends MongoDatabaseMetaData implements D
 
         docs.add(
                 createBottomBson(
-                        new BsonElement(TYPE_NAME, new BsonString(BSON_NULL.getBsonName())),
-                        new BsonElement(DATA_TYPE, new BsonInt32(BSON_NULL.getJdbcType())),
-                        new BsonElement(PRECISION, asBsonIntOrNull(BSON_NULL.getPrecision())),
+                        new BsonElement(TYPE_NAME, new BsonString(BSON_OBJECT.getBsonName())),
+                        new BsonElement(DATA_TYPE, BSON_OTHER_INT_VALUE),
+                        new BsonElement(PRECISION, asBsonIntOrNull(BSON_OBJECT.getPrecision())),
                         new BsonElement(LITERAL_PREFIX, BsonNull.VALUE),
                         new BsonElement(LITERAL_SUFFIX, BsonNull.VALUE),
                         new BsonElement(CREATE_PARAMS, BsonNull.VALUE),
                         new BsonElement(NULLABLE, BSON_COLUMN_NULLABLE_INT_VALUE),
                         new BsonElement(
-                                CASE_SENSITIVE, new BsonBoolean(BSON_NULL.getCaseSensitivity())),
+                                CASE_SENSITIVE, new BsonBoolean(BSON_OBJECT.getCaseSensitivity())),
                         new BsonElement(SEARCHABLE, BSON_TYPE_SEARCHABLE_INT_VALUE),
                         new BsonElement(UNSIGNED_ATTRIBUTE, BsonBoolean.FALSE),
                         new BsonElement(FIXED_PREC_SCALE, BsonBoolean.FALSE),
                         new BsonElement(AUTO_INCREMENT, BsonBoolean.FALSE),
                         new BsonElement(LOCAL_TYPE_NAME, BsonNull.VALUE),
-                        new BsonElement(MINIMUM_SCALE, new BsonInt32(BSON_NULL.getMinScale())),
-                        new BsonElement(MAXIMUM_SCALE, new BsonInt32(BSON_NULL.getMaxScale())),
+                        new BsonElement(MINIMUM_SCALE, new BsonInt32(BSON_OBJECT.getMinScale())),
+                        new BsonElement(MAXIMUM_SCALE, new BsonInt32(BSON_OBJECT.getMaxScale())),
                         new BsonElement(SQL_DATA_TYPE, BSON_ZERO_INT_VALUE),
                         new BsonElement(SQL_DATETIME_SUB, BSON_ZERO_INT_VALUE),
                         new BsonElement(
-                                NUM_PREC_RADIX, new BsonInt32(BSON_NULL.getNumPrecRadix()))));
+                                NUM_PREC_RADIX, new BsonInt32(BSON_OBJECT.getNumPrecRadix()))));
+
+        docs.add(
+                createBottomBson(
+                        new BsonElement(TYPE_NAME, new BsonString(BSON_OBJECTID.getBsonName())),
+                        new BsonElement(DATA_TYPE, BSON_OTHER_INT_VALUE),
+                        new BsonElement(PRECISION, asBsonIntOrNull(BSON_OBJECTID.getPrecision())),
+                        new BsonElement(LITERAL_PREFIX, BsonNull.VALUE),
+                        new BsonElement(LITERAL_SUFFIX, BsonNull.VALUE),
+                        new BsonElement(CREATE_PARAMS, BsonNull.VALUE),
+                        new BsonElement(NULLABLE, BSON_COLUMN_NULLABLE_INT_VALUE),
+                        new BsonElement(
+                                CASE_SENSITIVE,
+                                new BsonBoolean(BSON_OBJECTID.getCaseSensitivity())),
+                        new BsonElement(SEARCHABLE, BSON_TYPE_SEARCHABLE_INT_VALUE),
+                        new BsonElement(UNSIGNED_ATTRIBUTE, BsonBoolean.FALSE),
+                        new BsonElement(FIXED_PREC_SCALE, BsonBoolean.FALSE),
+                        new BsonElement(AUTO_INCREMENT, BsonBoolean.FALSE),
+                        new BsonElement(LOCAL_TYPE_NAME, BsonNull.VALUE),
+                        new BsonElement(MINIMUM_SCALE, new BsonInt32(BSON_OBJECTID.getMinScale())),
+                        new BsonElement(MAXIMUM_SCALE, new BsonInt32(BSON_OBJECTID.getMaxScale())),
+                        new BsonElement(SQL_DATA_TYPE, BSON_ZERO_INT_VALUE),
+                        new BsonElement(SQL_DATETIME_SUB, BSON_ZERO_INT_VALUE),
+                        new BsonElement(
+                                NUM_PREC_RADIX, new BsonInt32(BSON_OBJECTID.getNumPrecRadix()))));
+
 
         docs.add(
                 createBottomBson(
@@ -1620,29 +1644,6 @@ public class MongoSQLDatabaseMetaData extends MongoDatabaseMetaData implements D
                         new BsonElement(SQL_DATETIME_SUB, BSON_ZERO_INT_VALUE),
                         new BsonElement(
                                 NUM_PREC_RADIX, new BsonInt32(BSON_UNDEFINED.getNumPrecRadix()))));
-
-        docs.add(
-                createBottomBson(
-                        new BsonElement(TYPE_NAME, new BsonString(BSON_BSON.getBsonName())),
-                        new BsonElement(DATA_TYPE, BSON_OTHER_INT_VALUE),
-                        new BsonElement(PRECISION, asBsonIntOrNull(BSON_BSON.getPrecision())),
-                        new BsonElement(LITERAL_PREFIX, BsonNull.VALUE),
-                        new BsonElement(LITERAL_SUFFIX, BsonNull.VALUE),
-                        new BsonElement(CREATE_PARAMS, BsonNull.VALUE),
-                        new BsonElement(NULLABLE, BSON_COLUMN_NULLABLE_INT_VALUE),
-                        new BsonElement(
-                                CASE_SENSITIVE, new BsonBoolean(BSON_BSON.getCaseSensitivity())),
-                        new BsonElement(SEARCHABLE, BSON_TYPE_SEARCHABLE_INT_VALUE),
-                        new BsonElement(UNSIGNED_ATTRIBUTE, BsonBoolean.FALSE),
-                        new BsonElement(FIXED_PREC_SCALE, BsonBoolean.FALSE),
-                        new BsonElement(AUTO_INCREMENT, BsonBoolean.FALSE),
-                        new BsonElement(LOCAL_TYPE_NAME, BsonNull.VALUE),
-                        new BsonElement(MINIMUM_SCALE, new BsonInt32(BSON_BSON.getMinScale())),
-                        new BsonElement(MAXIMUM_SCALE, new BsonInt32(BSON_BSON.getMaxScale())),
-                        new BsonElement(SQL_DATA_TYPE, BSON_ZERO_INT_VALUE),
-                        new BsonElement(SQL_DATETIME_SUB, BSON_ZERO_INT_VALUE),
-                        new BsonElement(
-                                NUM_PREC_RADIX, new BsonInt32(BSON_BSON.getNumPrecRadix()))));
 
         // All fields in this result set are nested under the bottom namespace.
         MongoJsonSchema botSchema = MongoJsonSchema.createEmptyObjectSchema();

--- a/src/main/java/com/mongodb/jdbc/MongoSQLDatabaseMetaData.java
+++ b/src/main/java/com/mongodb/jdbc/MongoSQLDatabaseMetaData.java
@@ -1122,6 +1122,10 @@ public class MongoSQLDatabaseMetaData extends MongoDatabaseMetaData implements D
         ArrayList<BsonDocument> docs = new ArrayList<>();
         MongoJsonSchema schema = getTypeInfoJsonSchema();
 
+        // The following BSON Types are mostly ordered to follow the javadoc (i.e., they are ordered by DATA_TYPE).
+        // However, instead of ordering all the BSON Types with DATA_TYPE == 1111 by how closely they map to the
+        // corresponding JDBC SQL type (as the javadocs say), we order them alphabetically since "closest to JDBC
+        // SQL type" is meaningless in this case (as all 1111 types are inaccurate).
         docs.add(
                 createBottomBson(
                         new BsonElement(TYPE_NAME, new BsonString(BSON_LONG.getBsonName())),


### PR DESCRIPTION
I changed the ordering of the result set to be ordered by DATA_TYPE (from least to greatest) if the DATA_TYPE is not equal to 1111. Additionally, I sorted all the Types with DATA_TYPE == 1111 alphabetically and put them after the types with DATA_TYPE != 1111. 