### PR TITLE
SQL-1707: put result set in select list order

### DIFF
--- a/resources/integration_test/tests/query.yaml
+++ b/resources/integration_test/tests/query.yaml
@@ -69,30 +69,30 @@ tests:
     db: integration_test
     sql: SELECT enrolled AS e, studentid AS s, name AS n FROM class
     expected_result:
-      - [ true, John, 10329 ]
-      - [ false, Jane, 342 ]
-      - [ true, Mike, 303 ]
-      - [ false, Mary, 204323 ]
-      - [ false, Pete, 10 ]
+      - [ true, 10329, John ]
+      - [ false, 342, Jane ]
+      - [ true, 303, Mike ]
+      - [ false, 204323, Mary ]
+      - [ false, 10, Pete ]
     row_count: 5
     ordered: false
-    expected_sql_type: [ BOOLEAN, LONGVARCHAR, INTEGER ]
-    expected_bson_type: [bool, string, int]
+    expected_sql_type: [ BOOLEAN, INTEGER, LONGVARCHAR ]
+    expected_bson_type: [bool, int, string]
     expected_catalog_name: [ '', '', '' ]
-    expected_column_class_name: [ boolean, java.lang.String, int ]
-    expected_column_label: [ e, n, s ]
-    expected_column_display_size: [ 1, 0, 10 ]
-    expected_precision: [ 1, 0, 10 ]
+    expected_column_class_name: [ boolean, int, java.lang.String ]
+    expected_column_label: [ e, s, n ]
+    expected_column_display_size: [ 1, 10, 0 ]
+    expected_precision: [ 1, 10, 0 ]
     expected_scale: [ 0, 0, 0 ]
     expected_schema_name: [ '', '', '' ]
     expected_is_auto_increment: [ false, false, false ]
-    expected_is_case_sensitive: [ false, true, false ]
+    expected_is_case_sensitive: [ false, false, true ]
     expected_is_currency: [ false, false, false ]
     expected_is_definitely_writable: [ false, false, false ]
     expected_is_nullable: [ columnNoNulls, columnNoNulls, columnNoNulls ]
     expected_is_read_only: [ true, true, true ]
     expected_is_searchable: [ true, true, true ]
-    expected_is_signed: [ false, false, true ]
+    expected_is_signed: [ false, true, false ]
     expected_is_writable: [ false, false, false ]
 
   - description: inner_join
@@ -100,24 +100,24 @@ tests:
     sql: "SELECT class.name, grades.testid, grades.score FROM grades INNER JOIN class ON grades.studentid\
       = class.studentid"
     expected_result:
-      - [Mike, 84.5, 3]
-      - [John, 97.4, 3]
-      - [Jane, 89.3, 3]
-      - [Mary, 91.9, 3]
-      - [Mike, 87.5, 5]
-      - [John, 74.4, 5]
-      - [Jane, 80.1, 5]
-      - [Mary, 83.3, 5]
+      - [Mike, 3, 84.5]
+      - [John, 3, 97.4]
+      - [Jane, 3, 89.3]
+      - [Mary, 3, 91.9]
+      - [Mike, 5, 87.5]
+      - [John, 5, 74.4]
+      - [Jane, 5, 80.1]
+      - [Mary, 5, 83.3]
     row_count: 8
     ordered: false
-    expected_sql_type: [LONGVARCHAR, DOUBLE, INTEGER]
-    expected_bson_type: [string, double, int]
+    expected_sql_type: [LONGVARCHAR, INTEGER, DOUBLE]
+    expected_bson_type: [string, int, double]
     expected_catalog_name: ['', '', '']
-    expected_column_class_name: [java.lang.String, double, int]
-    expected_column_label: [name, score, testid]
-    expected_column_display_size: [0, 15, 10]
-    expected_precision: [0, 15, 10]
-    expected_scale: [0, 15, 0]
+    expected_column_class_name: [java.lang.String, int, double]
+    expected_column_label: [name, testid, score]
+    expected_column_display_size: [0, 10, 15]
+    expected_precision: [0, 10, 15]
+    expected_scale: [0, 0, 15]
     expected_schema_name: ['', '', '']
     expected_is_auto_increment: [false, false, false]
     expected_is_case_sensitive: [true, false, false]
@@ -373,4 +373,3 @@ tests:
       - ['[1, 2, 3, {"$oid": "000000000000000000000003"}, {"$timestamp": {"t": 200, "i": 0}}]',
          '{"foo": "bar", "objId": {"$oid": "000000000000000000000002"}, "value": 3, "time": {"$timestamp": {"t": 200, "i": 0}}}']
     row_count: 1
-

--- a/src/main/java/com/mongodb/jdbc/MongoDatabaseMetaData.java
+++ b/src/main/java/com/mongodb/jdbc/MongoDatabaseMetaData.java
@@ -351,7 +351,8 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
                         new MongoJsonSchema.ScalarProperties(PROCEDURE_TYPE, BSON_INT),
                         new MongoJsonSchema.ScalarProperties(SPECIFIC_NAME, BSON_STRING));
 
-        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
+        return new MongoResultSet(
+                conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
     }
 
     @Override
@@ -384,7 +385,8 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
                         new MongoJsonSchema.ScalarProperties(IS_NULLABLE, BSON_STRING),
                         new MongoJsonSchema.ScalarProperties(SPECIFIC_NAME, BSON_STRING));
 
-        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
+        return new MongoResultSet(
+                conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
     }
 
     @Override
@@ -1380,7 +1382,8 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
                         new MongoJsonSchema.ScalarProperties(TABLE_SCHEM, BSON_STRING),
                         new MongoJsonSchema.ScalarProperties(TABLE_CATALOG, BSON_STRING, false));
 
-        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
+        return new MongoResultSet(
+                conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
     }
 
     @Override
@@ -1939,7 +1942,8 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
                         new MongoJsonSchema.ScalarProperties(DECIMAL_DIGITS, BSON_INT, false),
                         new MongoJsonSchema.ScalarProperties(PSEUDO_COLUMN, BSON_INT));
 
