### PR TITLE
SQL-1534 & SQL-1523: improve error message and upgrade driver

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 group = org.mongodb
 artifactId = adf-java-driver
-mongodbDriverVersion = 4.9.1
+mongodbDriverVersion = 4.10.2
 junitJupiterVersion = 5.5.2
 mockitoVersion = 3.0.0
 googleLintVersion = 1.7

--- a/src/main/java/com/mongodb/jdbc/MongoDriver.java
+++ b/src/main/java/com/mongodb/jdbc/MongoDriver.java
@@ -173,7 +173,7 @@ public class MongoDriver implements Driver {
                 conn.testConnection(conn.getDefaultConnectionValidationTimeoutSeconds());
             } catch (TimeoutException te) {
                 throw new SQLTimeoutException(
-                        "Couldn't connect due to a timeout. Please check your host and port, and if necessary set a "
+                        "Couldn't connect due to a timeout. Please check your hostname and port. If necessary, set a "
                                 + "longer connection timeout in the MongoDB URI.");
             } catch (Exception e) {
                 throw new SQLException("Connection failed.", e);

--- a/src/main/java/com/mongodb/jdbc/MongoDriver.java
+++ b/src/main/java/com/mongodb/jdbc/MongoDriver.java
@@ -174,7 +174,7 @@ public class MongoDriver implements Driver {
             } catch (TimeoutException te) {
                 throw new SQLTimeoutException(
                         "Couldn't connect due to a timeout. Please check your host and port, and if necessary set a "
-                                + "longer connection timeout in the MongoDB URI ");
+                                + "longer connection timeout in the MongoDB URI.");
             } catch (Exception e) {
                 throw new SQLException("Connection failed.", e);
             }

--- a/src/main/java/com/mongodb/jdbc/MongoDriver.java
+++ b/src/main/java/com/mongodb/jdbc/MongoDriver.java
@@ -172,7 +172,9 @@ public class MongoDriver implements Driver {
             try {
                 conn.testConnection(conn.getDefaultConnectionValidationTimeoutSeconds());
             } catch (TimeoutException te) {
-                throw new SQLTimeoutException("Timeout. Can't connect.");
+                throw new SQLTimeoutException(
+                        "Couldn't connect due to a timeout. Please check your host and port, and if necessary set a "
+                                + "longer connection timeout in the MongoDB URI ");
             } catch (Exception e) {
                 throw new SQLException("Connection failed.", e);
             }


### PR DESCRIPTION
This is a quick driveby on two tickets worth doing a patch release for. The release will also enable ADF to run tests again using the JDBC driver, hopefully giving a lot more warning about breaking changes that may impact us.