### PR TITLE
MHOUSE-11099: Update `run-adf.sh` inline local adf config name

### DIFF
--- a/resources/run_adf.sh
+++ b/resources/run_adf.sh
@@ -416,7 +416,7 @@ if [ $ARG = $START ]; then
     mkdir -p $LOGS_PATH
     # Start mongohoused with appropriate config
     $GO run -tags mongosql ./cmd/mongohoused/mongohoused.go \
-      --config ./testdata/config/inline_local/frontend-agent-backend-crm.yaml >> $LOGS_PATH/${MONGOHOUSED}.log &
+      --config ./testdata/config/inline_local/frontend-agent-backend-resource-manager.yaml >> $LOGS_PATH/${MONGOHOUSED}.log &
     echo $! > $TMP_DIR/${MONGOHOUSED}.pid
 
     waitCounter=0


### PR DESCRIPTION
We're changing references to  the resource manager in ADF from acronyms `CRM`/`RM` to the full name, see [MHOUSE-11099](https://github.com/10gen/mongohouse/pull/9795). This includes config names so the referenced inline local file used by the SQL team also needs to be updated. This is necessary until the work in [MHOUSE-11063](https://jira.mongodb.org/browse/MHOUSE-11063) is done.