### PR TITLE
SQL-2049: Make all commit related logic no-op and report auto-commit = true instead of false.

### DIFF
--- a/src/main/java/com/mongodb/jdbc/MongoConnection.java
+++ b/src/main/java/com/mongodb/jdbc/MongoConnection.java
@@ -227,7 +227,7 @@ public class MongoConnection implements Connection {
         checkConnection();
         logger.log(
                 Level.WARNING,
-                "Changing the auto-commit mode has no effect. The driver doesn't support transactions and is read-only."
+                "Changing the auto-commit mode has no effect. The driver doesn't support transactions and is read-only. "
                         + "It will always report auto-commit true. Calling Commit() or Rollback() also has no effect");
     }
 

--- a/src/main/java/com/mongodb/jdbc/MongoConnection.java
+++ b/src/main/java/com/mongodb/jdbc/MongoConnection.java
@@ -223,26 +223,31 @@ public class MongoConnection implements Connection {
 
     @Override
     public void setAutoCommit(boolean autoCommit) throws SQLException {
+        // no-op, we only check that the connection is open
         checkConnection();
-        if (autoCommit) {
-            throw new SQLFeatureNotSupportedException(
-                    Thread.currentThread().getStackTrace()[1].toString());
-        }
+        logger.log(
+                Level.WARNING,
+                "Changing the auto-commit mode has no effect. The driver doesn't support transactions and is read-only."
+                        + "It will always report auto-commit true. Calling Commit() or Rollback() also has no effect");
     }
 
     @Override
     public boolean getAutoCommit() throws SQLException {
         checkConnection();
-        return false;
+        // By default, new connections are in auto-commit mode
+        // and since we don't support transactions, changing the auto-commit mode is a no-op
+        return true;
     }
 
     @Override
     public void commit() throws SQLException {
+        // no-op, we only check that the connection is open
         checkConnection();
     }
 
     @Override
     public void rollback() throws SQLException {
+        // no-op, we only check that the connection is open
         checkConnection();
     }
 

--- a/src/test/java/com/mongodb/jdbc/MongoConnectionTest.java
+++ b/src/test/java/com/mongodb/jdbc/MongoConnectionTest.java
@@ -89,9 +89,13 @@ class MongoConnectionTest extends MongoMock {
     }
 
     @Test
-    void testSetAutoCommit() {
-        testNoop(() -> mongoConnection.setAutoCommit(false));
+    void testSetAutoCommitTrue() {
         testNoop(() -> mongoConnection.setAutoCommit(true));
+    }
+
+    @Test
+    void testSetAutoCommitFalse() {
+        testNoop(() -> mongoConnection.setAutoCommit(false));
     }
 
     @Test

--- a/src/test/java/com/mongodb/jdbc/MongoConnectionTest.java
+++ b/src/test/java/com/mongodb/jdbc/MongoConnectionTest.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.*;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Savepoint;
 import java.sql.Statement;
 import org.junit.jupiter.api.BeforeAll;
@@ -91,14 +90,13 @@ class MongoConnectionTest extends MongoMock {
 
     @Test
     void testSetAutoCommit() {
-        assertThrows(
-                SQLFeatureNotSupportedException.class, () -> mongoConnection.setAutoCommit(true));
         testNoop(() -> mongoConnection.setAutoCommit(false));
+        testNoop(() -> mongoConnection.setAutoCommit(true));
     }
 
     @Test
     void testGetAutoCommit() throws SQLException {
-        assertFalse(mongoConnection.getAutoCommit());
+        assertTrue(mongoConnection.getAutoCommit());
     }
 
     @Test


### PR DESCRIPTION
I tested with an older version of DBeaver and a newer version.
The driver works with both versions with this change. It fails as described when using an older driver with the newer DBeaver.