### PR TITLE
MHOUSE-10606: Upgrade to go1.22

### DIFF
--- a/resources/run_adf.sh
+++ b/resources/run_adf.sh
@@ -24,7 +24,7 @@ if [[ -z $ARG ]]; then
   exit 0
 fi
 
-GO_VERSION="go1.20"
+GO_VERSION="go1.22"
 if [ -d "/opt/golang/$GO_VERSION" ]; then
   GOROOT="/opt/golang/$GO_VERSION"
   GOBINDIR="$GOROOT"/bin


### PR DESCRIPTION
In order to upgrade mongohouse to `go1.22`, its dependencies must also be upgraded to 1.22. In this PR, I'm upgrading the go vesrion from 1.20 -> 1.22. Both versions exist in the evergreen toolchain so no concerns about unavailability there.