### PR TITLE
SQL-2063: Update run-adf script to use updated config with CRM

### DIFF
--- a/resources/run_adf.sh
+++ b/resources/run_adf.sh
@@ -416,7 +416,7 @@ if [ $ARG = $START ]; then
     mkdir -p $LOGS_PATH
     # Start mongohoused with appropriate config
     $GO run -tags mongosql ./cmd/mongohoused/mongohoused.go \
-      --config ./testdata/config/inline_local/frontend-agent-backend.yaml >> $LOGS_PATH/${MONGOHOUSED}.log &
+      --config ./testdata/config/inline_local/frontend-agent-backend-crm.yaml >> $LOGS_PATH/${MONGOHOUSED}.log &
     echo $! > $TMP_DIR/${MONGOHOUSED}.pid
 
     waitCounter=0


### PR DESCRIPTION
Adding in logic to mongohouse to route queries using the resource manager is causing the test `TestJDBCMongoSQL` to fail ([see patch here](https://spruce.mongodb.com/task/mongohouse_amazon2_test_e2e_mongosqljdbc_patch_9283efb893e5d345655761a64665f40c3c35b9e2_662a6fc68c3dfe0007a208a2_24_04_25_14_59_24?execution=0&sortBy=STATUS&sortDir=ASC)). Nothing evident from logs why it's failing but I'm fairly confident it's because we need to update the config used to run adf from [`frontend-agent-backend.yaml`](https://github.com/10gen/mongohouse/blob/master/testdata/config/inline_local/frontend-agent-backend.yaml) to [`frontend-agent-backend-crm.yaml`](https://github.com/10gen/mongohouse/blob/master/testdata/config/inline_local/frontend-agent-backend-crm.yaml). The configs are the same, except the latter adds in additional query scheduler and resource manager fields so this cause shouldn't cause any problems.

Is there any testing I should do?