-        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
+        return new MongoResultSet(
+                conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
     }
 
     @Override
@@ -1962,7 +1966,8 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
                         new MongoJsonSchema.ScalarProperties(PK_NAME, BSON_STRING, false),
                         new MongoJsonSchema.ScalarProperties(DEFERRABILITY, BSON_INT));
 
-        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
+        return new MongoResultSet(
+                conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
     }
 
     @Override
@@ -1985,7 +1990,8 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
                         new MongoJsonSchema.ScalarProperties(PK_NAME, BSON_STRING, false),
                         new MongoJsonSchema.ScalarProperties(DEFERRABILITY, BSON_INT));
 
-        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
+        return new MongoResultSet(
+                conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
     }
 
     @Override
@@ -2014,7 +2020,8 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
                         new MongoJsonSchema.ScalarProperties(PK_NAME, BSON_STRING, false),
                         new MongoJsonSchema.ScalarProperties(DEFERRABILITY, BSON_INT));
 
-        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
+        return new MongoResultSet(
+                conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
     }
 
     // Helper for getting the rows for the getPrimaryKeys result set. Given a (dbName, tableName)
@@ -2750,7 +2757,8 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
                         new MongoJsonSchema.ScalarProperties(REMARKS, BSON_STRING),
                         new MongoJsonSchema.ScalarProperties(BASE_TYPE, BSON_INT, false));
 
-        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
+        return new MongoResultSet(
+                conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
     }
 
     @Override
@@ -2765,7 +2773,8 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
                         new MongoJsonSchema.ScalarProperties(SUPERTYPE_SCHEM, BSON_STRING, false),
                         new MongoJsonSchema.ScalarProperties(SUPERTYPE_NAME, BSON_STRING));
 
-        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
+        return new MongoResultSet(
+                conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
     }
 
     @Override
@@ -2778,7 +2787,8 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
                         new MongoJsonSchema.ScalarProperties(TABLE_NAME, BSON_STRING),
                         new MongoJsonSchema.ScalarProperties(SUPERTABLE_NAME, BSON_STRING));
 
-        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
+        return new MongoResultSet(
+                conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
     }
 
     @Override
@@ -2812,7 +2822,8 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
                         new MongoJsonSchema.ScalarProperties(SCOPE_TABLE, BSON_STRING, false),
                         new MongoJsonSchema.ScalarProperties(SOURCE_DATA_TYPE, BSON_INT, false));
 
-        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
+        return new MongoResultSet(
+                conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
     }
 
     //------------------------- JDBC 4.0 -----------------------------------
@@ -2836,7 +2847,8 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
         // All fields in this result set are nested under the bottom namespace.
         MongoJsonSchema botSchema = MongoJsonSchema.createEmptyObjectSchema();
         botSchema.properties.put(BOT_NAME, schema);
-        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
+        return new MongoResultSet(
+                conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
     }
 
     private MongoJsonSchema getFunctionJsonSchema() {
@@ -3049,6 +3061,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
                         new MongoJsonSchema.ScalarProperties(CHAR_OCTET_LENGTH, BSON_INT),
                         new MongoJsonSchema.ScalarProperties(IS_NULLABLE, BSON_STRING));
 
-        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
+        return new MongoResultSet(
+                conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
     }
 }

--- a/src/main/java/com/mongodb/jdbc/MongoDatabaseMetaData.java
+++ b/src/main/java/com/mongodb/jdbc/MongoDatabaseMetaData.java
@@ -351,8 +351,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
                         new MongoJsonSchema.ScalarProperties(PROCEDURE_TYPE, BSON_INT),
                         new MongoJsonSchema.ScalarProperties(SPECIFIC_NAME, BSON_STRING));
 
-        return new MongoResultSet(
-                conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
+        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema);
     }
 
     @Override
@@ -385,8 +384,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
                         new MongoJsonSchema.ScalarProperties(IS_NULLABLE, BSON_STRING),
                         new MongoJsonSchema.ScalarProperties(SPECIFIC_NAME, BSON_STRING));
 
-        return new MongoResultSet(
-                conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
+        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema);
     }
 
     @Override
@@ -403,7 +401,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
         MongoJsonSchema botSchema = MongoJsonSchema.createEmptyObjectSchema();
         botSchema.properties.put(BOT_NAME, schema);
 
-        return new MongoResultSet(conn.getLogger(), new BsonExplicitCursor(docs), botSchema, null);
+        return new MongoResultSet(conn.getLogger(), new BsonExplicitCursor(docs), botSchema);
     }
 
     // MHOUSE-7119: ADF quickstarts return empty strings and the admin database, so we filter them out
@@ -1372,7 +1370,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
         List<BsonDocument> docsList = docs.sorted().collect(Collectors.toList());
         BsonExplicitCursor c = new BsonExplicitCursor(docsList);
 
-        return new MongoResultSet(conn.getLogger(), c, botSchema, null);
+        return new MongoResultSet(conn.getLogger(), c, botSchema);
     }
 
     @Override
@@ -1382,8 +1380,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
                         new MongoJsonSchema.ScalarProperties(TABLE_SCHEM, BSON_STRING),
                         new MongoJsonSchema.ScalarProperties(TABLE_CATALOG, BSON_STRING, false));
 
-        return new MongoResultSet(
-                conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
+        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema);
     }
 
     @Override
@@ -1402,7 +1399,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
                                                                 TABLE_CAT, new BsonString(dbName))))
                                 .collect(Collectors.toList()));
 
