### PR TITLE
SQL-2098: Integrate JDBC vulnerability scanning (Silk)

### DIFF
--- a/.evg.yml
+++ b/.evg.yml
@@ -143,7 +143,7 @@ functions:
           SILK_CLIENT_SECRET=${SILK_CLIENT_SECRET}
           EOF
 
-          ls -lrt artifacts/ssdlc/
+          ls -lrt $SSDLC_DIR
 
           echo "SBOM_LITE_NAME = $SBOM_LITE_NAME"
 
@@ -183,7 +183,7 @@ functions:
           download --silk-asset-group ${SILK_ASSET_GROUP} --sbom-out /pwd/artifacts/ssdlc/$AUGMENTED_SBOM_NAME
           echo "-------------------------------"
 
-          ls -lrt artifacts/ssdlc/
+          ls -lrt $SSDLC_DIR
     - command: s3.put
       params:
         aws_key: ${AWS_ACCESS_KEY_ID}

--- a/.evg.yml
+++ b/.evg.yml
@@ -419,6 +419,7 @@ functions:
           export SBOM_LITE_NAME="mongo-jdbc-driver.cdx.json"
           export AUGMENTED_SBOM_NAME="mongo-jdbc-driver.augmented.sbom.json"
           export SSDLC_DIR="$ARTIFACTS_DIR/ssdlc"
+          mkdir -p $SSDLC_DIR
 
           # create expansions from values calculated above
           mkdir -p $ARTIFACTS_DIR
@@ -429,7 +430,6 @@ functions:
           SBOM_LITE_NAME: "$SBOM_LITE_NAME"
           AUGMENTED_SBOM_NAME: "$AUGMENTED_SBOM_NAME"
           SSDLC_DIR: "$SSDLC_DIR"
-          mkdir -p "$SSDLC_DIR"
           PREPARE_SHELL: |
             export ADF_TEST_LOCAL_USER=${adf_test_local_user}
             export ADF_TEST_LOCAL_PWD=${adf_test_local_pwd}

--- a/.evg.yml
+++ b/.evg.yml
@@ -55,6 +55,7 @@ buildvariants:
     tasks:
       - name: "test-smoke"
       - name: "publish-maven"
+      - name: "ssdlc-artifacts-release"
       - name: "download-center-update"
 
 tasks:

--- a/.evg.yml
+++ b/.evg.yml
@@ -429,7 +429,7 @@ functions:
           SBOM_LITE_NAME: "$SBOM_LITE_NAME"
           AUGMENTED_SBOM_NAME: "$AUGMENTED_SBOM_NAME"
           SSDLC_DIR: "$SSDLC_DIR"
-          mkdir -p $SSDLC_DIR
+          mkdir -p "$SSDLC_DIR"
           PREPARE_SHELL: |
             export ADF_TEST_LOCAL_USER=${adf_test_local_user}
             export ADF_TEST_LOCAL_PWD=${adf_test_local_pwd}

--- a/.evg.yml
+++ b/.evg.yml
@@ -35,6 +35,7 @@ buildvariants:
     tasks:
       - name: semgrep
       - name: sbom
+      - name: ssdlc-artifacts-snapshot
 
   - name: ubuntu2204-64-jdk-8
     display_name: Ubuntu 22.04 jdk-8
@@ -55,8 +56,7 @@ buildvariants:
       - name: "test-smoke"
       - name: "publish-maven"
       - name: "download-center-update"
-      - name: "ssdlc-artifacts"
-      - name: "publish-augmented-sbom"
+      - name: "ssdlc-artifacts-release"
       - name: "trace-artifacts"
 
 tasks:
@@ -117,23 +117,23 @@ tasks:
       - func: "pull augmented SBOM from Silk"
       - func: "scan sbom"
 
-  - name: ssdlc-artifacts
-    run_on: ubuntu2204-small
-    depends_on:
-      - name: sbom
-        variant: code-quality-and-correctness
-    exec_timeout_secs: 300 # 5m
-    commands:
-      - func: "pull augmented SBOM from Silk"
-
-  - name: publish-augmented-sbom
+  - name: ssdlc-artifacts-release
     run_on: ubuntu2204-small
     git_tag_only: true
     depends_on:
       - name: "publish-maven"
         variant: "release"
