### PR TITLE
SQL-2286: Test mongodb+srv style connection string

### DIFF
--- a/.evg.yml
+++ b/.evg.yml
@@ -510,6 +510,10 @@ functions:
             export ADF_TEST_PWD=${adf_test_pwd}
             export ADF_TEST_HOST=${adf_test_host}
             export ADF_TEST_AUTH_DB=${adf_test_auth_db}
+            export SRV_TEST_HOST=${srv_test_host}
+            export SRV_TEST_USER=${srv_test_user}
+            export SRV_TEST_PWD=${srv_test_pwd}
+            export SRV_TEST_AUTH_DB=${srv_test_auth_db}
             export JAVA_HOME=${JAVA_HOME}
             export PROJECT_DIRECTORY=${PROJECT_DIRECTORY}
             export MDBJDBC_VER=${MDBJDBC_VER}

--- a/src/integration-test/java/com/mongodb/jdbc/integration/MongoIntegrationTest.java
+++ b/src/integration-test/java/com/mongodb/jdbc/integration/MongoIntegrationTest.java
@@ -18,6 +18,8 @@ package com.mongodb.jdbc.integration;
 
 import static com.mongodb.jdbc.MongoDriver.MongoJDBCProperty.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -389,5 +391,33 @@ public class MongoIntegrationTest {
             }
         }
         assertEquals(4, uuidValues.size(), "Expected 4 different UUID values (including standard)");
+    }
+
+    /**
+     * Tests that the driver can work with SRV-style URIs.
+     */
+    @Test
+    public void testConnectWithSRVURI() throws SQLException {
+        String mongoURI = System.getenv("SRV_TEST_HOST");
+        assertNotNull(mongoURI, "SRV_TEST_HOST variable not set in environment");
+        String fullURI = "jdbc:" + mongoURI;
+
+        String user = System.getenv("SRV_TEST_USER");
+        assertNotNull(user, "SRV_TEST_USER variable not set in environment");
+        String pwd = System.getenv("SRV_TEST_PWD");
+        assertNotNull(pwd, "SRV_TEST_PWD variable not set in environment");
+        String authSource = System.getenv("SRV_TEST_AUTH_DB");
+        assertNotNull(authSource, "SRV_TEST_AUTH_DB variable not set in environment");
+
+        Properties p = new java.util.Properties();
+        p.setProperty("user", user);
+        p.setProperty("password", pwd);
+        p.setProperty("authSource", authSource);
+        p.setProperty("database", "test");
+
+        // TODO: SQL-2294: Support direct cluster mode (This should no longer expect an exception after that).
+        assertThrows(java.util.concurrent.ExecutionException.class, () -> {
+            MongoConnection conn = (MongoConnection) DriverManager.getConnection(fullURI, p);
+        });
     }
 }