-        return new MongoResultSet(conn.getLogger(), c, botSchema, null);
+        return new MongoResultSet(conn.getLogger(), c, botSchema);
     }
 
     /**
@@ -1677,7 +1674,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
         List<BsonDocument> docsList = docs.sorted().collect(Collectors.toList());
         BsonExplicitCursor c = new BsonExplicitCursor(docsList);
 
-        return new MongoResultSet(conn.getLogger(), c, botSchema, null);
+        return new MongoResultSet(conn.getLogger(), c, botSchema);
     }
 
     @Override
@@ -1735,7 +1732,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
         List<BsonDocument> docsList = docs.sorted().collect(Collectors.toList());
         BsonExplicitCursor c = new BsonExplicitCursor(docsList);
 
-        return new MongoResultSet(conn.getLogger(), c, botSchema, null);
+        return new MongoResultSet(conn.getLogger(), c, botSchema);
     }
 
     @Override
@@ -1782,7 +1779,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
         List<BsonDocument> docsList = docs.sorted().collect(Collectors.toList());
         BsonExplicitCursor c = new BsonExplicitCursor(docsList);
 
-        return new MongoResultSet(conn.getLogger(), c, botSchema, null);
+        return new MongoResultSet(conn.getLogger(), c, botSchema);
     }
 
     private Stream<BsonDocument> getFirstUniqueIndexDocsForTable(
@@ -1850,7 +1847,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
             List<BsonDocument> docsList = docs.collect(Collectors.toList());
             BsonExplicitCursor c = new BsonExplicitCursor(docsList);
 
-            return new MongoResultSet(conn.getLogger(), c, botSchema, null);
+            return new MongoResultSet(conn.getLogger(), c, botSchema);
         } catch (SQLException e) {
             throw new RuntimeException(e);
         }
@@ -1942,8 +1939,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
                         new MongoJsonSchema.ScalarProperties(DECIMAL_DIGITS, BSON_INT, false),
                         new MongoJsonSchema.ScalarProperties(PSEUDO_COLUMN, BSON_INT));
 
-        return new MongoResultSet(
-                conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
+        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema);
     }
 
     @Override
@@ -1966,8 +1962,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
                         new MongoJsonSchema.ScalarProperties(PK_NAME, BSON_STRING, false),
                         new MongoJsonSchema.ScalarProperties(DEFERRABILITY, BSON_INT));
 
-        return new MongoResultSet(
-                conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
+        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema);
     }
 
     @Override
@@ -1990,8 +1985,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
                         new MongoJsonSchema.ScalarProperties(PK_NAME, BSON_STRING, false),
                         new MongoJsonSchema.ScalarProperties(DEFERRABILITY, BSON_INT));
 
-        return new MongoResultSet(
-                conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
+        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema);
     }
 
     @Override
@@ -2020,8 +2014,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
                         new MongoJsonSchema.ScalarProperties(PK_NAME, BSON_STRING, false),
                         new MongoJsonSchema.ScalarProperties(DEFERRABILITY, BSON_INT));
 
-        return new MongoResultSet(
-                conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
+        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema);
     }
 
     // Helper for getting the rows for the getPrimaryKeys result set. Given a (dbName, tableName)
@@ -2631,7 +2624,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
         // All fields in this result set are nested under the bottom namespace.
         MongoJsonSchema botSchema = MongoJsonSchema.createEmptyObjectSchema();
         botSchema.properties.put(BOT_NAME, schema);
-        return new MongoResultSet(conn.getLogger(), new BsonExplicitCursor(docs), botSchema, null);
+        return new MongoResultSet(conn.getLogger(), new BsonExplicitCursor(docs), botSchema);
     }
 
     // Helper for creating stream of bson documents from the columns in the indexInfo doc.
@@ -2740,7 +2733,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
         List<BsonDocument> docsList = docs.sorted().collect(Collectors.toList());
         BsonExplicitCursor c = new BsonExplicitCursor(docsList);
 
-        return new MongoResultSet(conn.getLogger(), c, botSchema, null);
+        return new MongoResultSet(conn.getLogger(), c, botSchema);
     }
 
     @Override
@@ -2757,8 +2750,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
                         new MongoJsonSchema.ScalarProperties(REMARKS, BSON_STRING),
                         new MongoJsonSchema.ScalarProperties(BASE_TYPE, BSON_INT, false));
 
-        return new MongoResultSet(
-                conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
+        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema);
     }
 
     @Override
@@ -2773,8 +2765,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
                         new MongoJsonSchema.ScalarProperties(SUPERTYPE_SCHEM, BSON_STRING, false),
                         new MongoJsonSchema.ScalarProperties(SUPERTYPE_NAME, BSON_STRING));
 
-        return new MongoResultSet(
-                conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
+        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema);
     }
 
     @Override
@@ -2787,8 +2778,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
                         new MongoJsonSchema.ScalarProperties(TABLE_NAME, BSON_STRING),
                         new MongoJsonSchema.ScalarProperties(SUPERTABLE_NAME, BSON_STRING));
 
-        return new MongoResultSet(
-                conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
+        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema);
     }
 
     @Override
@@ -2822,8 +2812,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
                         new MongoJsonSchema.ScalarProperties(SCOPE_TABLE, BSON_STRING, false),
                         new MongoJsonSchema.ScalarProperties(SOURCE_DATA_TYPE, BSON_INT, false));
 
-        return new MongoResultSet(
-                conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
+        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema);
     }
 
     //------------------------- JDBC 4.0 -----------------------------------
@@ -2847,8 +2836,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
         // All fields in this result set are nested under the bottom namespace.
         MongoJsonSchema botSchema = MongoJsonSchema.createEmptyObjectSchema();
         botSchema.properties.put(BOT_NAME, schema);
-        return new MongoResultSet(
-                conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
+        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema);
     }
 
     private MongoJsonSchema getFunctionJsonSchema() {
@@ -2896,7 +2884,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
             docs.add(doc);
         }
 
-        return new MongoResultSet(conn.getLogger(), new BsonExplicitCursor(docs), schema, null);
+        return new MongoResultSet(conn.getLogger(), new BsonExplicitCursor(docs), schema);
     }
 
     private MongoJsonSchema getFunctionColumnJsonSchema() {
@@ -3038,7 +3026,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
             }
         }
 
-        return new MongoResultSet(conn.getLogger(), new BsonExplicitCursor(docs), schema, null);
+        return new MongoResultSet(conn.getLogger(), new BsonExplicitCursor(docs), schema);
     }
 
     //--------------------------JDBC 4.1 -----------------------------
@@ -3061,7 +3049,6 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
                         new MongoJsonSchema.ScalarProperties(CHAR_OCTET_LENGTH, BSON_INT),
                         new MongoJsonSchema.ScalarProperties(IS_NULLABLE, BSON_STRING));
 
-        return new MongoResultSet(
-                conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
+        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema);
     }
 }

--- a/src/main/java/com/mongodb/jdbc/MongoDatabaseMetaData.java
+++ b/src/main/java/com/mongodb/jdbc/MongoDatabaseMetaData.java
@@ -351,7 +351,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
                         new MongoJsonSchema.ScalarProperties(PROCEDURE_TYPE, BSON_INT),
                         new MongoJsonSchema.ScalarProperties(SPECIFIC_NAME, BSON_STRING));
 
-        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema);
+        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
     }
 
     @Override
@@ -384,7 +384,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
                         new MongoJsonSchema.ScalarProperties(IS_NULLABLE, BSON_STRING),
                         new MongoJsonSchema.ScalarProperties(SPECIFIC_NAME, BSON_STRING));
 
-        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema);
+        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
     }
 
     @Override
@@ -401,7 +401,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
         MongoJsonSchema botSchema = MongoJsonSchema.createEmptyObjectSchema();
         botSchema.properties.put(BOT_NAME, schema);
 
-        return new MongoResultSet(conn.getLogger(), new BsonExplicitCursor(docs), botSchema);
+        return new MongoResultSet(conn.getLogger(), new BsonExplicitCursor(docs), botSchema, null);
     }
 
     // MHOUSE-7119: ADF quickstarts return empty strings and the admin database, so we filter them out
@@ -1370,7 +1370,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
         List<BsonDocument> docsList = docs.sorted().collect(Collectors.toList());
         BsonExplicitCursor c = new BsonExplicitCursor(docsList);
 
-        return new MongoResultSet(conn.getLogger(), c, botSchema);
+        return new MongoResultSet(conn.getLogger(), c, botSchema, null);
     }
 
     @Override
@@ -1380,7 +1380,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
                         new MongoJsonSchema.ScalarProperties(TABLE_SCHEM, BSON_STRING),
                         new MongoJsonSchema.ScalarProperties(TABLE_CATALOG, BSON_STRING, false));
 
-        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema);
+        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
     }
 
     @Override
@@ -1399,7 +1399,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
                                                                 TABLE_CAT, new BsonString(dbName))))
                                 .collect(Collectors.toList()));
 
-        return new MongoResultSet(conn.getLogger(), c, botSchema);
+        return new MongoResultSet(conn.getLogger(), c, botSchema, null);
     }
 
     /**
@@ -1674,7 +1674,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
         List<BsonDocument> docsList = docs.sorted().collect(Collectors.toList());
         BsonExplicitCursor c = new BsonExplicitCursor(docsList);
 
-        return new MongoResultSet(conn.getLogger(), c, botSchema);
+        return new MongoResultSet(conn.getLogger(), c, botSchema, null);
     }
 
     @Override
@@ -1732,7 +1732,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
         List<BsonDocument> docsList = docs.sorted().collect(Collectors.toList());
         BsonExplicitCursor c = new BsonExplicitCursor(docsList);
 
-        return new MongoResultSet(conn.getLogger(), c, botSchema);
+        return new MongoResultSet(conn.getLogger(), c, botSchema, null);
     }
 
     @Override
@@ -1779,7 +1779,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
         List<BsonDocument> docsList = docs.sorted().collect(Collectors.toList());
         BsonExplicitCursor c = new BsonExplicitCursor(docsList);
 
-        return new MongoResultSet(conn.getLogger(), c, botSchema);
+        return new MongoResultSet(conn.getLogger(), c, botSchema, null);
     }
 
     private Stream<BsonDocument> getFirstUniqueIndexDocsForTable(
@@ -1847,7 +1847,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
             List<BsonDocument> docsList = docs.collect(Collectors.toList());
             BsonExplicitCursor c = new BsonExplicitCursor(docsList);
 
-            return new MongoResultSet(conn.getLogger(), c, botSchema);
+            return new MongoResultSet(conn.getLogger(), c, botSchema, null);
         } catch (SQLException e) {
             throw new RuntimeException(e);
         }
@@ -1939,7 +1939,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
                         new MongoJsonSchema.ScalarProperties(DECIMAL_DIGITS, BSON_INT, false),
                         new MongoJsonSchema.ScalarProperties(PSEUDO_COLUMN, BSON_INT));
 
-        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema);
+        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
     }
 
     @Override
@@ -1962,7 +1962,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
                         new MongoJsonSchema.ScalarProperties(PK_NAME, BSON_STRING, false),
                         new MongoJsonSchema.ScalarProperties(DEFERRABILITY, BSON_INT));
 
-        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema);
+        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
     }
 
     @Override
@@ -1985,7 +1985,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
                         new MongoJsonSchema.ScalarProperties(PK_NAME, BSON_STRING, false),
                         new MongoJsonSchema.ScalarProperties(DEFERRABILITY, BSON_INT));
 
-        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema);
+        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
     }
 
     @Override
@@ -2014,7 +2014,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
                         new MongoJsonSchema.ScalarProperties(PK_NAME, BSON_STRING, false),
                         new MongoJsonSchema.ScalarProperties(DEFERRABILITY, BSON_INT));
 
-        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema);
+        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
     }
 
     // Helper for getting the rows for the getPrimaryKeys result set. Given a (dbName, tableName)
@@ -2624,7 +2624,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
         // All fields in this result set are nested under the bottom namespace.
         MongoJsonSchema botSchema = MongoJsonSchema.createEmptyObjectSchema();
         botSchema.properties.put(BOT_NAME, schema);
-        return new MongoResultSet(conn.getLogger(), new BsonExplicitCursor(docs), botSchema);
+        return new MongoResultSet(conn.getLogger(), new BsonExplicitCursor(docs), botSchema, null);
     }
 
     // Helper for creating stream of bson documents from the columns in the indexInfo doc.
@@ -2733,7 +2733,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
         List<BsonDocument> docsList = docs.sorted().collect(Collectors.toList());
         BsonExplicitCursor c = new BsonExplicitCursor(docsList);
 
-        return new MongoResultSet(conn.getLogger(), c, botSchema);
+        return new MongoResultSet(conn.getLogger(), c, botSchema, null);
     }
 
     @Override
@@ -2750,7 +2750,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
                         new MongoJsonSchema.ScalarProperties(REMARKS, BSON_STRING),
                         new MongoJsonSchema.ScalarProperties(BASE_TYPE, BSON_INT, false));
 
-        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema);
+        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
     }
 
     @Override
@@ -2765,7 +2765,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
                         new MongoJsonSchema.ScalarProperties(SUPERTYPE_SCHEM, BSON_STRING, false),
                         new MongoJsonSchema.ScalarProperties(SUPERTYPE_NAME, BSON_STRING));
 
-        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema);
+        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
     }
 
     @Override
@@ -2778,7 +2778,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
                         new MongoJsonSchema.ScalarProperties(TABLE_NAME, BSON_STRING),
                         new MongoJsonSchema.ScalarProperties(SUPERTABLE_NAME, BSON_STRING));
 
-        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema);
+        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
     }
 
     @Override
@@ -2812,7 +2812,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
                         new MongoJsonSchema.ScalarProperties(SCOPE_TABLE, BSON_STRING, false),
                         new MongoJsonSchema.ScalarProperties(SOURCE_DATA_TYPE, BSON_INT, false));
 
-        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema);
+        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
     }
 
     //------------------------- JDBC 4.0 -----------------------------------
@@ -2836,7 +2836,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
         // All fields in this result set are nested under the bottom namespace.
         MongoJsonSchema botSchema = MongoJsonSchema.createEmptyObjectSchema();
         botSchema.properties.put(BOT_NAME, schema);
-        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema);
+        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
     }
 
     private MongoJsonSchema getFunctionJsonSchema() {
@@ -2884,7 +2884,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
             docs.add(doc);
         }
 
-        return new MongoResultSet(conn.getLogger(), new BsonExplicitCursor(docs), schema);
+        return new MongoResultSet(conn.getLogger(), new BsonExplicitCursor(docs), schema, null);
     }
 
     private MongoJsonSchema getFunctionColumnJsonSchema() {
@@ -3026,7 +3026,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
             }
         }
 
-        return new MongoResultSet(conn.getLogger(), new BsonExplicitCursor(docs), schema);
+        return new MongoResultSet(conn.getLogger(), new BsonExplicitCursor(docs), schema, null);
     }
 
     //--------------------------JDBC 4.1 -----------------------------
@@ -3049,6 +3049,6 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
                         new MongoJsonSchema.ScalarProperties(CHAR_OCTET_LENGTH, BSON_INT),
                         new MongoJsonSchema.ScalarProperties(IS_NULLABLE, BSON_STRING));
 
-        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema);
+        return new MongoResultSet(conn.getLogger(), BsonExplicitCursor.EMPTY_CURSOR, botSchema, null);
     }
 }

--- a/src/main/java/com/mongodb/jdbc/MongoJsonSchemaResult.java
+++ b/src/main/java/com/mongodb/jdbc/MongoJsonSchemaResult.java
@@ -16,10 +16,12 @@
 
 package com.mongodb.jdbc;
 
+import java.util.List;
 import java.util.Map;
 
 public class MongoJsonSchemaResult {
     public int ok;
     public Map<String, String> metadata;
     public MongoVersionedJsonSchema schema;
+    public List<List<String>> selectOrder;
 }

--- a/src/main/java/com/mongodb/jdbc/MongoResultSet.java
+++ b/src/main/java/com/mongodb/jdbc/MongoResultSet.java
@@ -46,6 +46,7 @@ import java.sql.Types;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
+import java.util.List;
 import java.util.Objects;
 import java.util.TimeZone;
 import javax.sql.rowset.serial.SerialBlob;
@@ -91,6 +92,7 @@ public class MongoResultSet implements ResultSet {
             MongoStatement statement,
             MongoCursor<BsonDocument> cursor,
             MongoJsonSchema schema,
+            List<List<String>> selectOrder,
             boolean extJsonMode)
             throws SQLException {
         Preconditions.checkNotNull(statement);
@@ -102,7 +104,7 @@ public class MongoResultSet implements ResultSet {
                         statement.getStatementId());
         this.extJsonMode = extJsonMode;
         setUpResultset(
-                cursor, schema, true, statement.getParentLogger(), statement.getStatementId());
+                cursor, schema, selectOrder, true, statement.getParentLogger(), statement.getStatementId());
     }
 
     /**
@@ -114,15 +116,17 @@ public class MongoResultSet implements ResultSet {
      * @throws SQLException
      */
     public MongoResultSet(
-            MongoLogger parentLogger, MongoCursor<BsonDocument> cursor, MongoJsonSchema schema)
+            MongoLogger parentLogger, MongoCursor<BsonDocument> cursor, MongoJsonSchema schema, 
+            List<List<String>> selectOrder)
             throws SQLException {
         this.logger = new MongoLogger(this.getClass().getCanonicalName(), parentLogger);
-        setUpResultset(cursor, schema, false, parentLogger, null);
+        setUpResultset(cursor, schema, selectOrder, false, parentLogger, null);
     }
 
     private void setUpResultset(
             MongoCursor<BsonDocument> cursor,
             MongoJsonSchema schema,
+            List<List<String>> selectOrder,
             boolean sortFieldsAlphabetically,
             MongoLogger parentLogger,
             Integer statementId)