-      - name: ssdlc-artifacts
-        variant: "release"
+      - name: sbom
+        variant: code-quality-and-correctness
+    exec_timeout_secs: 300 # 5m
+    commands:
+      - func: "publish augmented SBOM"
+
+  - name: ssdlc-artifacts-snapshot
+    run_on: ubuntu2204-small
+    depends_on:
+      - name: sbom
+        variant: code-quality-and-correctness
     exec_timeout_secs: 300 # 5m
     commands:
       - func: "publish augmented SBOM"
@@ -175,9 +175,6 @@ functions:
         working_dir: mongo-jdbc-driver
         script: |
           ${PREPARE_SHELL}
-          
-          mkdir -p $SSDLC_DIR
-
           cat << EOF > silkbomb.env
           SILK_CLIENT_ID=${SILK_CLIENT_ID}
           SILK_CLIENT_SECRET=${SILK_CLIENT_SECRET}
@@ -240,7 +237,6 @@ functions:
           set -o errexit
           
           mkdir -p $SBOM_TOOL_DIR
-          mkdir -p $SSDLC_DIR
           
           echo "------------------------------------"
           echo "Generating SBOM"
@@ -422,6 +418,7 @@ functions:
 
           export SBOM_LITE_NAME="mongo-jdbc-driver.cdx.json"
           export AUGMENTED_SBOM_NAME="mongo-jdbc-driver.augmented.sbom.json"
+          export SSDLC_DIR="$ARTIFACTS_DIR/ssdlc"
 
           # create expansions from values calculated above
           mkdir -p $ARTIFACTS_DIR
@@ -431,6 +428,8 @@ functions:
           JAVA_HOME: "$JAVA_HOME"
           SBOM_LITE_NAME: "$SBOM_LITE_NAME"
           AUGMENTED_SBOM_NAME: "$AUGMENTED_SBOM_NAME"
+          SSDLC_DIR: "$SSDLC_DIR"
+          mkdir -p $SSDLC_DIR
           PREPARE_SHELL: |
             export ADF_TEST_LOCAL_USER=${adf_test_local_user}
             export ADF_TEST_LOCAL_PWD=${adf_test_local_pwd}
@@ -449,7 +448,7 @@ functions:
             export SBOM_TOOL_DIR="sbom_generations"
             export SBOM_LITE_NAME="$SBOM_LITE_NAME"
             export AUGMENTED_SBOM_NAME="$AUGMENTED_SBOM_NAME"
-            export SSDLC_DIR="$ARTIFACTS_DIR/ssdlc"
+            export SSDLC_DIR="$SSDLC_DIR"
             export SBOM_LITE="$ARTIFACTS_DIR/ssdlc/$SBOM_LITE_NAME"
           
           EOT

--- a/.evg.yml
+++ b/.evg.yml
@@ -56,6 +56,7 @@ buildvariants:
       - name: "publish-maven"
       - name: "download-center-update"
       - name: "ssdlc-artifacts"
+      - name: "publish-augmented-sbom"
       - name: "trace-artifacts"
 
 tasks:
@@ -113,6 +114,7 @@ tasks:
       - func: "generate sbom"
       - func: "upload sbom"
       - func: "push SBOM Lite to Silk"
+      - func: "pull augmented SBOM from Silk"
       - func: "scan sbom"
 
   - name: ssdlc-artifacts
@@ -123,23 +125,21 @@ tasks:
     exec_timeout_secs: 300 # 5m
     commands:
       - func: "pull augmented SBOM from Silk"
+
+  - name: publish-augmented-sbom
+    run_on: ubuntu2204-small
+    git_tag_only: true
+    depends_on:
+      - name: "publish-maven"
+        variant: "release"
+      - name: ssdlc-artifacts
+        variant: "release"
+    exec_timeout_secs: 300 # 5m
+    commands:
       - func: "publish augmented SBOM"
 
 functions:
   "push SBOM Lite to Silk":
-    - command: ec2.assume_role
-      params:
-        role_arn: ${assume_role_arn}
-        duration_seconds: 3600
-    - command: s3.get
-      params:
-        aws_key: ${AWS_ACCESS_KEY_ID}
-        aws_secret: ${AWS_SECRET_ACCESS_KEY}
-        aws_session_token: ${AWS_SESSION_TOKEN}
-        local_file: artifacts/ssdlc/${SBOM_LITE_NAME}
-        remote_file: artifacts/${version_id}/ssdlc/${SBOM_LITE_NAME}
-        content_type: application/json
-        bucket: evg-bucket-mongo-jdbc-driver
     - command: shell.exec
       type: test
       params:
@@ -220,13 +220,12 @@ functions:
         bucket: evg-bucket-mongo-jdbc-driver
     - command: s3.put
       params:
