### PR TITLE
SQL-645: refactor MongoResultSet to use BsonTypeInfo

### DIFF
--- a/resources/run_adl.sh
+++ b/resources/run_adl.sh
@@ -24,7 +24,7 @@ if [[ -z $ARG ]]; then
   exit 0
 fi
 
-GO_VERSION="go1.17"
+GO_VERSION="go1.18"
 if [ -d "/opt/golang/$GO_VERSION" ]; then
   GOROOT="/opt/golang/$GO_VERSION"
   GOBINDIR="$GOROOT"/bin

--- a/src/main/java/com/mongodb/jdbc/BsonTypeInfo.java
+++ b/src/main/java/com/mongodb/jdbc/BsonTypeInfo.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import org.bson.BsonType;
+import org.bson.BsonValue;
 
 public enum BsonTypeInfo {
     BSON_DOUBLE("double", BsonType.DOUBLE, Types.DOUBLE, false, 15, 15, 2, 15, 15, 8),
@@ -56,16 +57,18 @@ public enum BsonTypeInfo {
     BSON_DECIMAL("decimal", BsonType.DECIMAL128, Types.DECIMAL, false, 34, 34, 10, 34, 34, 16),
     BSON_MINKEY("minKey", BsonType.MIN_KEY, Types.OTHER, false, 0, 0, 0, null, null, null),
     BSON_MAXKEY("maxKey", BsonType.MAX_KEY, Types.OTHER, false, 0, 0, 0, null, null, null),
-    BSON_BSON("bson", BsonType.UNDEFINED, Types.OTHER, false, 0, 0, 0, null, null, null);
+    BSON_BSON("bson", BsonType.UNDEFINED, Types.OTHER, false, 0, 0, 0, null, null, null),
+    BSON_DOCUMENT("document", BsonType.DOCUMENT, Types.OTHER, false, 0, 0, 0, null, null, null);
 
     // BSON_TYPE_NAMES is the set of all valid BSON type names as listed
-    // here: https://docs.mongodb.com/manual/reference/bson-types/#bson-types
+    // here: https://mongodb.github.io/mongo-java-driver/3.12/javadoc/org/bson/BsonType.html
     // Note that BsonTypeInfo contains a BSON_BSON variant which is intentionally
     // omitted from this set. That is because "bson" is our catch-all for a
     // value that has "any" type, but is not an actual specific BSON type.
     private static final Set<String> BSON_TYPE_NAMES =
             new HashSet<>(
                     Arrays.asList(
+                            BSON_DOCUMENT.bsonName,
                             BSON_DOUBLE.bsonName,
                             BSON_STRING.bsonName,
                             BSON_OBJECT.bsonName,
@@ -192,6 +195,65 @@ public enum BsonTypeInfo {
         }
     }
 
+  /**
+   * Converts a bson value to a BsonTypeInfo
+   * @param obj is the Bson value to convert.
+   * @return BsonTypeInfo object corresponding to the Bson type.
+   * @throws SQLException
+   */
+  public static BsonTypeInfo getBsonTypeInfoFromBson(BsonValue obj) throws SQLException {
+        if (obj == null) {
+            throw new SQLException("Missing bson type name. Value is Null");
+        }
+        BsonType type = obj.getBsonType();
+        switch (type) {
+            case DOUBLE:
+                return BSON_DOUBLE;
+            case STRING:
+                return BSON_STRING;
+            case DOCUMENT:
+                return BSON_DOCUMENT;
+            case ARRAY:
+                return BSON_ARRAY;
+            case BINARY:
+                return BSON_BINDATA;
+            case UNDEFINED:
+                return BSON_UNDEFINED;
+            case OBJECT_ID:
+                return BSON_OBJECTID;
+            case BOOLEAN:
+                return BSON_BOOL;
+            case DATE_TIME:
+                return BSON_DATE;
+            case NULL:
+                return BSON_NULL;
+            case REGULAR_EXPRESSION:
+                return BSON_REGEX;
+            case DB_POINTER:
+                return BSON_DBPOINTER;
+            case JAVASCRIPT:
+                return BSON_JAVASCRIPT;
+            case SYMBOL:
+                return BSON_SYMBOL;
+            case JAVASCRIPT_WITH_SCOPE:
+                return BSON_JAVASCRIPTWITHSCOPE;
+            case INT32:
+                return BSON_INT;
+            case TIMESTAMP:
+                return BSON_TIMESTAMP;
+            case INT64:
+                return BSON_LONG;
+            case DECIMAL128:
+                return BSON_DECIMAL;
+            case MIN_KEY:
+                return BSON_MINKEY;
+            case MAX_KEY:
+                return BSON_MAXKEY;
+            default:
+                throw new SQLException("Unknown bson type name: \"" + type.name() + "\"");
+        }
+    }
+
     /**
      * Converts a bson type name to a BsonTypeInfo
      *
@@ -228,6 +290,8 @@ public enum BsonTypeInfo {
                         return BSON_DOUBLE;
                     case 7:
                         return BSON_DECIMAL;
+                    case 8:
+                        return BSON_DOCUMENT;
                     case 9:
                         return BSON_DBPOINTER;
                 }

--- a/src/main/java/com/mongodb/jdbc/BsonTypeInfo.java
+++ b/src/main/java/com/mongodb/jdbc/BsonTypeInfo.java
@@ -202,7 +202,7 @@ public enum BsonTypeInfo {
      * @return BsonTypeInfo object corresponding to the Bson type.
      * @throws SQLException
      */
-    public static BsonTypeInfo getBsonTypeInfoFromBson(BsonValue obj) throws SQLException {
+    public static BsonTypeInfo getBsonTypeInfoFromBsonValue(BsonValue obj) throws SQLException {
         if (obj == null) {
             throw new SQLException("Missing bson type name. Value is Null");
         }

--- a/src/main/java/com/mongodb/jdbc/BsonTypeInfo.java
+++ b/src/main/java/com/mongodb/jdbc/BsonTypeInfo.java
@@ -195,13 +195,14 @@ public enum BsonTypeInfo {
         }
     }
 
-  /**
-   * Converts a bson value to a BsonTypeInfo
-   * @param obj is the Bson value to convert.
-   * @return BsonTypeInfo object corresponding to the Bson type.
-   * @throws SQLException
-   */
-  public static BsonTypeInfo getBsonTypeInfoFromBson(BsonValue obj) throws SQLException {
+    /**
+     * Converts a bson value to a BsonTypeInfo
+     *
+     * @param obj is the Bson value to convert.
+     * @return BsonTypeInfo object corresponding to the Bson type.
+     * @throws SQLException
+     */
+    public static BsonTypeInfo getBsonTypeInfoFromBson(BsonValue obj) throws SQLException {
         if (obj == null) {
             throw new SQLException("Missing bson type name. Value is Null");
         }

--- a/src/main/java/com/mongodb/jdbc/BsonTypeInfo.java
+++ b/src/main/java/com/mongodb/jdbc/BsonTypeInfo.java
@@ -57,8 +57,7 @@ public enum BsonTypeInfo {
     BSON_DECIMAL("decimal", BsonType.DECIMAL128, Types.DECIMAL, false, 34, 34, 10, 34, 34, 16),
     BSON_MINKEY("minKey", BsonType.MIN_KEY, Types.OTHER, false, 0, 0, 0, null, null, null),
     BSON_MAXKEY("maxKey", BsonType.MAX_KEY, Types.OTHER, false, 0, 0, 0, null, null, null),
-    BSON_BSON("bson", BsonType.UNDEFINED, Types.OTHER, false, 0, 0, 0, null, null, null),
-    BSON_DOCUMENT("document", BsonType.DOCUMENT, Types.OTHER, false, 0, 0, 0, null, null, null);
+    BSON_BSON("bson", BsonType.UNDEFINED, Types.OTHER, false, 0, 0, 0, null, null, null);
 
     // BSON_TYPE_NAMES is the set of all valid BSON type names as listed
     // here: https://mongodb.github.io/mongo-java-driver/3.12/javadoc/org/bson/BsonType.html
@@ -68,7 +67,6 @@ public enum BsonTypeInfo {
     private static final Set<String> BSON_TYPE_NAMES =
             new HashSet<>(
                     Arrays.asList(
-                            BSON_DOCUMENT.bsonName,
                             BSON_DOUBLE.bsonName,
                             BSON_STRING.bsonName,
                             BSON_OBJECT.bsonName,
@@ -213,7 +211,9 @@ public enum BsonTypeInfo {
             case STRING:
                 return BSON_STRING;
             case DOCUMENT:
-                return BSON_DOCUMENT;
+                // BsonDocument and BSON_OBJECT are synonymous. To maintain consistency within ADL,
+                // BsonDocuments will be treated as BSON_OBJECTs
+                return BSON_OBJECT;
             case ARRAY:
                 return BSON_ARRAY;
             case BINARY:
@@ -291,8 +291,6 @@ public enum BsonTypeInfo {
                         return BSON_DOUBLE;
                     case 7:
                         return BSON_DECIMAL;
-                    case 8:
-                        return BSON_DOCUMENT;
                     case 9:
                         return BSON_DBPOINTER;
                 }

--- a/src/main/java/com/mongodb/jdbc/MongoResultSet.java
+++ b/src/main/java/com/mongodb/jdbc/MongoResultSet.java
@@ -229,7 +229,7 @@ public class MongoResultSet implements ResultSet {
             wasNull = true;
             return true;
         }
-        switch (BsonTypeInfo.getBsonTypeInfoFromBson(obj).getBsonType()) {
+        switch (BsonTypeInfo.getBsonTypeInfoFromBsonValue(obj).getBsonType()) {
             case NULL:
             case UNDEFINED:
                 wasNull = true;
@@ -256,7 +256,7 @@ public class MongoResultSet implements ResultSet {
         // we only allow getting Strings and Binaries as Bytes so that
         // we can conveniently ignore Endianess issues. Null and undefined
         // are still supported because Bytes's can be null.
-        BsonTypeInfo bsonType = BsonTypeInfo.getBsonTypeInfoFromBson(o);
+        BsonTypeInfo bsonType = BsonTypeInfo.getBsonTypeInfoFromBsonValue(o);
         switch (bsonType.getBsonType()) {
             case BINARY:
                 return o.asBinary().getData();
@@ -372,7 +372,7 @@ public class MongoResultSet implements ResultSet {
         if (checkNull(o)) {
             return false;
         }
-        BsonTypeInfo bsonType = BsonTypeInfo.getBsonTypeInfoFromBson(o);
+        BsonTypeInfo bsonType = BsonTypeInfo.getBsonTypeInfoFromBsonValue(o);
         switch (bsonType.getBsonType()) {
             case BOOLEAN:
                 return o.asBoolean().getValue();
@@ -389,16 +389,13 @@ public class MongoResultSet implements ResultSet {
             case INT64:
                 return o.asInt64().getValue() != 0;
             case NULL:
+            case UNDEFINED:
                 // this is consistent with $convert in mongodb insofar as getBoolean
                 // returns false for null values.
                 return false;
             case STRING:
                 // mongodb $convert converts all strings to true, even the empty string.
                 return true;
-            case UNDEFINED:
-                // this is consistent with $convert in mongodb insofar as getBoolean
-                // returns false for null values.
-                return false;
             default:
                 return handleBooleanConversionFailure(bsonType.getBsonName());
         }
@@ -479,7 +476,7 @@ public class MongoResultSet implements ResultSet {
         if (checkNull(o)) {
             return 0L;
         }
-        BsonTypeInfo bsonType = BsonTypeInfo.getBsonTypeInfoFromBson(o);
+        BsonTypeInfo bsonType = BsonTypeInfo.getBsonTypeInfoFromBsonValue(o);
         switch (o.getBsonType()) {
             case BOOLEAN:
                 return o.asBoolean().getValue() ? 1 : 0;
@@ -547,7 +544,7 @@ public class MongoResultSet implements ResultSet {
         if (checkNull(o)) {
             return 0.0;
         }
-        BsonTypeInfo bsonType = BsonTypeInfo.getBsonTypeInfoFromBson(o);
+        BsonTypeInfo bsonType = BsonTypeInfo.getBsonTypeInfoFromBsonValue(o);
         switch (o.getBsonType()) {
             case BOOLEAN:
                 return o.asBoolean().getValue() ? 1.0 : 0.0;
@@ -562,14 +559,13 @@ public class MongoResultSet implements ResultSet {
                 return o.asInt32().getValue();
             case INT64:
                 return (double) o.asInt64().getValue();
-            case NULL:
-                return 0.0;
             case STRING:
                 try {
                     return Double.parseDouble(o.asString().getValue());
                 } catch (NumberFormatException e) {
                     throw new SQLException(e);
                 }
+            case NULL:
             case UNDEFINED:
                 // this is consistent with $convert in mongodb insofar as getDouble
                 // returns 0.0 for null values.
@@ -778,7 +774,7 @@ public class MongoResultSet implements ResultSet {
         if (checkNull(o)) {
             return BigDecimal.ZERO;
         }
-        BsonTypeInfo bsonType = BsonTypeInfo.getBsonTypeInfoFromBson(o);
+        BsonTypeInfo bsonType = BsonTypeInfo.getBsonTypeInfoFromBsonValue(o);
         switch (o.getBsonType()) {
             case BOOLEAN:
                 return o.asBoolean().getValue() ? BigDecimal.ONE : BigDecimal.ZERO;
@@ -1306,7 +1302,7 @@ public class MongoResultSet implements ResultSet {
         if (checkNull(o)) {
             return null;
         }
-        BsonTypeInfo bsonType = BsonTypeInfo.getBsonTypeInfoFromBson(o);
+        BsonTypeInfo bsonType = BsonTypeInfo.getBsonTypeInfoFromBsonValue(o);
         switch (o.getBsonType()) {
             case DATE_TIME:
                 return new java.util.Date(o.asDateTime().getValue());

--- a/src/main/java/com/mongodb/jdbc/MongoResultSet.java
+++ b/src/main/java/com/mongodb/jdbc/MongoResultSet.java
@@ -1261,7 +1261,10 @@ public class MongoResultSet implements ResultSet {
     }
 
     protected Clob getClob(BsonValue o) throws SQLException {
-        return new SerialClob(Objects.requireNonNull(getString(o)).toCharArray());
+        if (checkNull(o)) {
+            return null;
+        }
+        return new SerialClob(getString(o).toCharArray());
     }
 
     @Override

--- a/src/main/java/com/mongodb/jdbc/MongoResultSet.java
+++ b/src/main/java/com/mongodb/jdbc/MongoResultSet.java
@@ -377,10 +377,11 @@ public class MongoResultSet implements ResultSet {
             case BOOLEAN:
                 return o.asBoolean().getValue();
             case DECIMAL128:
-            {
-                Decimal128 v = o.asDecimal128().getValue();
-                return !Objects.equals(v, Decimal128.POSITIVE_ZERO) && !Objects.equals(v, Decimal128.NEGATIVE_ZERO);
-            }
+                {
+                    Decimal128 v = o.asDecimal128().getValue();
+                    return !Objects.equals(v, Decimal128.POSITIVE_ZERO)
+                            && !Objects.equals(v, Decimal128.NEGATIVE_ZERO);
+                }
             case DOUBLE:
                 return o.asDouble().getValue() != 0.0;
             case INT32:
@@ -804,8 +805,8 @@ public class MongoResultSet implements ResultSet {
                     throw new SQLException(e);
                 }
             default:
-        return handleBigDecimalConversionFailure(bsonType.getBsonName());
-       }
+                return handleBigDecimalConversionFailure(bsonType.getBsonName());
+        }
     }
 
     @Override

--- a/src/test/java/com/mongodb/jdbc/BsonTypeInfoTest.java
+++ b/src/test/java/com/mongodb/jdbc/BsonTypeInfoTest.java
@@ -20,7 +20,15 @@ import static com.mongodb.jdbc.BsonTypeInfo.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
+import java.time.Instant;
+import java.util.Date;
+
+import org.bson.*;
+import org.bson.types.Decimal128;
+import org.bson.types.ObjectId;
 import org.junit.jupiter.api.Test;
 
 public class BsonTypeInfoTest {
@@ -47,11 +55,36 @@ public class BsonTypeInfoTest {
         assertEquals(BSON_SYMBOL, getBsonTypeInfoByName("symbol"));
         assertEquals(BSON_TIMESTAMP, getBsonTypeInfoByName("timestamp"));
         assertEquals(BSON_UNDEFINED, getBsonTypeInfoByName("undefined"));
+        assertEquals(BSON_DOCUMENT, getBsonTypeInfoByName("document"));
 
         // Test invalid type name
         assertThrows(
                 SQLException.class,
                 () -> getBsonTypeInfoByName("invalid"),
                 "invalid BSON type name expected to throw exception");
+    }
+    @Test
+    void testGetBsonTypeInfoByValue() throws SQLException {
+        assertEquals(BSON_ARRAY, getBsonTypeInfoFromBson(new BsonArray()));
+        assertEquals(BSON_BOOL, getBsonTypeInfoFromBson(new BsonBoolean(true)));
+        assertEquals(BSON_BINDATA, getBsonTypeInfoFromBson(new BsonBinary("a".getBytes(StandardCharsets.UTF_8))));
+        assertEquals(BSON_DATE, getBsonTypeInfoFromBson(new BsonDateTime(1)));
+        assertEquals(BSON_DBPOINTER, getBsonTypeInfoFromBson(new BsonDbPointer("test", new ObjectId())));
+        assertEquals(BSON_DECIMAL, getBsonTypeInfoFromBson(new BsonDecimal128(new Decimal128(1))));
+        assertEquals(BSON_DOUBLE, getBsonTypeInfoFromBson(new BsonDouble(2.2)));
+        assertEquals(BSON_INT, getBsonTypeInfoFromBson(new BsonInt32(1)));
+        assertEquals(BSON_JAVASCRIPT, getBsonTypeInfoFromBson(new BsonJavaScript("")));
+        assertEquals(BSON_JAVASCRIPTWITHSCOPE, getBsonTypeInfoFromBson(new BsonJavaScriptWithScope("", new BsonDocument())));
+        assertEquals(BSON_LONG, getBsonTypeInfoFromBson(new BsonInt64(1)));
+        assertEquals(BSON_MAXKEY, getBsonTypeInfoFromBson(new BsonMaxKey()));
+        assertEquals(BSON_MINKEY, getBsonTypeInfoFromBson(new BsonMinKey()));
+        assertEquals(BSON_NULL, getBsonTypeInfoFromBson(new BsonNull()));
+        assertEquals(BSON_OBJECTID, getBsonTypeInfoFromBson(new BsonObjectId()));
+        assertEquals(BSON_REGEX, getBsonTypeInfoFromBson(new BsonRegularExpression("")));
+        assertEquals(BSON_STRING, getBsonTypeInfoFromBson(new BsonString("")));
+        assertEquals(BSON_SYMBOL, getBsonTypeInfoFromBson(new BsonSymbol("")));
+        assertEquals(BSON_TIMESTAMP, getBsonTypeInfoFromBson(new BsonTimestamp()));
+        assertEquals(BSON_UNDEFINED, getBsonTypeInfoFromBson(new BsonUndefined()));
+        assertEquals(BSON_DOCUMENT, getBsonTypeInfoFromBson(new BsonDocument()));
     }
 }

--- a/src/test/java/com/mongodb/jdbc/BsonTypeInfoTest.java
+++ b/src/test/java/com/mongodb/jdbc/BsonTypeInfoTest.java
@@ -61,32 +61,34 @@ public class BsonTypeInfoTest {
     }
 
     @Test
-    void testGetBsonTypeInfoByValue() throws SQLException {
-        assertEquals(BSON_ARRAY, getBsonTypeInfoFromBson(new BsonArray()));
-        assertEquals(BSON_BOOL, getBsonTypeInfoFromBson(new BsonBoolean(true)));
+    void testGetBsonTypeInfoFromBsonValue() throws SQLException {
+        assertEquals(BSON_ARRAY, getBsonTypeInfoFromBsonValue(new BsonArray()));
+        assertEquals(BSON_BOOL, getBsonTypeInfoFromBsonValue(new BsonBoolean(true)));
         assertEquals(
                 BSON_BINDATA,
-                getBsonTypeInfoFromBson(new BsonBinary("a".getBytes(StandardCharsets.UTF_8))));
-        assertEquals(BSON_DATE, getBsonTypeInfoFromBson(new BsonDateTime(1)));
+                getBsonTypeInfoFromBsonValue(new BsonBinary("a".getBytes(StandardCharsets.UTF_8))));
+        assertEquals(BSON_DATE, getBsonTypeInfoFromBsonValue(new BsonDateTime(1)));
         assertEquals(
-                BSON_DBPOINTER, getBsonTypeInfoFromBson(new BsonDbPointer("test", new ObjectId())));
-        assertEquals(BSON_DECIMAL, getBsonTypeInfoFromBson(new BsonDecimal128(new Decimal128(1))));
-        assertEquals(BSON_DOUBLE, getBsonTypeInfoFromBson(new BsonDouble(2.2)));
-        assertEquals(BSON_INT, getBsonTypeInfoFromBson(new BsonInt32(1)));
-        assertEquals(BSON_JAVASCRIPT, getBsonTypeInfoFromBson(new BsonJavaScript("")));
+                BSON_DBPOINTER,
+                getBsonTypeInfoFromBsonValue(new BsonDbPointer("test", new ObjectId())));
+        assertEquals(
+                BSON_DECIMAL, getBsonTypeInfoFromBsonValue(new BsonDecimal128(new Decimal128(1))));
+        assertEquals(BSON_DOUBLE, getBsonTypeInfoFromBsonValue(new BsonDouble(2.2)));
+        assertEquals(BSON_INT, getBsonTypeInfoFromBsonValue(new BsonInt32(1)));
+        assertEquals(BSON_JAVASCRIPT, getBsonTypeInfoFromBsonValue(new BsonJavaScript("")));
         assertEquals(
                 BSON_JAVASCRIPTWITHSCOPE,
-                getBsonTypeInfoFromBson(new BsonJavaScriptWithScope("", new BsonDocument())));
-        assertEquals(BSON_LONG, getBsonTypeInfoFromBson(new BsonInt64(1)));
-        assertEquals(BSON_MAXKEY, getBsonTypeInfoFromBson(new BsonMaxKey()));
-        assertEquals(BSON_MINKEY, getBsonTypeInfoFromBson(new BsonMinKey()));
-        assertEquals(BSON_NULL, getBsonTypeInfoFromBson(new BsonNull()));
-        assertEquals(BSON_OBJECTID, getBsonTypeInfoFromBson(new BsonObjectId()));
-        assertEquals(BSON_REGEX, getBsonTypeInfoFromBson(new BsonRegularExpression("")));
-        assertEquals(BSON_STRING, getBsonTypeInfoFromBson(new BsonString("")));
-        assertEquals(BSON_SYMBOL, getBsonTypeInfoFromBson(new BsonSymbol("")));
-        assertEquals(BSON_TIMESTAMP, getBsonTypeInfoFromBson(new BsonTimestamp()));
-        assertEquals(BSON_UNDEFINED, getBsonTypeInfoFromBson(new BsonUndefined()));
-        assertEquals(BSON_DOCUMENT, getBsonTypeInfoFromBson(new BsonDocument()));
+                getBsonTypeInfoFromBsonValue(new BsonJavaScriptWithScope("", new BsonDocument())));
+        assertEquals(BSON_LONG, getBsonTypeInfoFromBsonValue(new BsonInt64(1)));
+        assertEquals(BSON_MAXKEY, getBsonTypeInfoFromBsonValue(new BsonMaxKey()));
+        assertEquals(BSON_MINKEY, getBsonTypeInfoFromBsonValue(new BsonMinKey()));
+        assertEquals(BSON_NULL, getBsonTypeInfoFromBsonValue(new BsonNull()));
+        assertEquals(BSON_OBJECTID, getBsonTypeInfoFromBsonValue(new BsonObjectId()));
+        assertEquals(BSON_REGEX, getBsonTypeInfoFromBsonValue(new BsonRegularExpression("")));
+        assertEquals(BSON_STRING, getBsonTypeInfoFromBsonValue(new BsonString("")));
+        assertEquals(BSON_SYMBOL, getBsonTypeInfoFromBsonValue(new BsonSymbol("")));
+        assertEquals(BSON_TIMESTAMP, getBsonTypeInfoFromBsonValue(new BsonTimestamp()));
+        assertEquals(BSON_UNDEFINED, getBsonTypeInfoFromBsonValue(new BsonUndefined()));
+        assertEquals(BSON_DOCUMENT, getBsonTypeInfoFromBsonValue(new BsonDocument()));
     }
 }

--- a/src/test/java/com/mongodb/jdbc/BsonTypeInfoTest.java
+++ b/src/test/java/com/mongodb/jdbc/BsonTypeInfoTest.java
@@ -16,34 +16,6 @@
 
 package com.mongodb.jdbc;
 
-import org.bson.BsonArray;
-import org.bson.BsonBinary;
-import org.bson.BsonBoolean;
-import org.bson.BsonDateTime;
-import org.bson.BsonDbPointer;
-import org.bson.BsonDecimal128;
-import org.bson.BsonDocument;
-import org.bson.BsonDouble;
-import org.bson.BsonInt32;
-import org.bson.BsonInt64;
-import org.bson.BsonJavaScript;
-import org.bson.BsonJavaScriptWithScope;
-import org.bson.BsonMaxKey;
-import org.bson.BsonMinKey;
-import org.bson.BsonNull;
-import org.bson.BsonObjectId;
-import org.bson.BsonRegularExpression;
-import org.bson.BsonString;
-import org.bson.BsonSymbol;
-import org.bson.BsonTimestamp;
-import org.bson.BsonUndefined;
-import org.bson.types.Decimal128;
-import org.bson.types.ObjectId;
-import org.junit.jupiter.api.Test;
-
-import java.nio.charset.StandardCharsets;
-import java.sql.SQLException;
-
 import static com.mongodb.jdbc.BsonTypeInfo.BSON_ARRAY;
 import static com.mongodb.jdbc.BsonTypeInfo.BSON_BINDATA;
 import static com.mongodb.jdbc.BsonTypeInfo.BSON_BOOL;
@@ -69,6 +41,33 @@ import static com.mongodb.jdbc.BsonTypeInfo.getBsonTypeInfoByName;
 import static com.mongodb.jdbc.BsonTypeInfo.getBsonTypeInfoFromBsonValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.charset.StandardCharsets;
+import java.sql.SQLException;
+import org.bson.BsonArray;
+import org.bson.BsonBinary;
+import org.bson.BsonBoolean;
+import org.bson.BsonDateTime;
+import org.bson.BsonDbPointer;
+import org.bson.BsonDecimal128;
+import org.bson.BsonDocument;
+import org.bson.BsonDouble;
+import org.bson.BsonInt32;
+import org.bson.BsonInt64;
+import org.bson.BsonJavaScript;
+import org.bson.BsonJavaScriptWithScope;
+import org.bson.BsonMaxKey;
+import org.bson.BsonMinKey;
+import org.bson.BsonNull;
+import org.bson.BsonObjectId;
+import org.bson.BsonRegularExpression;
+import org.bson.BsonString;
+import org.bson.BsonSymbol;
+import org.bson.BsonTimestamp;
+import org.bson.BsonUndefined;
+import org.bson.types.Decimal128;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.Test;
 
 public class BsonTypeInfoTest {
     @Test

--- a/src/test/java/com/mongodb/jdbc/BsonTypeInfoTest.java
+++ b/src/test/java/com/mongodb/jdbc/BsonTypeInfoTest.java
@@ -20,12 +20,8 @@ import static com.mongodb.jdbc.BsonTypeInfo.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
-import java.time.Instant;
-import java.util.Date;
-
 import org.bson.*;
 import org.bson.types.Decimal128;
 import org.bson.types.ObjectId;
@@ -63,18 +59,24 @@ public class BsonTypeInfoTest {
                 () -> getBsonTypeInfoByName("invalid"),
                 "invalid BSON type name expected to throw exception");
     }
+
     @Test
     void testGetBsonTypeInfoByValue() throws SQLException {
         assertEquals(BSON_ARRAY, getBsonTypeInfoFromBson(new BsonArray()));
         assertEquals(BSON_BOOL, getBsonTypeInfoFromBson(new BsonBoolean(true)));
-        assertEquals(BSON_BINDATA, getBsonTypeInfoFromBson(new BsonBinary("a".getBytes(StandardCharsets.UTF_8))));
+        assertEquals(
+                BSON_BINDATA,
+                getBsonTypeInfoFromBson(new BsonBinary("a".getBytes(StandardCharsets.UTF_8))));
         assertEquals(BSON_DATE, getBsonTypeInfoFromBson(new BsonDateTime(1)));
-        assertEquals(BSON_DBPOINTER, getBsonTypeInfoFromBson(new BsonDbPointer("test", new ObjectId())));
+        assertEquals(
+                BSON_DBPOINTER, getBsonTypeInfoFromBson(new BsonDbPointer("test", new ObjectId())));
         assertEquals(BSON_DECIMAL, getBsonTypeInfoFromBson(new BsonDecimal128(new Decimal128(1))));
         assertEquals(BSON_DOUBLE, getBsonTypeInfoFromBson(new BsonDouble(2.2)));
         assertEquals(BSON_INT, getBsonTypeInfoFromBson(new BsonInt32(1)));
         assertEquals(BSON_JAVASCRIPT, getBsonTypeInfoFromBson(new BsonJavaScript("")));
-        assertEquals(BSON_JAVASCRIPTWITHSCOPE, getBsonTypeInfoFromBson(new BsonJavaScriptWithScope("", new BsonDocument())));
+        assertEquals(
+                BSON_JAVASCRIPTWITHSCOPE,
+                getBsonTypeInfoFromBson(new BsonJavaScriptWithScope("", new BsonDocument())));
         assertEquals(BSON_LONG, getBsonTypeInfoFromBson(new BsonInt64(1)));
         assertEquals(BSON_MAXKEY, getBsonTypeInfoFromBson(new BsonMaxKey()));
         assertEquals(BSON_MINKEY, getBsonTypeInfoFromBson(new BsonMinKey()));

--- a/src/test/java/com/mongodb/jdbc/BsonTypeInfoTest.java
+++ b/src/test/java/com/mongodb/jdbc/BsonTypeInfoTest.java
@@ -16,16 +16,59 @@
 
 package com.mongodb.jdbc;
 
-import static com.mongodb.jdbc.BsonTypeInfo.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
-import java.nio.charset.StandardCharsets;
-import java.sql.SQLException;
-import org.bson.*;
+import org.bson.BsonArray;
+import org.bson.BsonBinary;
+import org.bson.BsonBoolean;
+import org.bson.BsonDateTime;
+import org.bson.BsonDbPointer;
+import org.bson.BsonDecimal128;
+import org.bson.BsonDocument;
+import org.bson.BsonDouble;
+import org.bson.BsonInt32;
+import org.bson.BsonInt64;
+import org.bson.BsonJavaScript;
+import org.bson.BsonJavaScriptWithScope;
+import org.bson.BsonMaxKey;
+import org.bson.BsonMinKey;
+import org.bson.BsonNull;
+import org.bson.BsonObjectId;
+import org.bson.BsonRegularExpression;
+import org.bson.BsonString;
+import org.bson.BsonSymbol;
+import org.bson.BsonTimestamp;
+import org.bson.BsonUndefined;
 import org.bson.types.Decimal128;
 import org.bson.types.ObjectId;
 import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.sql.SQLException;
+
+import static com.mongodb.jdbc.BsonTypeInfo.BSON_ARRAY;
+import static com.mongodb.jdbc.BsonTypeInfo.BSON_BINDATA;
+import static com.mongodb.jdbc.BsonTypeInfo.BSON_BOOL;
+import static com.mongodb.jdbc.BsonTypeInfo.BSON_DATE;
+import static com.mongodb.jdbc.BsonTypeInfo.BSON_DBPOINTER;
+import static com.mongodb.jdbc.BsonTypeInfo.BSON_DECIMAL;
+import static com.mongodb.jdbc.BsonTypeInfo.BSON_DOUBLE;
+import static com.mongodb.jdbc.BsonTypeInfo.BSON_INT;
+import static com.mongodb.jdbc.BsonTypeInfo.BSON_JAVASCRIPT;
+import static com.mongodb.jdbc.BsonTypeInfo.BSON_JAVASCRIPTWITHSCOPE;
+import static com.mongodb.jdbc.BsonTypeInfo.BSON_LONG;
+import static com.mongodb.jdbc.BsonTypeInfo.BSON_MAXKEY;
+import static com.mongodb.jdbc.BsonTypeInfo.BSON_MINKEY;
+import static com.mongodb.jdbc.BsonTypeInfo.BSON_NULL;
+import static com.mongodb.jdbc.BsonTypeInfo.BSON_OBJECT;
+import static com.mongodb.jdbc.BsonTypeInfo.BSON_OBJECTID;
+import static com.mongodb.jdbc.BsonTypeInfo.BSON_REGEX;
+import static com.mongodb.jdbc.BsonTypeInfo.BSON_STRING;
+import static com.mongodb.jdbc.BsonTypeInfo.BSON_SYMBOL;
+import static com.mongodb.jdbc.BsonTypeInfo.BSON_TIMESTAMP;
+import static com.mongodb.jdbc.BsonTypeInfo.BSON_UNDEFINED;
+import static com.mongodb.jdbc.BsonTypeInfo.getBsonTypeInfoByName;
+import static com.mongodb.jdbc.BsonTypeInfo.getBsonTypeInfoFromBsonValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class BsonTypeInfoTest {
     @Test
@@ -51,7 +94,6 @@ public class BsonTypeInfoTest {
         assertEquals(BSON_SYMBOL, getBsonTypeInfoByName("symbol"));
         assertEquals(BSON_TIMESTAMP, getBsonTypeInfoByName("timestamp"));
         assertEquals(BSON_UNDEFINED, getBsonTypeInfoByName("undefined"));
-        assertEquals(BSON_DOCUMENT, getBsonTypeInfoByName("document"));
 
         // Test invalid type name
         assertThrows(
@@ -89,6 +131,6 @@ public class BsonTypeInfoTest {
         assertEquals(BSON_SYMBOL, getBsonTypeInfoFromBsonValue(new BsonSymbol("")));
         assertEquals(BSON_TIMESTAMP, getBsonTypeInfoFromBsonValue(new BsonTimestamp()));
         assertEquals(BSON_UNDEFINED, getBsonTypeInfoFromBsonValue(new BsonUndefined()));
-        assertEquals(BSON_DOCUMENT, getBsonTypeInfoFromBsonValue(new BsonDocument()));
+        assertEquals(BSON_OBJECT, getBsonTypeInfoFromBsonValue(new BsonDocument()));
     }
 }


### PR DESCRIPTION
This refactors `MongoResultSet` to use `BsonTypeInfo` and significantly cleans up the switch statements.

I've also removed the "end_of_document" check from `MongoResultSet` as it wasn't used in any meaningful way other than it couldn't be converted in any of the switches. Since it was a BsonValue that is being passed into the various conversion methods, there's actually no way for it to be an "end_of_document" since it can't be created as a concrete type to derive a `BsonType` from (let alone a `BsonTypeInfo`).

This also updates the go version used in the build task, addressing SQL-1083.