--- a/src/integration-test/java/com/mongodb/jdbc/integration/MongoIntegrationTest.java
+++ b/src/integration-test/java/com/mongodb/jdbc/integration/MongoIntegrationTest.java
@@ -416,7 +416,7 @@ public class MongoIntegrationTest {
         p.setProperty("database", "test");
 
         // TODO: SQL-2294: Support direct cluster mode (This should no longer expect an exception after that).
-        assertThrows(java.util.concurrent.ExecutionException.class, () -> {
+        assertThrows(java.sql.SQLException.class, () -> {
             MongoConnection conn = (MongoConnection) DriverManager.getConnection(fullURI, p);
         });
     }

--- a/src/integration-test/java/com/mongodb/jdbc/integration/MongoIntegrationTest.java
+++ b/src/integration-test/java/com/mongodb/jdbc/integration/MongoIntegrationTest.java
@@ -398,8 +398,9 @@ public class MongoIntegrationTest {
      */
     @Test
     public void testConnectWithSRVURI() throws SQLException {
-        String mongoURI = System.getenv("SRV_TEST_HOST");
-        assertNotNull(mongoURI, "SRV_TEST_HOST variable not set in environment");
+        String mongoHost = System.getenv("SRV_TEST_HOST");
+        assertNotNull(mongoHost, "SRV_TEST_HOST variable not set in environment");
+        String mongoURI = "mongodb+srv://" + mongoHost + "/?readPreference=secondaryPreferred&connectTimeoutMS=300000";
         String fullURI = "jdbc:" + mongoURI;
 
         String user = System.getenv("SRV_TEST_USER");

--- a/src/integration-test/java/com/mongodb/jdbc/integration/MongoIntegrationTest.java
+++ b/src/integration-test/java/com/mongodb/jdbc/integration/MongoIntegrationTest.java
@@ -393,14 +393,15 @@ public class MongoIntegrationTest {
         assertEquals(4, uuidValues.size(), "Expected 4 different UUID values (including standard)");
     }
 
-    /**
-     * Tests that the driver can work with SRV-style URIs.
-     */
+    /** Tests that the driver can work with SRV-style URIs. */
     @Test
     public void testConnectWithSRVURI() throws SQLException {
         String mongoHost = System.getenv("SRV_TEST_HOST");
         assertNotNull(mongoHost, "SRV_TEST_HOST variable not set in environment");
-        String mongoURI = "mongodb+srv://" + mongoHost + "/?readPreference=secondaryPreferred&connectTimeoutMS=300000";
+        String mongoURI =
+                "mongodb+srv://"
+                        + mongoHost
+                        + "/?readPreference=secondaryPreferred&connectTimeoutMS=300000";
         String fullURI = "jdbc:" + mongoURI;
 
         String user = System.getenv("SRV_TEST_USER");
@@ -417,8 +418,11 @@ public class MongoIntegrationTest {
         p.setProperty("database", "test");
 
         // TODO: SQL-2294: Support direct cluster mode (This should no longer expect an exception after that).
-        assertThrows(java.sql.SQLException.class, () -> {
-            MongoConnection conn = (MongoConnection) DriverManager.getConnection(fullURI, p);
-        });
+        assertThrows(
+                java.sql.SQLException.class,
+                () -> {
+                    MongoConnection conn =
+                            (MongoConnection) DriverManager.getConnection(fullURI, p);
+                });
     }
 }

--- a/src/main/java/com/mongodb/jdbc/MongoDriver.java
+++ b/src/main/java/com/mongodb/jdbc/MongoDriver.java
@@ -466,6 +466,7 @@ public class MongoDriver implements Driver {
         ConnectionString c =
                 new ConnectionString(
                         buildNewURI(
+                                originalConnectionString.isSrvProtocol(),
                                 originalConnectionString.getHosts(),
                                 user,
                                 password,
@@ -627,6 +628,7 @@ public class MongoDriver implements Driver {
      *     arguments user provided,
      */
     private static String buildNewURI(
+            boolean isSrvProtocol,
             List<String> hosts,
             String user,
             char[] password,
@@ -635,8 +637,8 @@ public class MongoDriver implements Driver {
             Properties options)
             throws SQLException {
         // The returned URI should be of the following format:
-        //"mongodb://[user:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][/[authDatabase][?options]]")
-        String ret = "mongodb://";
+        //"mongodb(+srv)?://[user:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][/[authDatabase][?options]]")
+        String ret = isSrvProtocol ? "mongodb+srv://" : "mongodb://";
         if (user != null) {
             ret += sqlURLEncode(user);
             if (password != null) {


### PR DESCRIPTION
This PR adds an integration test for a `mongodb+srv` style uri. For now, I'm using the `nathan` user but will talk to Alexi today about creating a new dedicated test user on her cluster.

Also, for now I have it expecting the exception that is thrown since Atlas does not natively support the SQL commands. I put a TODO to update it when we eventually implement support. The test will also start failing when we implement support, so the TODO is almost redundant.

This took a while since I initially investigated using the AWS Secret Manager, but it was not as easy as the wiki page implied (the wiki makes reference to scripts without links so it's unclear which scripts they're talking about or what they're supposed to do). Instead, I opted to use evergreen as our secret manager like we do for all other values in our tests -- it's easier and more consistent for now. If we ever have to fully switch from evergreen secret managing to AWS, we should migrate everything at once. I don't think now is the time to make the change!