-        aws_key: ${AWS_ACCESS_KEY_ID}
-        aws_secret: ${AWS_SECRET_ACCESS_KEY}
-        aws_session_token: ${AWS_SESSION_TOKEN}
+        aws_key: ${release_aws_key}
+        aws_secret: ${release_aws_secret}
         local_file: artifacts/ssdlc/mongodb-jdbc-${MDBJDBC_VER}.sbom.json
-        remote_file: mongodb-jdbc/v2/mongodb-jdbc-${MDBJDBC_VER}.sbom.json
+        remote_file: mongodb-jdbc/mongodb-jdbc-${MDBJDBC_VER}.sbom.json
         content_type: application/json
-        bucket: evg-bucket-mongo-jdbc-driver
+        bucket: translators-connectors-releases
         permissions: public-read
         display_name: mongodb-jdbc-${MDBJDBC_VER}.sbom.json
 
@@ -287,7 +286,7 @@ functions:
         aws_secret: ${AWS_SECRET_ACCESS_KEY}
         aws_session_token: ${AWS_SESSION_TOKEN}
         local_files_include_filter:
-          - mongo-jdbc-driver.cdx.json
+          - ${SBOM_LITE_NAME}
         remote_file: artifacts/${version_id}/ssdlc/
         content_type: application/json
         bucket: evg-bucket-mongo-jdbc-driver

--- a/.evg.yml
+++ b/.evg.yml
@@ -55,6 +55,7 @@ buildvariants:
       - name: "test-smoke"
       - name: "publish-maven"
       - name: "download-center-update"
+      - name: "ssdlc-artifacts"
 
 tasks:
   - name: "build"
@@ -102,9 +103,124 @@ tasks:
     commands:
       - func: "generate sbom"
       - func: "upload sbom"
+      - func: "push SBOM Lite to Silk"
       - func: "scan sbom"
 
+  - name: ssdlc-artifacts
+    run_on: ubuntu2204-small
+    depends_on:
+      - name: sbom
+        variant: code-quality-and-correctness
+    exec_timeout_secs: 300 # 5m
+    commands:
+      - func: "pull augmented SBOM from Silk"
+      - func: "publish augmented SBOM"
+
 functions:
