### PR TITLE
SQL-1941: Add doRefresh for OIDC authentication

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -160,6 +160,11 @@ task runAuthFlow(type: JavaExec) {
     main = 'com.mongodb.jdbc.oidc.TestOidcAuthFlow'
 }
 
+task runAuthFlowAndRefresh(type: JavaExec) {
+    classpath = sourceSets.main.runtimeClasspath
+    main = 'com.mongodb.jdbc.oidc.TestOidcAuthFlowAndRefresh'
+}
+
 jar {
     manifest {
         attributes('Implementation-Title': project.name,

--- a/src/main/java/com/mongodb/jdbc/oidc/OidcAuthFlow.java
+++ b/src/main/java/com/mongodb/jdbc/oidc/OidcAuthFlow.java
@@ -18,13 +18,13 @@ package com.mongodb.jdbc.oidc;
 
 import com.mongodb.jdbc.logging.MongoLogger;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
-import com.nimbusds.oauth2.sdk.ParseException;
-import com.nimbusds.oauth2.sdk.RefreshTokenGrant;
-import com.nimbusds.oauth2.sdk.TokenErrorResponse;
 import com.nimbusds.oauth2.sdk.AuthorizationCodeGrant;
 import com.nimbusds.oauth2.sdk.AuthorizationRequest;
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.RefreshTokenGrant;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.Scope;
+import com.nimbusds.oauth2.sdk.TokenErrorResponse;
 import com.nimbusds.oauth2.sdk.TokenRequest;
 import com.nimbusds.oauth2.sdk.TokenResponse;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
@@ -247,11 +247,11 @@ public class OidcAuthFlow {
             return false;
         }
         if (clientID == null || clientID.isEmpty()) {
-            log(Level.SEVERE,"Client ID is null or empty");
+            log(Level.SEVERE, "Client ID is null or empty");
             return false;
         }
         if (!issuerURI.startsWith("https")) {
-            log(Level.SEVERE,"Issuer URI must be HTTPS");
+            log(Level.SEVERE, "Issuer URI must be HTTPS");
             return false;
         }
         return true;


### PR DESCRIPTION
This can be run using:
```
./gradlew  runAuthFlowAndRefresh
```

The actual `doRefresh` logic to be reviewed is in[ this commit](https://github.com/mongodb/mongo-jdbc-driver/commit/c3db95fb6c8138f8fe221ebc3b9d5b0f6b21d3e6).  The other functionality for `doAuthCodeFlow()` is in another PR SQL-1940. 

I'll update the branch it is based on to master when SQL-1940 is merged.  

