### PR TITLE
SQL-1328: Report authorized Collections for getTables and getColumns

### DIFF
--- a/src/main/java/com/mongodb/jdbc/MongoListTablesResult.java
+++ b/src/main/java/com/mongodb/jdbc/MongoListTablesResult.java
@@ -16,12 +16,21 @@
 
 package com.mongodb.jdbc;
 
+import org.bson.Document;
+
 public class MongoListTablesResult {
     public static final String TABLE = "table";
     public static final String COLLECTION = "collection";
 
     public String name;
     public String type;
+
+    public MongoListTablesResult() {}
+
+    public MongoListTablesResult(Document document) {
+        this.name = document.getString("name");
+        setType(document.getString("type"));
+    }
 
     public void setType(String type) {
         // If mongodb type is COLLECTION, map it as TABLE.


### PR DESCRIPTION
Tested on remote ADF by adding collection actions on specific collections and running `tryGetTables()` in the TestUtils class. 
Code without the change gets `Command failed with error 13 (Unauthorized): 'not authorized,`.  With this change the tables are listed.  I considered adding an integration test to verify this, I didn't find a simple way to set the configuration for ADF but it seems possible.

In testing also found that databases that user is not authorized to use returns as an empty string "", added some code to filter that out.