### PR TITLE
SQL-2248: Fix integration test hang on amazon2-arm64 host

### DIFF
--- a/.evg.yml
+++ b/.evg.yml
@@ -55,8 +55,7 @@ buildvariants:
     tasks:
       - name: "build"
       - name: "test-unit"
-      # SQL-2248: Fix integration test hang
-      # - name: "test-integration"
+      - name: "test-integration"
 
   - name: release
     display_name: "Release"
@@ -361,9 +360,55 @@ functions:
           ${PREPARE_SHELL}
           ./resources/run_adf.sh start &&
           ./gradlew -Dorg.gradle.java.home=${JAVA_HOME} runDataLoader &&
-          ./gradlew -Dorg.gradle.java.home=${JAVA_HOME} clean integrationTest -x test
-          EXITCODE=$?
+          ./gradlew -Dorg.gradle.java.home=${JAVA_HOME} clean integrationTest \
+              -x test  > gradle_output.log 2>&1 &
+          GRADLE_PID=$!
+
+          echo "Gradle process started with PID $GRADLE_PID"
+
+          # On Amazon Linux 2 hosts, the gradlew integrationTest command was hanging indefinitely.
+          # This monitoring approach will detect build completion or failure even when the Gradle 
+          # process doesn't terminate properly and allows the task to complete.
+          SECONDS=0
+          TIMEOUT=1800  # 30 minute timeout
+
+          while true; do
+              if grep -q "BUILD SUCCESSFUL" gradle_output.log; then
+                  echo "Build successful!"
+                  EXITCODE=0
+                  break
+              fi
+
+              if grep -q "BUILD FAILED" gradle_output.log; then
+                  echo "Build failed!"
+                  EXITCODE=1
+                  break
+              fi
+              
+              if (( SECONDS > TIMEOUT )); then
+                  echo "$TIMEOUT second timeout reached. Exiting with failure."
+                  EXITCODE=1
+                  break
+              fi
+              
+              # Check if Gradle process is still running
+              if ! kill -0 $GRADLE_PID 2>/dev/null; then
+                  echo "Gradle process has finished."
+                  wait $GRADLE_PID
+                  EXITCODE=$?
+                  break
+              fi
+              
+              sleep 5
+          done
+
+          cat gradle_output.log
+          
+          kill $GRADLE_PID 2>/dev/null || true
+
           ./resources/run_adf.sh stop
+          
+          echo "Integration test exit code: $EXITCODE"
           exit $EXITCODE
 
   "trace artifacts":


### PR DESCRIPTION
Adding a workaround for the `gradlew` command hanging on the Amazon Linux 2 host.  
The script would hang on the gradlew integration test, luckily it would output the `BUILD SUCCESS` or `BUILD FAILURE` status.  So I made the change to run the process in the background and check for one of those outputs.  Otherwise it times out with a failure.  

Here's an example of it correctly detecting a failure ([link](https://spruce.mongodb.com/task/mongo_jdbc_driver_amazon2_arm64_jdk_11_test_integration_patch_401a6ed19cf39e7b37a178f305ae5989a17d2680_66aaa69cc8b94100076e28ed_24_07_31_21_03_36/logs?execution=0&sortBy=STATUS&sortDir=ASC)).