### PR TITLE
SQL-1953: Fix the build script to update the json feed correctly

### DIFF
--- a/.evg.yml
+++ b/.evg.yml
@@ -159,7 +159,9 @@ functions:
           ARTIFACTS_DIR=artifacts
           S3_ARTIFACTS_DIR='mongo-jdbc-driver/artifacts/${version_id}/${build_variant}'
 
-          # get the version from the gradle.properties file, so we don't need to update in two places.
+          # Get the version from trigger.
+          # Tag triggered runs are releases and the version is set in the tag.
+          # Other runs are snapshot builds (periodic builds or patches)
           if [[ "${triggered_by_git_tag}" != "" ]]; then
             export MDBJDBC_VER=$(echo ${triggered_by_git_tag} | sed s/v//)
           else

--- a/.evg.yml
+++ b/.evg.yml
@@ -90,6 +90,7 @@ functions:
     command: shell.exec
     type: test
     params:
+      shell: bash
       working_dir: mongo-jdbc-driver
       script: |
           ${PREPARE_SHELL}
@@ -99,6 +100,7 @@ functions:
     command: shell.exec
     type: test
     params:
+      shell: bash
       working_dir: mongo-jdbc-driver
       script: |
           ${PREPARE_SHELL}
@@ -108,6 +110,7 @@ functions:
     command: shell.exec
     type: test
     params:
+      shell: bash
       working_dir: mongo-jdbc-driver
       script: |
           ${PREPARE_SHELL}
@@ -117,6 +120,7 @@ functions:
     command: shell.exec
     type: test
     params:
+      shell: bash
       working_dir: mongo-jdbc-driver
       script: |
           ${PREPARE_SHELL}
@@ -131,6 +135,7 @@ functions:
     command: shell.exec
     type: test
     params:
+      shell: bash
       working_dir: mongo-jdbc-driver
       script: |
         ${PREPARE_SHELL}
@@ -145,6 +150,7 @@ functions:
   "export variables":
     - command: shell.exec
       params:
+        shell: bash
         silent: true
         working_dir: mongo-jdbc-driver
         script: |
@@ -214,6 +220,7 @@ functions:
   "fetch source":
     - command: shell.exec
       params:
+        shell: bash
         silent: true
         script: |
           rm -rf mongo-jdbc-driver
@@ -390,6 +397,7 @@ functions:
     - command: shell.exec
       type: test
       params:
+        shell: bash
         silent: true
         working_dir: mongo-jdbc-driver
         script: |

--- a/.evg.yml
+++ b/.evg.yml
@@ -120,7 +120,6 @@ functions:
     command: shell.exec
     type: test
     params:
-      shell: bash
       working_dir: mongo-jdbc-driver
       script: |
           ${PREPARE_SHELL}
@@ -135,7 +134,6 @@ functions:
     command: shell.exec
     type: test
     params:
-      shell: bash
       working_dir: mongo-jdbc-driver
       script: |
         ${PREPARE_SHELL}


### PR DESCRIPTION
The issue was that the shell type was not specified on the Evergreen task and we used a specific Bash syntax.

Here is a task which I ran in a debug branch with the tag debug0.0.0 which work:
https://spruce.mongodb.com/task/mongo_jdbc_driver_test_version_from_tag_release_release_smoke__debug0.0.0_24_04_11_23_36_00/logs?execution=0
