### PR TITLE
SQL-2105: Trace JDBC releases using the Papertrail service

### DIFF
--- a/.evg.yml
+++ b/.evg.yml
@@ -97,7 +97,7 @@ tasks:
   - name: trace-artifacts
     git_tag_only: true
     depends_on:
-      - name: "download-center-update"
+      - name: "publish-maven"
         variant: "release"
     commands:
       - func: "trace artifacts"

--- a/.evg.yml
+++ b/.evg.yml
@@ -52,6 +52,7 @@ buildvariants:
       - name: "test-smoke"
       - name: "publish-maven"
       - name: "download-center-update"
+      - name: "trace-artifacts"
 
 tasks:
   - name: "build"
@@ -89,6 +90,14 @@ tasks:
         variant: "release"
     commands:
       - func: "update download center feed"
+
+  - name: trace-artifacts
+    git_tag_only: true
+    depends_on:
+      - name: "download-center-update"
+        variant: "release"
+    commands:
+      - func: "trace artifacts"
 
   - name: semgrep
     exec_timeout_secs: 3600 # 1h 
@@ -140,6 +149,17 @@ functions:
           EXITCODE=$?
           ./resources/run_adf.sh stop
           exit $EXITCODE
+
+  "trace artifacts":
+    command: papertrail.trace
+    params:
+      work_dir: mongo-jdbc-driver
+      key_id: ${papertrail_id}
+      secret_key: ${papertrail_key}
+      product: mongo-jdbc-driver
+      version: ${MDBJDBC_VER}
+      filenames:
+        - "build/libs/*.jar"
 
   "run smoke test":
     command: shell.exec


### PR DESCRIPTION
Since the releases are created by gradle plugins, testing the tracing seems to be pretty complicated, so we've decided to skip the testing for now. At release time, we will adjust/fix if necessary. 