### PR TITLE
Update SnakeYAML to a version without vulnerabilities reported

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ googleLintVersion = 1.7
 guavaVersion = 28.2-jre
 lang3Version = 3.0
 nexusDomain = http://localhost:8081/nexus
-snakeYamlVersion = 1.29
+snakeYamlVersion = 1.33
 # to disable publication of both SHA-256 and SHA-512 checksums which causes error in maven release
 systemProp.org.gradle.internal.publish.checksums.insecure = true


### PR DESCRIPTION
Updated SnakeYAML to 1.33 to address CVE-2022-25857