@@ -137,7 +141,7 @@ public class MongoResultSet implements ResultSet {
 
         this.rsMetaData =
                 new MongoResultSetMetaData(
-                        schema, sortFieldsAlphabetically, parentLogger, statementId);
+                        schema, selectOrder, sortFieldsAlphabetically, parentLogger, statementId);
     }
 
     // This is only used for testing, and that is why it has package level access, and the

--- a/src/main/java/com/mongodb/jdbc/MongoResultSet.java
+++ b/src/main/java/com/mongodb/jdbc/MongoResultSet.java
@@ -104,7 +104,12 @@ public class MongoResultSet implements ResultSet {
                         statement.getStatementId());
         this.extJsonMode = extJsonMode;
         setUpResultset(
-                cursor, schema, selectOrder, true, statement.getParentLogger(), statement.getStatementId());
+                cursor,
+                schema,
+                selectOrder,
+                true,
+                statement.getParentLogger(),
+                statement.getStatementId());
     }
 
     /**
@@ -116,7 +121,9 @@ public class MongoResultSet implements ResultSet {
      * @throws SQLException
      */
     public MongoResultSet(
-            MongoLogger parentLogger, MongoCursor<BsonDocument> cursor, MongoJsonSchema schema, 
+            MongoLogger parentLogger,
+            MongoCursor<BsonDocument> cursor,
+            MongoJsonSchema schema,
             List<List<String>> selectOrder)
             throws SQLException {
         this.logger = new MongoLogger(this.getClass().getCanonicalName(), parentLogger);

--- a/src/main/java/com/mongodb/jdbc/MongoResultSet.java
+++ b/src/main/java/com/mongodb/jdbc/MongoResultSet.java
@@ -121,13 +121,10 @@ public class MongoResultSet implements ResultSet {
      * @throws SQLException
      */
     public MongoResultSet(
-            MongoLogger parentLogger,
-            MongoCursor<BsonDocument> cursor,
-            MongoJsonSchema schema,
-            List<List<String>> selectOrder)
+            MongoLogger parentLogger, MongoCursor<BsonDocument> cursor, MongoJsonSchema schema)
             throws SQLException {
         this.logger = new MongoLogger(this.getClass().getCanonicalName(), parentLogger);
-        setUpResultset(cursor, schema, selectOrder, false, parentLogger, null);
+        setUpResultset(cursor, schema, null, false, parentLogger, null);
     }
 
     private void setUpResultset(

--- a/src/main/java/com/mongodb/jdbc/MongoResultSetMetaData.java
+++ b/src/main/java/com/mongodb/jdbc/MongoResultSetMetaData.java
@@ -75,6 +75,7 @@ public class MongoResultSetMetaData implements ResultSetMetaData {
      */
     public MongoResultSetMetaData(
             MongoJsonSchema schema,
+            List<List<String>> selectOrder,
             boolean sortFieldsAlphabetically,
             MongoLogger parentLogger,
             Integer statementId)

--- a/src/main/java/com/mongodb/jdbc/MongoResultSetMetaData.java
+++ b/src/main/java/com/mongodb/jdbc/MongoResultSetMetaData.java
@@ -98,6 +98,10 @@ public class MongoResultSetMetaData implements ResultSetMetaData {
         for (String datasource : datasources) {
             processDataSource(schema, datasource, sortFieldsAlphabetically);
         }
+
+        if (selectOrder != null) {
+            processSelectOrder(selectOrder);
+        }
     }
 
     private void assertDatasourceSchema(MongoJsonSchema schema) throws SQLException {
@@ -131,6 +135,29 @@ public class MongoResultSetMetaData implements ResultSetMetaData {
             }
         }
     };
+
+    private void processSelectOrder(List<List<String>> selectOrder) throws SQLException {
+        // turn columnIndices into a map
+        HashMap<List<String>, NameSpace> columnIndexMap = new HashMap<List<String>, NameSpace>();
+        for (NameSpace n : columnIndices) {
+            columnIndexMap.put(Arrays.asList(n.datasource, n.columnLabel), n);
+        }
+
+        // turn columnInfo into a map as well
+        HashMap<List<String>, MongoColumnInfo> columnInfoMap =
+                new HashMap<List<String>, MongoColumnInfo>();
+        for (MongoColumnInfo t : columnInfo) {
+            columnInfoMap.put(Arrays.asList(t.getTableName(), t.getColumnName()), t);
+        }
+
+        // reset columnIndices and columnInfo to empty lists and populate in select order
+        columnIndices = new ArrayList<NameSpace>();
+        columnInfo = new ArrayList<MongoColumnInfo>();
+        for (List<String> column : selectOrder) {
+            columnIndices.add(columnIndexMap.remove(column));
+            columnInfo.add(columnInfoMap.remove(column));
+        }
+    }
 
     // This gets the datasource for a given columnLabel, and is used
     // in MongoResultSet to retrieve data by label.

--- a/src/main/java/com/mongodb/jdbc/MongoStatement.java
+++ b/src/main/java/com/mongodb/jdbc/MongoStatement.java
@@ -212,7 +212,7 @@ public class MongoStatement implements Statement {
                             .runCommand(getSchemaCmd, MongoJsonSchemaResult.class);
 
             MongoJsonSchema schema = schemaResult.schema.mongoJsonSchema;
-            resultSet = new MongoResultSet(this, iterable.cursor(), schema, conn.getExtJsonMode());
+            resultSet = new MongoResultSet(this, iterable.cursor(), schema, null, conn.getExtJsonMode());
             return resultSet;
         } catch (MongoExecutionTimeoutException e) {
             throw new SQLTimeoutException(e);

--- a/src/main/java/com/mongodb/jdbc/MongoStatement.java
+++ b/src/main/java/com/mongodb/jdbc/MongoStatement.java
@@ -212,7 +212,9 @@ public class MongoStatement implements Statement {
                             .runCommand(getSchemaCmd, MongoJsonSchemaResult.class);
 
             MongoJsonSchema schema = schemaResult.schema.mongoJsonSchema;
-            resultSet = new MongoResultSet(this, iterable.cursor(), schema, null, conn.getExtJsonMode());
+            resultSet =
+                    new MongoResultSet(
+                            this, iterable.cursor(), schema, null, conn.getExtJsonMode());
             return resultSet;
         } catch (MongoExecutionTimeoutException e) {
             throw new SQLTimeoutException(e);

--- a/src/main/java/com/mongodb/jdbc/MongoStatement.java
+++ b/src/main/java/com/mongodb/jdbc/MongoStatement.java
@@ -24,6 +24,7 @@ import com.mongodb.jdbc.logging.AutoLoggable;
 import com.mongodb.jdbc.logging.MongoLogger;
 import java.sql.*;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.bson.BsonDocument;
 import org.bson.BsonInt32;
@@ -212,9 +213,10 @@ public class MongoStatement implements Statement {
                             .runCommand(getSchemaCmd, MongoJsonSchemaResult.class);
 
             MongoJsonSchema schema = schemaResult.schema.mongoJsonSchema;
+            List<List<String>> selectOrder = schemaResult.selectOrder;
             resultSet =
                     new MongoResultSet(
-                            this, iterable.cursor(), schema, null, conn.getExtJsonMode());
+                            this, iterable.cursor(), schema, selectOrder, conn.getExtJsonMode());
             return resultSet;
         } catch (MongoExecutionTimeoutException e) {
             throw new SQLTimeoutException(e);

--- a/src/test/java/com/mongodb/jdbc/MongoResultSetMetaDataTest.java
+++ b/src/test/java/com/mongodb/jdbc/MongoResultSetMetaDataTest.java
@@ -21,6 +21,8 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Types;
+import java.util.Arrays;
+import java.util.List;
 import org.bson.BsonValue;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -61,12 +63,29 @@ class MongoResultSetMetaDataTest extends MongoMock {
         String[] expected_sorted_columns =
                 new String[] {"a", "binary", "str", "a", "b", "c", "d", "doc", "null", "vec"};
         String[] expected_original_columns =
-                new String[] {"a", "binary", "str", "c", "a", "d", "b", "vec", "null", "doc"};                
+                new String[] {"a", "binary", "str", "c", "a", "d", "b", "vec", "null", "doc"};
+        String[] expected_select_order_columns =
+                new String[] {"binary", "str", "a", "b", "c", "d", "doc", "null", "vec", "a"};
+        List<List<String>> selectOrder =
+                Arrays.asList(
+                        Arrays.asList("", "binary"),
+                        Arrays.asList("", "str"),
+                        Arrays.asList("foo", "a"),
+                        Arrays.asList("foo", "b"),
+                        Arrays.asList("foo", "c"),
+                        Arrays.asList("foo", "d"),
+                        Arrays.asList("foo", "doc"),
+                        Arrays.asList("foo", "null"),
+                        Arrays.asList("foo", "vec"),
+                        Arrays.asList("", "a"));
         MongoJsonSchema schema = generateMongoJsonSchema();
         MongoResultSetMetaData unsortedMedata =
                 new MongoResultSetMetaData(schema, null, false, mongoConnection.getLogger(), 0);
         MongoResultSetMetaData sortedMedata =
                 new MongoResultSetMetaData(schema, null, true, mongoConnection.getLogger(), 0);
+        MongoResultSetMetaData selectOrderedMetadata =
+                new MongoResultSetMetaData(
+                        schema, selectOrder, false, mongoConnection.getLogger(), 0);
 
         assertEquals(
                 expected_original_columns.length,
@@ -82,6 +101,15 @@ class MongoResultSetMetaDataTest extends MongoMock {
                 "The number of expected columns doesn't match the actual number of columns");
         for (int i = 0; i < sortedMedata.getColumnCount(); i++) {
             assertEquals(expected_sorted_columns[i], sortedMedata.getColumnName(i + 1));
+        }
+
+        assertEquals(
+                expected_select_order_columns.length,
+                selectOrderedMetadata.getColumnCount(),
+                "The number of expected columns doesn't match the actual number of columns");
+        for (int i = 0; i < selectOrderedMetadata.getColumnCount(); i++) {
+            assertEquals(
+                    expected_select_order_columns[i], selectOrderedMetadata.getColumnName(i + 1));
         }
     }
 

--- a/src/test/java/com/mongodb/jdbc/MongoResultSetMetaDataTest.java
+++ b/src/test/java/com/mongodb/jdbc/MongoResultSetMetaDataTest.java
@@ -38,7 +38,7 @@ class MongoResultSetMetaDataTest extends MongoMock {
         try {
             resultSetMetaData =
                     new MongoResultSetMetaData(
-                            generateMongoJsonSchema(), true, mongoConnection.getLogger(), 0);
+                            generateMongoJsonSchema(), null, true, mongoConnection.getLogger(), 0);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -61,12 +61,12 @@ class MongoResultSetMetaDataTest extends MongoMock {
         String[] expected_sorted_columns =
                 new String[] {"a", "binary", "str", "a", "b", "c", "d", "doc", "null", "vec"};
         String[] expected_original_columns =
-                new String[] {"a", "binary", "str", "c", "a", "d", "b", "vec", "null", "doc"};
+                new String[] {"a", "binary", "str", "c", "a", "d", "b", "vec", "null", "doc"};                
         MongoJsonSchema schema = generateMongoJsonSchema();
         MongoResultSetMetaData unsortedMedata =
-                new MongoResultSetMetaData(schema, false, mongoConnection.getLogger(), 0);
+                new MongoResultSetMetaData(schema, null, false, mongoConnection.getLogger(), 0);
         MongoResultSetMetaData sortedMedata =
-                new MongoResultSetMetaData(schema, true, mongoConnection.getLogger(), 0);
+                new MongoResultSetMetaData(schema, null, true, mongoConnection.getLogger(), 0);
 
         assertEquals(
                 expected_original_columns.length,

--- a/src/test/java/com/mongodb/jdbc/MongoResultSetTest.java
+++ b/src/test/java/com/mongodb/jdbc/MongoResultSetTest.java
@@ -123,7 +123,11 @@ class MongoResultSetTest extends MongoMock {
         try {
             mongoResultSet =
                     new MongoResultSet(
-                            mongoStatement, new BsonExplicitCursor(mongoResultDocs), schema, null, false);
+                            mongoStatement,
+                            new BsonExplicitCursor(mongoResultDocs),
+                            schema,
+                            null,
+                            false);
             mongoResultSetAllTypes =
                     new MongoResultSet(
                             mongoStatement,
@@ -133,10 +137,18 @@ class MongoResultSetTest extends MongoMock {
                             false);
             closedMongoResultSet =
                     new MongoResultSet(
-                            mongoStatement, new BsonExplicitCursor(mongoResultDocs), schema, null, false);
+                            mongoStatement,
+                            new BsonExplicitCursor(mongoResultDocs),
+                            schema,
+                            null,
+                            false);
             mongoResultSetExtended =
                     new MongoResultSet(
-                            mongoStatement, new BsonExplicitCursor(mongoResultDocs), schema, null, true);
+                            mongoStatement,
+                            new BsonExplicitCursor(mongoResultDocs),
+                            schema,
+                            null,
+                            true);
             mongoResultSet.next();
             mongoResultSetAllTypes.next();
             closedMongoResultSet.next();

--- a/src/test/java/com/mongodb/jdbc/MongoResultSetTest.java
+++ b/src/test/java/com/mongodb/jdbc/MongoResultSetTest.java
@@ -76,7 +76,7 @@ class MongoResultSetTest extends MongoMock {
         try {
             schema = generateMongoJsonSchema();
             resultSetMetaData =
-                    new MongoResultSetMetaData(schema, true, mongoConnection.getLogger(), 0);
+                    new MongoResultSetMetaData(schema, null, true, mongoConnection.getLogger(), 0);
             mongoStatement = new MongoStatement(mongoConnection, "test");
         } catch (SQLException e) {
             throw new RuntimeException(e);
@@ -123,19 +123,20 @@ class MongoResultSetTest extends MongoMock {
         try {
             mongoResultSet =
                     new MongoResultSet(
-                            mongoStatement, new BsonExplicitCursor(mongoResultDocs), schema, false);
+                            mongoStatement, new BsonExplicitCursor(mongoResultDocs), schema, null, false);
             mongoResultSetAllTypes =
                     new MongoResultSet(
                             mongoStatement,
                             new BsonExplicitCursor(mongoResultDocsAllTypes),
                             schemaAllTypes,
+                            null,
                             false);
             closedMongoResultSet =
                     new MongoResultSet(
-                            mongoStatement, new BsonExplicitCursor(mongoResultDocs), schema, false);
+                            mongoStatement, new BsonExplicitCursor(mongoResultDocs), schema, null, false);
             mongoResultSetExtended =
                     new MongoResultSet(
-                            mongoStatement, new BsonExplicitCursor(mongoResultDocs), schema, true);
+                            mongoStatement, new BsonExplicitCursor(mongoResultDocs), schema, null, true);
             mongoResultSet.next();
             mongoResultSetAllTypes.next();
             closedMongoResultSet.next();
@@ -1045,7 +1046,7 @@ class MongoResultSetTest extends MongoMock {
                             return generateRow();
                         });
 
-        mockResultSet = new MongoResultSet(mongoStatement, cursor, schema, false);
+        mockResultSet = new MongoResultSet(mongoStatement, cursor, schema, null, false);
 
         boolean hasNext = mockResultSet.next();
         assertFalse(hasNext);
@@ -1065,7 +1066,7 @@ class MongoResultSetTest extends MongoMock {
 
         BsonExplicitCursor cursor =
                 new BsonExplicitCursor(Arrays.asList(valuesDoc, valuesDoc2, valuesDoc3));
-        mockResultSet = new MongoResultSet(mongoStatement, cursor, schema, false);
+        mockResultSet = new MongoResultSet(mongoStatement, cursor, schema, null, false);
 
         assertFalse(mockResultSet.isFirst());
         assertFalse(mockResultSet.isLast());
@@ -1102,7 +1103,7 @@ class MongoResultSetTest extends MongoMock {
                             return emptyResultDoc;
                         });
 
-        mockResultSet = new MongoResultSet(mongoStatement, cursor, schema, false);
+        mockResultSet = new MongoResultSet(mongoStatement, cursor, schema, null, false);
 
         assertFalse(mockResultSet.isFirst());
         // For empty result set, isLast should always be true
@@ -1136,7 +1137,7 @@ class MongoResultSetTest extends MongoMock {
                             return emptyResultDoc;
                         });
 
-        mockResultSet = new MongoResultSet(mongoStatement, cursor, schema, false);
+        mockResultSet = new MongoResultSet(mongoStatement, cursor, schema, null, false);
 
         assertEquals(10, mockResultSet.getMetaData().getColumnCount());
         assertFalse(mockResultSet.isFirst());
@@ -1196,7 +1197,7 @@ class MongoResultSetTest extends MongoMock {
                             return doc;
                         });
 
-        mockResultSet = new MongoResultSet(mongoStatement, cursor, sameMetadataSchema, false);
+        mockResultSet = new MongoResultSet(mongoStatement, cursor, sameMetadataSchema, null, false);
 
         ResultSetMetaData metaData = mockResultSet.getMetaData();
         assertEquals(1, metaData.getColumnCount());


### PR DESCRIPTION
To test, ran the SQL-1773 version of mongosql locally in ADF. tried each of unit tests and integration tests. Failing tests are the two result set tests expecting alphabetical order but getting select order