### PR TITLE
SQL-1835:  The driver disables all logger when connecting

### DIFF
--- a/src/main/java/com/mongodb/jdbc/MongoDriver.java
+++ b/src/main/java/com/mongodb/jdbc/MongoDriver.java
@@ -22,8 +22,6 @@ import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
 import com.mongodb.ConnectionString;
 import com.mongodb.MongoClientSettings;
 import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.sql.Connection;
@@ -40,7 +38,6 @@ import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
-import java.util.logging.LogManager;
 import java.util.stream.Stream;
 import org.bson.codecs.BsonValueCodecProvider;
 import org.bson.codecs.ValueCodecProvider;
@@ -107,18 +104,6 @@ public class MongoDriver implements Driver {
     static final String EXTENDED = "EXTENDED";
     public static final String LOG_TO_CONSOLE = "console";
     protected static final String CONNECTION_ERROR_SQLSTATE = "08000";
-
-    // Load logging.properties
-    static {
-        InputStream stream =
-                MongoDriver.class.getClassLoader().getResourceAsStream("logging.properties");
-        try {
-            LogManager.getLogManager().reset();
-            LogManager.getLogManager().readConfiguration(stream);
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-    }
 
     static CodecRegistry registry =
             fromProviders(

--- a/src/main/java/com/mongodb/jdbc/logging/MongoSimpleFormatter.java
+++ b/src/main/java/com/mongodb/jdbc/logging/MongoSimpleFormatter.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.jdbc.logging;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Date;
+import java.util.logging.Formatter;
+import java.util.logging.LogRecord;
+
+public class MongoSimpleFormatter extends Formatter {
+    private final String format = "[%1$tF %1$tT.%1$tL] [%4$s] %2$s: %5$s %6$s %n";
+    private final Date date = new Date();
+
+    @Override
+    public String format(LogRecord record) {
+        date.setTime(record.getMillis());
+        String source;
+        if (record.getSourceClassName() != null) {
+            source = record.getSourceClassName();
+            if (record.getSourceMethodName() != null) {
+                source += " " + record.getSourceMethodName();
+            }
+        } else {
+            source = record.getLoggerName();
+        }
+        String message = formatMessage(record);
+        String throwable = "";
+        if (record.getThrown() != null) {
+            StringWriter sw = new StringWriter();
+            PrintWriter pw = new PrintWriter(sw);
+            pw.println();
+            record.getThrown().printStackTrace(pw);
+            pw.close();
+            throwable = sw.toString();
+        }
+        return String.format(
+                format,
+                date,
+                source,
+                record.getLoggerName(),
+                record.getLevel().getLocalizedName(),
+                message,
+                throwable);
+    }
+}

--- a/src/main/resources/logging.properties
+++ b/src/main/resources/logging.properties
@@ -1,5 +1,0 @@
-handlers=
-.level= OFF
-java.util.logging.FileHandler.limit = 10000000
-java.util.logging.FileHandler.count = 5
-java.util.logging.SimpleFormatter.format = [%1$tF %1$tT.%1$tL] [%4$s] %2$s: %5$s %6$s %n


### PR DESCRIPTION
MongoDriver used to reset the log manager configuration with the configuration of the logging.properties from inside our jar. This is problematic for other applications using JUL as their configuration is deleted.
Instead, we now do the configuration for our Filehandler programmatically.