+  "push SBOM Lite to Silk":
+    - command: ec2.assume_role
+      params:
+        role_arn: ${assume_role_arn}
+        duration_seconds: 3600
+    - command: s3.get
+      params:
+        aws_key: ${AWS_ACCESS_KEY_ID}
+        aws_secret: ${AWS_SECRET_ACCESS_KEY}
+        aws_session_token: ${AWS_SESSION_TOKEN}
+        local_file: artifacts/ssdlc/${SBOM_LITE_NAME}
+        remote_file: artifacts/${version_id}/ssdlc/${SBOM_LITE_NAME}
+        content_type: application/json
+        bucket: evg-bucket-mongo-jdbc-driver
+    - command: shell.exec
+      type: test
+      params:
+        shell: bash
+        working_dir: mongo-jdbc-driver
+        script: |
+          ${PREPARE_SHELL}
+          cat << EOF > silkbomb.env
+          SILK_CLIENT_ID=${SILK_CLIENT_ID}
+          SILK_CLIENT_SECRET=${SILK_CLIENT_SECRET}
+          EOF
+
+          ls -lrt artifacts/ssdlc/
+
+          echo "SBOM_LITE_NAME = $SBOM_LITE_NAME"
+
+          echo "-- Uploading initial SBOM Lite to Silk --"
+          docker run -i --platform="linux/amd64" --rm -v "$PWD":/pwd \
+          --env-file silkbomb.env \
+          artifactory.corp.mongodb.com/release-tools-container-registry-public-local/silkbomb:1.0 \
+          upload --silk-asset-group ${SILK_ASSET_GROUP} --sbom-in /pwd/artifacts/ssdlc/$SBOM_LITE_NAME
+          echo "-------------------------------"
+
+  "pull augmented SBOM from Silk":
+    - command: ec2.assume_role
+      params:
+        role_arn: ${assume_role_arn}
+        duration_seconds: 3600
+    - command: shell.exec
+      type: test
+      params:
+        shell: bash
+        working_dir: mongo-jdbc-driver
+        script: |
+          ${PREPARE_SHELL}
+          
+          mkdir -p $SSDLC_DIR
+
+          cat << EOF > silkbomb.env
+          SILK_CLIENT_ID=${SILK_CLIENT_ID}
+          SILK_CLIENT_SECRET=${SILK_CLIENT_SECRET}
+          EOF
+
+          echo "AUGMENTED_SBOM_NAME = $AUGMENTED_SBOM_NAME"
+
+          echo "-- Downloading augmented SBOM --"
+          docker run -i --platform="linux/amd64" --rm -v "$PWD":/pwd \
+          --env-file silkbomb.env \
+          artifactory.corp.mongodb.com/release-tools-container-registry-public-local/silkbomb:1.0 \
+          download --silk-asset-group ${SILK_ASSET_GROUP} --sbom-out /pwd/artifacts/ssdlc/$AUGMENTED_SBOM_NAME
+          echo "-------------------------------"
+
+          ls -lrt artifacts/ssdlc/
+    - command: s3.put
+      params:
+        aws_key: ${AWS_ACCESS_KEY_ID}
+        aws_secret: ${AWS_SECRET_ACCESS_KEY}
+        aws_session_token: ${AWS_SESSION_TOKEN}
+        local_file: mongo-jdbc-driver/artifacts/ssdlc/${AUGMENTED_SBOM_NAME}
+        remote_file: artifacts/${version_id}/ssdlc/${AUGMENTED_SBOM_NAME}
+        content_type: application/json
+        bucket: evg-bucket-mongo-jdbc-driver
+        permissions: public-read
+
+  "publish augmented SBOM":
+    - command: ec2.assume_role
+      params:
+        role_arn: ${assume_role_arn}
+        duration_seconds: 3600
+    - command: s3.get
+      params:
+        aws_key: ${AWS_ACCESS_KEY_ID}
+        aws_secret: ${AWS_SECRET_ACCESS_KEY}
+        aws_session_token: ${AWS_SESSION_TOKEN}
+        local_file: artifacts/ssdlc/mongodb-jdbc-${MDBJDBC_VER}.sbom.json
+        remote_file: artifacts/${version_id}/ssdlc/${AUGMENTED_SBOM_NAME}
+        content_type: application/json
+        bucket: evg-bucket-mongo-jdbc-driver
+    - command: s3.put
+      params:
+        aws_key: ${AWS_ACCESS_KEY_ID}
+        aws_secret: ${AWS_SECRET_ACCESS_KEY}
+        aws_session_token: ${AWS_SESSION_TOKEN}
+        local_file: artifacts/ssdlc/mongodb-jdbc-${MDBJDBC_VER}.sbom.json
+        remote_file: mongodb-jdbc/v2/mongodb-jdbc-${MDBJDBC_VER}.sbom.json
+        content_type: application/json
+        bucket: evg-bucket-mongo-jdbc-driver
+        permissions: public-read
+        display_name: mongodb-jdbc-${MDBJDBC_VER}.sbom.json
+
   "generate sbom":
     - command: shell.exec
       type: test
@@ -116,12 +232,12 @@ functions:
           set -o errexit
           
           mkdir -p $SBOM_TOOL_DIR
-          mkdir -p $SBOM_DIR
+          mkdir -p $SSDLC_DIR
           
           echo "------------------------------------"
           echo "Generating SBOM"
           echo "------------------------------------"
-          ./gradlew clean cyclonedxBom -PcyclonedxBomDestination=$SBOM_DIR -PcyclonedxBomName=sbom_without_team_name
+          ./gradlew clean cyclonedxBom -PcyclonedxBomDestination=$SSDLC_DIR -PcyclonedxBomName=sbom_without_team_name
     - command: shell.exec
       type: test
       params:
@@ -163,8 +279,8 @@ functions:
         aws_session_token: ${AWS_SESSION_TOKEN}
         local_files_include_filter:
           - mongo-jdbc-driver.cdx.json
-        remote_file: artifacts/${version_id}/${build_variant}/ssdlc/
-        content_type: text/plain
+        remote_file: artifacts/${version_id}/ssdlc/
+        content_type: application/json
         bucket: evg-bucket-mongo-jdbc-driver
         permissions: public-read
 
@@ -285,12 +401,17 @@ functions:
           # export any environment variables that will be needed by subprocesses
           export PROJECT_DIRECTORY="$(pwd)"
 
