### PR TITLE
SQL-1779: Update java driver version to 4.11.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 group = org.mongodb
 artifactId = adf-java-driver
-mongodbDriverVersion = 4.10.2
+mongodbDriverVersion = 4.11.1
 junitJupiterVersion = 5.5.2
 mockitoVersion = 3.0.0
 googleLintVersion = 1.7


### PR DESCRIPTION
This PR bumps the java driver version to 4.11.1. The release notes don't include anything that looks relevant for us, so this is just a one-liner bumping up the version.