### PR TITLE
SQL-1916: Fail retrieving info by column name if the column name is duplicated

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -158,7 +158,7 @@ jar {
 }
 
 dependencies {
-    implementation "org.yaml:snakeyaml:$snakeYamlVersion"
+    integrationTestImplementation "org.yaml:snakeyaml:$snakeYamlVersion"
     api "org.mongodb:mongodb-driver-sync:$mongodbDriverVersion"
     integrationTestImplementation "org.junit.jupiter:junit-jupiter:$junitJupiterVersion"
     integrationTestImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: junitJupiterVersion

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,9 +4,9 @@ mongodbDriverVersion = 4.11.1
 junitJupiterVersion = 5.5.2
 mockitoVersion = 3.0.0
 googleLintVersion = 1.7
-guavaVersion = 31.1-jre
+guavaVersion = 32.0.1-jre
 lang3Version = 3.0
 nexusDomain = http://localhost:8081/nexus
-snakeYamlVersion = 1.29
+snakeYamlVersion = 2.2
 # to disable publication of both SHA-256 and SHA-512 checksums which causes error in maven release
 systemProp.org.gradle.internal.publish.checksums.insecure = true

--- a/resources/integration_test/tests/query.yaml
+++ b/resources/integration_test/tests/query.yaml
@@ -95,6 +95,36 @@ tests:
     expected_is_signed: [ false, true, false ]
     expected_is_writable: [ false, false, false ]
 
+  - description: select_list_order
+    db: integration_test
+    sql: SELECT studentid AS s, name AS n, enrolled AS e FROM class
+    expected_result:
+      - [ 10329, John, true ]
+      - [ 342, Jane, false ]
+      - [ 303, Mike, true ]
+      - [ 204323, Mary, false ]
+      - [ 10, Pete, false ]
+    row_count: 5
+    ordered: false
+    expected_sql_type: [ INTEGER, LONGVARCHAR, BOOLEAN ]
+    expected_bson_type: [ int, string, bool ]
+    expected_catalog_name: [ '', '', '' ]
+    expected_column_class_name: [ int, java.lang.String, boolean ]
+    expected_column_label: [ s, n, e ]
+    expected_column_display_size: [ 10, 0, 1 ]
+    expected_precision: [ 10, 0, 1 ]
+    expected_scale: [ 0, 0, 0 ]
+    expected_schema_name: [ '', '', '' ]
+    expected_is_auto_increment: [ false, false, false ]
+    expected_is_case_sensitive: [ false, true, false ]
+    expected_is_currency: [ false, false, false ]
+    expected_is_definitely_writable: [ false, false, false ]
+    expected_is_nullable: [ columnNoNulls, columnNoNulls, columnNoNulls ]
+    expected_is_read_only: [ true, true, true ]
+    expected_is_searchable: [ true, true, true ]
+    expected_is_signed: [ true, false, false ]
+    expected_is_writable: [ false, false, false ]
+
   - description: inner_join
     db: integration_test
     sql: "SELECT class.name, grades.testid, grades.score FROM grades INNER JOIN class ON grades.studentid\
@@ -284,6 +314,7 @@ tests:
     expected_result:
       - [1, 2, 3, 4, 5, 6, 7, 8, 9]
     row_count: 1
+    duplicated_columns_names: [_id, a]
     expected_sql_type: [INTEGER, INTEGER, INTEGER, INTEGER, INTEGER, INTEGER, INTEGER,
                         INTEGER, INTEGER]
     expected_bson_type: [int, int, int, int, int, int, int, int, int]

--- a/src/integration-test/java/com/mongodb/jdbc/integration/testharness/DataLoader.java
+++ b/src/integration-test/java/com/mongodb/jdbc/integration/testharness/DataLoader.java
@@ -44,8 +44,11 @@ import org.bson.BsonDocument;
 import org.bson.BsonInt32;
 import org.bson.BsonString;
 import org.bson.Document;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
+import org.yaml.snakeyaml.inspector.TagInspector;
+import org.yaml.snakeyaml.nodes.Tag;
 
 public class DataLoader {
     public static final String TEST_DATA_DIRECTORY = "resources/integration_test/testdata";
@@ -57,7 +60,20 @@ public class DataLoader {
                     + ":"
                     + System.getenv("ADF_TEST_LOCAL_PWD")
                     + "@localhost";
-    private static Yaml yaml = new Yaml(new Constructor(TestData.class));
+    private static Yaml yaml;
+
+    static {
+        TagInspector allowGlobalTags =
+                new TagInspector() {
+                    @Override
+                    public boolean isGlobalTagAllowed(Tag tag) {
+                        return true;
+                    }
+                };
+        LoaderOptions loaderOptions = new LoaderOptions();
+        loaderOptions.setTagInspector(allowGlobalTags);
+        yaml = new Yaml(new Constructor(TestData.class, loaderOptions));
+    };
 
     private List<TestDataEntry> datasets;
     private Set<Pair<String, String>> collections;

--- a/src/integration-test/java/com/mongodb/jdbc/integration/testharness/models/TestEntry.java
+++ b/src/integration-test/java/com/mongodb/jdbc/integration/testharness/models/TestEntry.java
@@ -28,6 +28,7 @@ public class TestEntry {
     public Integer row_count;
     public Boolean row_count_gte;
     public Boolean ordered;
+    public List<String> duplicated_columns_names;
     public List<Object> expected_result;
     public List<Map<String, Object>> expected_result_extended_json;
     public List<String> expected_sql_type;

--- a/src/main/java/com/mongodb/jdbc/MongoResultSet.java
+++ b/src/main/java/com/mongodb/jdbc/MongoResultSet.java
@@ -205,12 +205,15 @@ public class MongoResultSet implements ResultSet {
     private BsonValue getBsonValue(String columnLabel) throws SQLException {
         int columnIndex;
         if (rsMetaData.hasColumnWithLabel(columnLabel)) {
-            columnIndex = rsMetaData.getColumnPositionFromLabel(columnLabel);
+            try {
+                columnIndex = rsMetaData.getColumnPositionFromLabel(columnLabel);
+                return getBsonValue(columnIndex + 1);
+            } catch (Exception e) {
+                throw new SQLException(e.getMessage());
+            }
         } else {
-
             throw new SQLException(String.format("column label '%s' not found", columnLabel));
         }
-        return getBsonValue(columnIndex + 1);
     }
 
     private void checkClosed() throws SQLException {
@@ -753,7 +756,11 @@ public class MongoResultSet implements ResultSet {
         if (!rsMetaData.hasColumnWithLabel(columnLabel)) {
             throw new SQLException("No such column: '" + columnLabel + "'.");
         }
-        return rsMetaData.getColumnPositionFromLabel(columnLabel) + 1;
+        try {
+            return rsMetaData.getColumnPositionFromLabel(columnLabel) + 1;
+        } catch (Exception e) {
+            throw new SQLException(e.getMessage());
+        }
     }
 
     // --------------------------JDBC 2.0-----------------------------------

--- a/src/main/java/com/mongodb/jdbc/MongoResultSetMetaData.java
+++ b/src/main/java/com/mongodb/jdbc/MongoResultSetMetaData.java
@@ -176,8 +176,10 @@ public class MongoResultSetMetaData implements ResultSetMetaData {
     protected String getDatasource(String columnLabel) throws Exception {
         List<DatasourceAndIndex> columnsForLabel = columnLabels.get(columnLabel);
         if (columnsForLabel.size() > 1) {
-throw new Exception(String.format(
-            "Multiple columns with the label '%s' exist. Use indexes to avoid ambiguity.", columnLabel));
+            throw new Exception(
+                    String.format(
+                            "Multiple columns with the label '%s' exist. Use indexes to avoid ambiguity.",
+                            columnLabel));
         } else {
             return columnsForLabel.get(0).datasource;
         }

--- a/src/main/java/com/mongodb/jdbc/MongoResultSetMetaData.java
+++ b/src/main/java/com/mongodb/jdbc/MongoResultSetMetaData.java
@@ -233,7 +233,9 @@ public class MongoResultSetMetaData implements ResultSetMetaData {
         List<DatasourceAndIndex> columnsForLabel = columnLabels.get(label);
         if (columnsForLabel.size() > 1) {
             throw new Exception(
-                    "Multiple columns with the same label exists. Please use indexes instead.");
+                    "Multiple columns with the label '"
+                            + label
+                            + "' exist. Use indexes to avoid ambiguity.");
         } else {
             return columnsForLabel.get(0).index;
         }

--- a/src/main/java/com/mongodb/jdbc/MongoResultSetMetaData.java
+++ b/src/main/java/com/mongodb/jdbc/MongoResultSetMetaData.java
@@ -176,8 +176,8 @@ public class MongoResultSetMetaData implements ResultSetMetaData {
     protected String getDatasource(String columnLabel) throws Exception {
         List<DatasourceAndIndex> columnsForLabel = columnLabels.get(columnLabel);
         if (columnsForLabel.size() > 1) {
-            throw new Exception(
-                    "Multiple columns with the same label exists. Please use indexes instead.");
+throw new Exception(String.format(
+            "Multiple columns with the label '%s' exist. Use indexes to avoid ambiguity.", columnLabel));
         } else {
             return columnsForLabel.get(0).datasource;
         }

--- a/src/test/java/com/mongodb/jdbc/MongoMock.java
+++ b/src/test/java/com/mongodb/jdbc/MongoMock.java
@@ -44,36 +44,44 @@ public abstract class MongoMock {
     protected static int DOUBLE_COL = 1;
     // __bot.binary
     protected static int BINARY_COL = 2;
+    // __bot.dup
+    protected static int BOT_DUP_COL = 3;
     // __bot.str
-    protected static int STRING_COL = 3;
+    protected static int STRING_COL = 4;
     // foo.a
-    protected static int ANY_OF_INT_STRING_COL = 4;
+    protected static int ANY_OF_INT_STRING_COL = 5;
     // foo.b
-    protected static int INT_OR_NULL_COL = 5;
+    protected static int INT_OR_NULL_COL = 6;
     // foo.c
-    protected static int INT_COL = 6;
+    protected static int INT_COL = 7;
     // foo.d
-    protected static int ANY_COL = 7;
+    protected static int ANY_COL = 8;
     // foo.doc
-    protected static int DOC_COL = 8;
+    protected static int DOC_COL = 9;
+    // foo.dup
+    protected static int FOO_DUP_COL = 10;
     // foo.null
-    protected static int NULL_COL = 9;
+    protected static int NULL_COL = 11;
     // foo.vec
-    protected static int ARRAY_COL = 10;
+    protected static int ARRAY_COL = 12;
 
     // __bot fields
     protected static String DOUBLE_COL_LABEL = "a";
     protected static String BINARY_COL_LABEL = "binary";
     protected static String STRING_COL_LABEL = "str";
 
+    protected static String BOT_DUP_COL_LABEL = "dup";
+
     // foo fields
-    protected static String ANY_OF_INT_STRING_COL_LABEL = "a";
+    protected static String ANY_OF_INT_STRING_COL_LABEL = "anyOfStrOrInt";
     protected static String INT_NULLABLE_COL_LABEL = "b";
     protected static String INT_COL_LABEL = "c";
     protected static String ANY_COL_LABEL = "d";
     protected static String DOC_COL_LABEL = "doc";
     protected static String NULL_COL_LABEL = "null";
     protected static String ARRAY_COL_LABEL = "vec";
+
+    protected static String FOO_DUP_COL_LABEL = "dup";
 
     // all.double
     protected static String ALL_DOUBLE_COL_LABEL = "double";
@@ -214,7 +222,7 @@ public abstract class MongoMock {
                         c: {
                             bsonType: int
                         },
-                        a: {
+                        anyOfStrOrInt: {
                             anyOf: [
                                 {bsonType: int},
                                 {bsonType: string},
@@ -244,9 +252,12 @@ public abstract class MongoMock {
                               }
                            },
                            required: [c]
-                        }
+                        },
+                        dup: {
+                            bsonType: int
+                       }
                     },
-                    required: [a, b, vec, doc],
+                    required: [anyOfStrOrInt, b, vec, doc, dup],
                 },
                 "": {
                    bsonType: object,
@@ -259,6 +270,9 @@ public abstract class MongoMock {
                        }
                        str: {
                            bsonType: string
+                       }
+                       dup: {
+                            bsonType: string
                        }
                    }
                 },
@@ -278,6 +292,7 @@ public abstract class MongoMock {
         fooSchema.required.add(INT_NULLABLE_COL_LABEL);
         fooSchema.required.add(ARRAY_COL_LABEL);
         fooSchema.required.add(DOC_COL_LABEL);
+        fooSchema.required.add(FOO_DUP_COL_LABEL);
 
         MongoJsonSchema aSchema = new MongoJsonSchema();
         aSchema.anyOf = new HashSet<MongoJsonSchema>();
@@ -308,6 +323,9 @@ public abstract class MongoMock {
         MongoJsonSchema nullSchema = new MongoJsonSchema();
         nullSchema.bsonType = "null";
 
+        MongoJsonSchema fooDupSchema = new MongoJsonSchema();
+        fooDupSchema.bsonType = "int";
+
         // For the doc schema, we reuse the foo.c INT field variables
         MongoJsonSchema docSchema = MongoJsonSchema.createEmptyObjectSchema();
         docSchema.required.add(INT_COL_LABEL);
@@ -322,6 +340,7 @@ public abstract class MongoMock {
         fooSchema.properties.put(ARRAY_COL_LABEL, vecSchema);
         fooSchema.properties.put(NULL_COL_LABEL, nullSchema);
         fooSchema.properties.put(DOC_COL_LABEL, docSchema);
+        fooSchema.properties.put(FOO_DUP_COL_LABEL, fooDupSchema);
 
         MongoJsonSchema botSchema = new MongoJsonSchema();
         botSchema.bsonType = "object";
@@ -335,6 +354,9 @@ public abstract class MongoMock {
         MongoJsonSchema strSchema = new MongoJsonSchema();
         strSchema.bsonType = "string";
         botSchema.properties.put("str", strSchema);
+        MongoJsonSchema botDupSchema = new MongoJsonSchema();
+        botDupSchema.bsonType = "string";
+        botSchema.properties.put(BOT_DUP_COL_LABEL, botDupSchema);
 
         schema.properties = new LinkedHashMap<String, MongoJsonSchema>();
         schema.properties.put("foo", fooSchema);
@@ -374,6 +396,7 @@ public abstract class MongoMock {
         foo.put(INT_COL_LABEL, new BsonInt32(2));
         foo.put(ANY_COL_LABEL, new BsonUndefined());
         foo.put(NULL_COL_LABEL, new BsonNull());
+        foo.put(FOO_DUP_COL_LABEL, new BsonInt32(8));
 
         BsonArray array = new BsonArray();
         array.add(new BsonInt32(1));
@@ -389,6 +412,7 @@ public abstract class MongoMock {
         byte binary[] = {10, 20, 30};
         bot.put(BINARY_COL_LABEL, new BsonBinary(binary));
         bot.put(STRING_COL_LABEL, new BsonString("a"));
+        bot.put(BOT_DUP_COL_LABEL, new BsonString("dupCol"));
 
         document.put("", bot);
         document.put("foo", foo);

--- a/src/test/java/com/mongodb/jdbc/MongoResultSetMetaDataTest.java
+++ b/src/test/java/com/mongodb/jdbc/MongoResultSetMetaDataTest.java
@@ -53,7 +53,7 @@ class MongoResultSetMetaDataTest extends MongoMock {
 
     @Test
     void testGetColumnCount() throws SQLException {
-        assertEquals(10, MongoResultSetMetaDataTest.resultSetMetaData.getColumnCount());
+        assertEquals(12, MongoResultSetMetaDataTest.resultSetMetaData.getColumnCount());
     }
 
     @Test
@@ -61,23 +61,65 @@ class MongoResultSetMetaDataTest extends MongoMock {
 
         // Verify that the columns are sorted alphabetically when the sortFieldsAlphabetically is true and that the original order is kept when it's false.
         String[] expected_sorted_columns =
-                new String[] {"a", "binary", "str", "a", "b", "c", "d", "doc", "null", "vec"};
+                new String[] {
+                    "a",
+                    "binary",
+                    "dup",
+                    "str",
+                    "anyOfStrOrInt",
+                    "b",
+                    "c",
+                    "d",
+                    "doc",
+                    "dup",
+                    "null",
+                    "vec"
+                };
         String[] expected_original_columns =
-                new String[] {"a", "binary", "str", "c", "a", "d", "b", "vec", "null", "doc"};
+                new String[] {
+                    "a",
+                    "binary",
+                    "str",
+                    "dup",
+                    "c",
+                    "anyOfStrOrInt",
+                    "d",
+                    "b",
+                    "vec",
+                    "null",
+                    "doc",
+                    "dup"
+                };
         String[] expected_select_order_columns =
-                new String[] {"binary", "str", "a", "b", "c", "d", "doc", "null", "vec", "a"};
+                new String[] {
+                    "binary",
+                    "anyOfStrOrInt",
+                    "b",
+                    "dup",
+                    "c",
+                    "d",
+                    "doc",
+                    "null",
+                    "vec",
+                    "a",
+                    "dup",
+                    "str"
+                };
         List<List<String>> selectOrder =
                 Arrays.asList(
                         Arrays.asList("", "binary"),
-                        Arrays.asList("", "str"),
-                        Arrays.asList("foo", "a"),
+                        Arrays.asList("foo", "anyOfStrOrInt"),
                         Arrays.asList("foo", "b"),
+                        Arrays.asList("foo", "dup"),
                         Arrays.asList("foo", "c"),
                         Arrays.asList("foo", "d"),
                         Arrays.asList("foo", "doc"),
                         Arrays.asList("foo", "null"),
                         Arrays.asList("foo", "vec"),
-                        Arrays.asList("", "a"));
+                        Arrays.asList("", "a"),
+                        Arrays.asList("", "dup"),
+                        Arrays.asList("", "str"));
+
         MongoJsonSchema schema = generateMongoJsonSchema();
         MongoResultSetMetaData unsortedMedata =
                 new MongoResultSetMetaData(schema, null, false, mongoConnection.getLogger(), 0);
@@ -132,6 +174,8 @@ class MongoResultSetMetaDataTest extends MongoMock {
         assertEquals(NULL_COL_LABEL, resultSetMetaData.getColumnName(NULL_COL));
         assertEquals(ARRAY_COL_LABEL, resultSetMetaData.getColumnName(ARRAY_COL));
         assertEquals(DOC_COL_LABEL, resultSetMetaData.getColumnName(DOC_COL));
+        assertEquals(BOT_DUP_COL_LABEL, resultSetMetaData.getColumnName(BOT_DUP_COL));
+        assertEquals(FOO_DUP_COL_LABEL, resultSetMetaData.getColumnName(FOO_DUP_COL));
     }
 
     @Test
@@ -147,12 +191,15 @@ class MongoResultSetMetaDataTest extends MongoMock {
         assertEquals(NULL_COL_LABEL, resultSetMetaData.getColumnName(NULL_COL));
         assertEquals(ARRAY_COL_LABEL, resultSetMetaData.getColumnLabel(ARRAY_COL));
         assertEquals(DOC_COL_LABEL, resultSetMetaData.getColumnLabel(DOC_COL));
+        assertEquals(BOT_DUP_COL_LABEL, resultSetMetaData.getColumnName(BOT_DUP_COL));
+        assertEquals(FOO_DUP_COL_LABEL, resultSetMetaData.getColumnName(FOO_DUP_COL));
     }
 
     @Test
     void testGetTableName() throws SQLException {
         assertEquals("", resultSetMetaData.getTableName(DOUBLE_COL));
         assertEquals("", resultSetMetaData.getTableName(STRING_COL));
+        assertEquals("", resultSetMetaData.getTableName(BOT_DUP_COL));
         assertEquals("foo", resultSetMetaData.getTableName(ANY_OF_INT_STRING_COL));
         assertEquals("foo", resultSetMetaData.getTableName(INT_OR_NULL_COL));
         assertEquals("foo", resultSetMetaData.getTableName(INT_COL));
@@ -160,6 +207,7 @@ class MongoResultSetMetaDataTest extends MongoMock {
         assertEquals("foo", resultSetMetaData.getTableName(NULL_COL));
         assertEquals("foo", resultSetMetaData.getTableName(ARRAY_COL));
         assertEquals("foo", resultSetMetaData.getTableName(DOC_COL));
+        assertEquals("foo", resultSetMetaData.getTableName(FOO_DUP_COL));
     }
 
     @Test
@@ -173,6 +221,8 @@ class MongoResultSetMetaDataTest extends MongoMock {
         assertEquals(false, resultSetMetaData.isCaseSensitive(NULL_COL));
         assertEquals(false, resultSetMetaData.isCaseSensitive(ARRAY_COL));
         assertEquals(false, resultSetMetaData.isCaseSensitive(DOC_COL));
+        assertEquals(true, resultSetMetaData.isCaseSensitive(BOT_DUP_COL));
+        assertEquals(false, resultSetMetaData.isCaseSensitive(FOO_DUP_COL));
     }
 
     @Test
@@ -189,6 +239,8 @@ class MongoResultSetMetaDataTest extends MongoMock {
         assertEquals(ResultSetMetaData.columnNullable, resultSetMetaData.isNullable(NULL_COL));
         assertEquals(ResultSetMetaData.columnNoNulls, resultSetMetaData.isNullable(ARRAY_COL));
         assertEquals(ResultSetMetaData.columnNoNulls, resultSetMetaData.isNullable(DOC_COL));
+        assertEquals(ResultSetMetaData.columnNullable, resultSetMetaData.isNullable(BOT_DUP_COL));
+        assertEquals(ResultSetMetaData.columnNoNulls, resultSetMetaData.isNullable(FOO_DUP_COL));
     }
 
     @Test
@@ -202,6 +254,8 @@ class MongoResultSetMetaDataTest extends MongoMock {
         assertEquals(false, resultSetMetaData.isSigned(NULL_COL));
         assertEquals(false, resultSetMetaData.isSigned(ARRAY_COL));
         assertEquals(false, resultSetMetaData.isSigned(DOC_COL));
+        assertEquals(false, resultSetMetaData.isSigned(BOT_DUP_COL));
+        assertEquals(true, resultSetMetaData.isSigned(FOO_DUP_COL));
     }
 
     @Test
@@ -215,6 +269,8 @@ class MongoResultSetMetaDataTest extends MongoMock {
         assertEquals(0, resultSetMetaData.getColumnDisplaySize(NULL_COL));
         assertEquals(0, resultSetMetaData.getColumnDisplaySize(ARRAY_COL));
         assertEquals(0, resultSetMetaData.getColumnDisplaySize(DOC_COL));
+        assertEquals(0, resultSetMetaData.getColumnDisplaySize(BOT_DUP_COL));
+        assertEquals(10, resultSetMetaData.getColumnDisplaySize(FOO_DUP_COL));
     }
 
     @Test
@@ -228,6 +284,8 @@ class MongoResultSetMetaDataTest extends MongoMock {
         assertEquals(0, resultSetMetaData.getPrecision(NULL_COL));
         assertEquals(0, resultSetMetaData.getPrecision(ARRAY_COL));
         assertEquals(0, resultSetMetaData.getPrecision(DOC_COL));
+        assertEquals(0, resultSetMetaData.getPrecision(BOT_DUP_COL));
+        assertEquals(10, resultSetMetaData.getPrecision(FOO_DUP_COL));
     }
 
     @Test
@@ -241,6 +299,8 @@ class MongoResultSetMetaDataTest extends MongoMock {
         assertEquals(0, resultSetMetaData.getScale(NULL_COL));
         assertEquals(0, resultSetMetaData.getScale(ARRAY_COL));
         assertEquals(0, resultSetMetaData.getScale(DOC_COL));
+        assertEquals(0, resultSetMetaData.getScale(BOT_DUP_COL));
+        assertEquals(0, resultSetMetaData.getScale(FOO_DUP_COL));
     }
 
     @Test
@@ -254,6 +314,8 @@ class MongoResultSetMetaDataTest extends MongoMock {
         assertEquals(Types.NULL, resultSetMetaData.getColumnType(NULL_COL));
         assertEquals(Types.OTHER, resultSetMetaData.getColumnType(ARRAY_COL));
         assertEquals(Types.OTHER, resultSetMetaData.getColumnType(DOC_COL));
+        assertEquals(Types.LONGVARCHAR, resultSetMetaData.getColumnType(BOT_DUP_COL));
+        assertEquals(Types.INTEGER, resultSetMetaData.getColumnType(FOO_DUP_COL));
     }
 
     @Test
@@ -269,6 +331,8 @@ class MongoResultSetMetaDataTest extends MongoMock {
         assertEquals(null, resultSetMetaData.getColumnClassName(NULL_COL));
         assertEquals(BsonValue.class.getName(), resultSetMetaData.getColumnClassName(ARRAY_COL));
         assertEquals(BsonValue.class.getName(), resultSetMetaData.getColumnClassName(DOC_COL));
+        assertEquals(String.class.getName(), resultSetMetaData.getColumnClassName(BOT_DUP_COL));
+        assertEquals(int.class.getName(), resultSetMetaData.getColumnClassName(FOO_DUP_COL));
     }
 
     @Test
@@ -282,11 +346,12 @@ class MongoResultSetMetaDataTest extends MongoMock {
         assertEquals("null", resultSetMetaData.getColumnTypeName(NULL_COL));
         assertEquals("array", resultSetMetaData.getColumnTypeName(ARRAY_COL));
         assertEquals("object", resultSetMetaData.getColumnTypeName(DOC_COL));
+        assertEquals("string", resultSetMetaData.getColumnTypeName(BOT_DUP_COL));
+        assertEquals("int", resultSetMetaData.getColumnTypeName(FOO_DUP_COL));
     }
 
     @Test
-    void testGetDatasource() throws SQLException {
-        // note, we cannot get foo.a using the label a.
+    void testGetDatasource() throws Exception {
         assertEquals("", resultSetMetaData.getDatasource(DOUBLE_COL_LABEL));
         assertEquals("", resultSetMetaData.getDatasource(STRING_COL_LABEL));
         assertEquals("foo", resultSetMetaData.getDatasource(INT_NULLABLE_COL_LABEL));
@@ -295,5 +360,8 @@ class MongoResultSetMetaDataTest extends MongoMock {
         assertEquals("foo", resultSetMetaData.getDatasource(NULL_COL_LABEL));
         assertEquals("foo", resultSetMetaData.getDatasource(ARRAY_COL_LABEL));
         assertEquals("foo", resultSetMetaData.getDatasource(DOC_COL_LABEL));
+        // Duplicated column names fail
+        assertThrows(Exception.class, () -> resultSetMetaData.getDatasource(FOO_DUP_COL_LABEL));
+        assertThrows(Exception.class, () -> resultSetMetaData.getDatasource(BOT_DUP_COL_LABEL));
     }
 }

--- a/src/test/java/com/mongodb/jdbc/MongoResultSetTest.java
+++ b/src/test/java/com/mongodb/jdbc/MongoResultSetTest.java
@@ -299,6 +299,8 @@ class MongoResultSetTest extends MongoMock {
         assertEquals(ANY_COL, mongoResultSet.findColumn(ANY_COL_LABEL));
         assertEquals(ARRAY_COL, mongoResultSet.findColumn(ARRAY_COL_LABEL));
         assertEquals(DOC_COL, mongoResultSet.findColumn(DOC_COL_LABEL));
+        assertThrows(SQLException.class, () -> mongoResultSet.findColumn(BOT_DUP_COL_LABEL));
+        assertThrows(SQLException.class, () -> mongoResultSet.findColumn(FOO_DUP_COL_LABEL));
 
         // Test that the IDX and LABELS are working together correctly.
         assertEquals(
@@ -1124,7 +1126,7 @@ class MongoResultSetTest extends MongoMock {
         // For empty result set, isFirst should always be false
         assertFalse(mockResultSet.isFirst());
         assertTrue(mockResultSet.isLast());
-        assertEquals(10, mockResultSet.getMetaData().getColumnCount());
+        assertEquals(12, mockResultSet.getMetaData().getColumnCount());
         assertFalse(mockResultSet.next());
         // query value for existing column in empty result should result to exception
         assertThrows(
@@ -1151,7 +1153,7 @@ class MongoResultSetTest extends MongoMock {
 
         mockResultSet = new MongoResultSet(mongoStatement, cursor, schema, null, false);
 
-        assertEquals(10, mockResultSet.getMetaData().getColumnCount());
+        assertEquals(12, mockResultSet.getMetaData().getColumnCount());
         assertFalse(mockResultSet.isFirst());
         assertTrue(mockResultSet.isLast());
         assertFalse(mockResultSet.next());

--- a/src/test/java/com/mongodb/jdbc/MongoStatementTest.java
+++ b/src/test/java/com/mongodb/jdbc/MongoStatementTest.java
@@ -103,7 +103,7 @@ class MongoStatementTest extends MongoMock {
 
         ResultSet rs = mongoStatement.executeQuery("select * from foo");
         ResultSetMetaData metaData = rs.getMetaData();
-        assertEquals(10, metaData.getColumnCount());
+        assertEquals(12, metaData.getColumnCount());
 
         rs.next();
         assertThrows(
@@ -137,7 +137,7 @@ class MongoStatementTest extends MongoMock {
 
         ResultSet rs = mongoStatement.executeQuery("select * from foo");
         ResultSetMetaData metaData = rs.getMetaData();
-        assertEquals(10, metaData.getColumnCount());
+        assertEquals(12, metaData.getColumnCount());
         // need to call next() first
         assertThrows(
                 SQLException.class,
@@ -147,7 +147,7 @@ class MongoStatementTest extends MongoMock {
 
         assertTrue(rs.next());
         assertEquals(1, rs.getInt(1));
-        assertEquals("a", rs.getString(3));
+        assertEquals("a", rs.getString(4));
         assertFalse(rs.next());
         assertTrue(rs.isLast());
     }


### PR DESCRIPTION
In order to not break the existing behavior (and to match MySQL and Postgres), I did not rename the columns. 
Instead, the driver will fail retrieving information by column name if there is more than one column with the requested name.