+          export SBOM_LITE_NAME="mongo-jdbc-driver.cdx.json"
+          export AUGMENTED_SBOM_NAME="mongo-jdbc-driver.augmented.sbom.json"
+
           # create expansions from values calculated above
           mkdir -p $ARTIFACTS_DIR
           cat <<EOT > $ARTIFACTS_DIR/expansions.yml
           S3_ARTIFACTS_DIR: "$S3_ARTIFACTS_DIR"
           MDBJDBC_VER: "$MDBJDBC_VER"
           JAVA_HOME: "$JAVA_HOME"
+          SBOM_LITE_NAME: "$SBOM_LITE_NAME"
+          AUGMENTED_SBOM_NAME: "$AUGMENTED_SBOM_NAME"
           PREPARE_SHELL: |
             export ADF_TEST_LOCAL_USER=${adf_test_local_user}
             export ADF_TEST_LOCAL_PWD=${adf_test_local_pwd}
@@ -305,10 +426,15 @@ functions:
             export MDBJDBC_VER=${MDBJDBC_VER}
           
             # sbom relevant variables
-            export SBOM_TOOL_DIR=sbom_generations
-            export SBOM_DIR=$ARTIFACTS_DIR/sboms
-            export SBOM_LITE=$ARTIFACTS_DIR/sboms/mongo-jdbc-driver.cdx.json
-            export SBOM_WITHOUT_TEAM_NAME=$ARTIFACTS_DIR/sboms/sbom_without_team_name.json
+            export SBOM_WITHOUT_TEAM_NAME=$ARTIFACTS_DIR/ssdlc/sbom_without_team_name.json
+          
+            # ssdlc relevant variables
+            export SBOM_TOOL_DIR="sbom_generations"
+            export SBOM_LITE_NAME="$SBOM_LITE_NAME"
+            export AUGMENTED_SBOM_NAME="$AUGMENTED_SBOM_NAME"
+            export SSDLC_DIR="$ARTIFACTS_DIR/ssdlc"
+            export SBOM_LITE="$ARTIFACTS_DIR/ssdlc/$SBOM_LITE_NAME"
+          
           EOT
 
     - command: expansions.update
@@ -546,7 +672,6 @@ functions:
         script: |
           ${prepare_shell}
           echo "Running static code analysis with Semgrep..."
-          cat mongo-jdbc-driver/artifacts/${version_id}/${build_variant}/ssdlc/mongo-jdbc-driver.sast.sarif
 
           venv='venv'
           # Setup or use the existing virtualenv for semgrep
@@ -578,7 +703,7 @@ functions:
         aws_session_token: ${AWS_SESSION_TOKEN}
         local_files_include_filter:
           - mongo-jdbc-driver.sast.*
-        remote_file: artifacts/${version_id}/${build_variant}/ssdlc/
-        content_type: text/plain
+        remote_file: artifacts/${version_id}/ssdlc/
+        content_type: application/json
         bucket: evg-bucket-mongo-jdbc-driver
         permissions: public-read

--- a/.evg.yml
+++ b/.evg.yml
@@ -425,10 +425,8 @@ functions:
             export PROJECT_DIRECTORY=${PROJECT_DIRECTORY}
             export MDBJDBC_VER=${MDBJDBC_VER}
           
-            # sbom relevant variables
-            export SBOM_WITHOUT_TEAM_NAME=$ARTIFACTS_DIR/ssdlc/sbom_without_team_name.json
-          
             # ssdlc relevant variables
+            export SBOM_WITHOUT_TEAM_NAME=$ARTIFACTS_DIR/ssdlc/sbom_without_team_name.json
             export SBOM_TOOL_DIR="sbom_generations"
             export SBOM_LITE_NAME="$SBOM_LITE_NAME"
             export AUGMENTED_SBOM_NAME="$AUGMENTED_SBOM_NAME"

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,4 +13,4 @@ thymeLeafVersion = 3.1.2.RELEASE
 # to disable publication of both SHA-256 and SHA-512 checksums which causes error in maven release
 systemProp.org.gradle.internal.publish.checksums.insecure = true
 cyclonedxBomName = sbom_without_team_name
-cyclonedxBomDestination = artifacts/sboms
+cyclonedxBomDestination = artifacts/ssdlc


### PR DESCRIPTION
I changed the naming of things a little bit to be more consistent with what was done here https://github.com/10gen/sqlproxy/pull/460. 

Successful task and augmented SBOM can be seen here: https://spruce.mongodb.com/task/mongo_jdbc_driver_release_ssdlc_artifacts_patch_55092b1f39209c99237670c784a7d33d217edebb_6671e342268d4f0007bff51a_24_06_18_19_43_01/logs?execution=0

