### PR TITLE
SQL-2292: Load mongosqltranslate library if found

### DIFF
--- a/.evg.yml
+++ b/.evg.yml
@@ -365,18 +365,16 @@ functions:
       script: |
         ${PREPARE_SHELL}
         set -e
-        
-        # Get current working directory
-        PWD=$(pwd)
-        
-        ls "${PWD}/src/test/resources/MongoSqlLibraryTest/libmongosqltranslate.so"
+
         # Test loading library from path specified in ENV variable
-        MONGOSQL_TRANSLATE_PATH="${PWD}/src/test/resources/MongoSqlLibraryTest/libmongosqltranslate.so" ./gradlew runMongoSQLTranslateLibTest -PtestMethod=testLibraryLoadingWithEnvironmentVariable
+        MONGOSQL_TRANSLATE_PATH="$PWD/src/test/resources/MongoSqlLibraryTest/libmongosqltranslate.so" \
+            ./gradlew runMongoSQLTranslateLibTest -PtestMethod=testLibraryLoadingWithEnvironmentVariable
         
         # Move library file
+        mkdir -p build/classes/java/
         mv -f src/test/resources/MongoSqlLibraryTest/libmongosqltranslate.so build/classes/java/
         
-        # Test loading library from same directory as the JDBC driver
+        # Test loading library from same directory as where the JDBC driver is located
         ./gradlew runMongoSQLTranslateLibTest -PtestMethod=testLibraryLoadingFromDriverPath
 
   "run integration test":

--- a/.evg.yml
+++ b/.evg.yml
@@ -45,6 +45,7 @@ buildvariants:
     tasks:
       - name: "build"
       - name: "test-unit"
+      - name: "test-mongo-sql-translate"
       - name: "test-integration"
 
   - name: amazon2-arm64-jdk-11
@@ -76,6 +77,10 @@ tasks:
   - name: "test-unit"
     commands:
       - func: "run unit test"
+
+  - name: "test-mongo-sql-translate"
+    commands:
+      - func: "run mongo sql translate test"
 
   - name: "test-integration"
     commands:
@@ -350,6 +355,29 @@ functions:
       script: |
           ${PREPARE_SHELL}
           ./gradlew -Dorg.gradle.java.home=${JAVA_HOME} clean test
+
+  "run mongo sql translate test":
+    command: shell.exec
+    type: test
+    params:
+      shell: bash
+      working_dir: mongo-jdbc-driver
+      script: |
+        ${PREPARE_SHELL}
+        set -e
+        
+        # Get current working directory
+        PWD=$(pwd)
+        
+        ls "${PWD}/src/test/resources/MongoSqlLibraryTest/libmongosqltranslate.so"
+        # Test loading library from path specified in ENV variable
+        MONGOSQL_TRANSLATE_PATH="${PWD}/src/test/resources/MongoSqlLibraryTest/libmongosqltranslate.so" ./gradlew runMongoSQLTranslateLibTest -PtestMethod=testLibraryLoadingWithEnvironmentVariable
+        
+        # Move library file
+        mv -f src/test/resources/MongoSqlLibraryTest/libmongosqltranslate.so build/classes/java/
+        
+        # Test loading library from same directory as the JDBC driver
+        ./gradlew runMongoSQLTranslateLibTest -PtestMethod=testLibraryLoadingFromDriverPath
 
   "run integration test":
     command: shell.exec

--- a/.evg.yml
+++ b/.evg.yml
@@ -365,12 +365,8 @@ functions:
       script: |
         ${PREPARE_SHELL}
         set -e
-
-        # Test loading library from path specified in ENV variable
-        MONGOSQL_TRANSLATE_PATH="$PWD/src/test/resources/MongoSqlLibraryTest/libmongosqltranslate.so" \
-            ./gradlew runMongoSQLTranslateLibTest -PtestMethod=testLibraryLoadingWithEnvironmentVariable
         
-        # Move library file
+        # Move library file to where MongoDriver class is located
         mkdir -p build/classes/java/
         mv -f src/test/resources/MongoSqlLibraryTest/libmongosqltranslate.so build/classes/java/
         

--- a/.evg.yml
+++ b/.evg.yml
@@ -366,6 +366,10 @@ functions:
         ${PREPARE_SHELL}
         set -e
         
+        # Test loading library from path specified in ENV variable
+        MONGOSQL_TRANSLATE_PATH="$PWD/src/test/resources/MongoSqlLibraryTest/libmongosqltranslate.so" \
+            ./gradlew runMongoSQLTranslateLibTest -PtestMethod=testLibraryLoadingWithEnvironmentVariable
+        
         # Move library file to where MongoDriver class is located
         mkdir -p build/classes/java/
         mv -f src/test/resources/MongoSqlLibraryTest/libmongosqltranslate.so build/classes/java/

--- a/.evg.yml
+++ b/.evg.yml
@@ -80,7 +80,7 @@ tasks:
 
   - name: "test-mongo-sql-translate"
     commands:
-      - func: "run mongo sql translate test"
+      - func: "run mongosqltranslate library load test"
 
   - name: "test-integration"
     commands:
@@ -356,7 +356,7 @@ functions:
           ${PREPARE_SHELL}
           ./gradlew -Dorg.gradle.java.home=${JAVA_HOME} clean test
 
-  "run mongo sql translate test":
+  "run mongosqltranslate library load test":
     command: shell.exec
     type: test
     params:

--- a/build.gradle
+++ b/build.gradle
@@ -267,5 +267,29 @@ def getAbbreviatedGitVersion() {
     out.toString().substring(1).trim()
 }
 
+tasks.register('runMongoSQLTranslateLibTest', Test) {
+    description = 'Runs MongoSQLTranslateLibTest'
+    group = 'verification'
+
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+
+    useJUnitPlatform()
+
+    filter {
+        if (project.hasProperty('testMethod')) {
+            includeTestsMatching "*MongoSQLTranslateLibTest.$testMethod"
+        } else {
+            includeTestsMatching "*MongoSQLTranslateLibTest"
+        }
+    }
+}
+
+tasks.test {
+    filter {
+        excludeTestsMatching "*MongoSQLTranslateLibTest"
+    }
+}
+
 apply from: 'gradle/publish.gradle'
 apply from: 'gradle/deploy.gradle'

--- a/src/main/java/com/mongodb/jdbc/MongoDriver.java
+++ b/src/main/java/com/mongodb/jdbc/MongoDriver.java
@@ -184,9 +184,9 @@ public class MongoDriver implements Driver {
     private static String getLibraryPath() {
         try {
             URL url = MongoDriver.class.getProtectionDomain().getCodeSource().getLocation();
-            Path jarPath = Paths.get(url.toURI());
-            Path jarDir = jarPath.getParent();
-            return jarDir.resolve(System.mapLibraryName(MONGOSQL_TRANSLATE_NAME)).toString();
+            Path driverPath = Paths.get(url.toURI());
+            Path driverDir = driverPath.getParent();
+            return driverDir.resolve(System.mapLibraryName(MONGOSQL_TRANSLATE_NAME)).toString();
         } catch (Exception e) {
             return null;
         }

--- a/src/main/java/com/mongodb/jdbc/MongoDriver.java
+++ b/src/main/java/com/mongodb/jdbc/MongoDriver.java
@@ -26,7 +26,10 @@ import com.mongodb.client.MongoClient;
 import java.io.File;
 import java.io.UnsupportedEncodingException;
 import java.lang.ref.WeakReference;
+import java.net.URL;
 import java.net.URLEncoder;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.DriverManager;
@@ -120,6 +123,10 @@ public class MongoDriver implements Driver {
         return VERSION != null ? VERSION : MAJOR_VERSION + "." + MINOR_VERSION;
     }
 
+    private static boolean mongoSqlTranslateLibraryLoaded = false;
+    private static final String MONGOSQL_TRANSLATE_NAME = "mongosqltranslate";
+    public static final String MONGOSQL_TRANSLATE_PATH = "MONGOSQL_TRANSLATE_PATH";
+
     static CodecRegistry registry =
             fromProviders(
                     new BsonValueCodecProvider(),
@@ -152,6 +159,64 @@ public class MongoDriver implements Driver {
         String name = unit.getClass().getPackage().getImplementationTitle();
         NAME = (name != null) ? name : "mongodb-jdbc";
         Runtime.getRuntime().addShutdownHook(new Thread(MongoDriver::closeAllClients));
+
+        initializeMongoSqlTranslateLibrary();
+    }
+
+    /**
+     * Attempts to initialize the MongoSQL Translate library. This method tries to load the library
+     * from various paths and sets a flag indicating success or failure.
+     */
+    private static void initializeMongoSqlTranslateLibrary() {
+        try {
+            String[] libraryPaths = resolveLibraryPaths();
+            for (String path : libraryPaths) {
+                if (loadMongoSqlTranslateLibrary(path)) {
+                    mongoSqlTranslateLibraryLoaded = true;
+                    return;
+                }
+            }
+            mongoSqlTranslateLibraryLoaded = false;
+        } catch (Exception e) {
+            mongoSqlTranslateLibraryLoaded = false;
+        }
+    }
+
+    /**
+     * Attempts to load the MongoSQL Translate library from a specific path.
+     *
+     * @param libraryPath The path to the library file
+     * @return true if the library was successfully loaded, false otherwise
+     */
+    private static boolean loadMongoSqlTranslateLibrary(String libraryPath) {
+        try {
+            System.load(libraryPath);
+            return true;
+        } catch (Throwable t) {
+            return false;
+        }
+    }
+
+    // Resolves the potential paths where the MongoSQL Translate library are expected be located.
+    private static String[] resolveLibraryPaths() throws Exception {
+        String driverPath = getDriverPath();
+        String envPath = System.getenv(MONGOSQL_TRANSLATE_PATH);
+
+        List<String> paths = new ArrayList<>();
+        if (driverPath != null) {
+            paths.add(driverPath);
+        }
+        if (envPath != null && !envPath.isEmpty()) {
+            paths.add(envPath);
+        }
+        return paths.toArray(new String[0]);
+    }
+
+    private static String getDriverPath() throws Exception {
+        URL url = MongoDriver.class.getProtectionDomain().getCodeSource().getLocation();
+        Path jarPath = Paths.get(url.toURI());
+        Path jarDir = jarPath.getParent();
+        return jarDir.resolve(System.mapLibraryName(MONGOSQL_TRANSLATE_NAME)).toString();
     }
 
     @Override
@@ -380,6 +445,10 @@ public class MongoDriver implements Driver {
     @Override
     public java.util.logging.Logger getParentLogger() throws SQLFeatureNotSupportedException {
         throw new SQLFeatureNotSupportedException();
+    }
+
+    public static boolean isMongoSqlTranslateLibraryLoaded() {
+        return mongoSqlTranslateLibraryLoaded;
     }
 
     // removePrefix removes a prefix from a String.

--- a/src/test/java/com/mongodb/jdbc/MongoSQLTranslateLibTest.java
+++ b/src/test/java/com/mongodb/jdbc/MongoSQLTranslateLibTest.java
@@ -49,23 +49,4 @@ public class MongoSQLTranslateLibTest {
         MongosqlLibTest test = new MongosqlLibTest();
         test.testRunCommand();
     }
-
-    @Test
-    void testLibraryLoadingWithEnvironmentVariable() throws Exception {
-        String envPath = System.getenv(MongoDriver.MONGOSQL_TRANSLATE_PATH);
-        assertNotNull(envPath, "MONGOSQL_TRANSLATE_PATH should be set");
-
-        // Test initializeMongoSqlTranslateLibrary, with Environment variable set it should find the library
-        Method initMethod =
-                MongoDriver.class.getDeclaredMethod("initializeMongoSqlTranslateLibrary");
-        initMethod.setAccessible(true);
-        initMethod.invoke(null);
-
-        assertTrue(
-                MongoDriver.isMongoSqlTranslateLibraryLoaded(),
-                "Library should be loaded when MONGOSQL_TRANSLATE_PATH is set");
-
-        MongosqlLibTest test = new MongosqlLibTest();
-        test.testRunCommand();
-    }
 }

--- a/src/test/java/com/mongodb/jdbc/MongoSQLTranslateLibTest.java
+++ b/src/test/java/com/mongodb/jdbc/MongoSQLTranslateLibTest.java
@@ -26,6 +26,9 @@ import org.junit.jupiter.api.Test;
 public class MongoSQLTranslateLibTest {
     @BeforeEach
     void setup() throws Exception {
+        // Reset the mongoSqlTranslateLibraryLoaded flag to false before each test case.
+        // This ensures that the flag starts with a known value at the start of the test
+        // as it can be set during the static initialization or test interference.
         Field field = MongoDriver.class.getDeclaredField("mongoSqlTranslateLibraryLoaded");
         field.setAccessible(true);
         field.set(null, false);

--- a/src/test/java/com/mongodb/jdbc/MongoSQLTranslateLibTest.java
+++ b/src/test/java/com/mongodb/jdbc/MongoSQLTranslateLibTest.java
@@ -52,4 +52,23 @@ public class MongoSQLTranslateLibTest {
         MongosqlLibTest test = new MongosqlLibTest();
         test.testRunCommand();
     }
+
+    @Test
+    void testLibraryLoadingWithEnvironmentVariable() throws Exception {
+        String envPath = System.getenv(MongoDriver.MONGOSQL_TRANSLATE_PATH);
+        assertNotNull(envPath, "MONGOSQL_TRANSLATE_PATH should be set");
+
+        // Test initializeMongoSqlTranslateLibrary, with Environment variable set it should find the library
+        Method initMethod =
+                MongoDriver.class.getDeclaredMethod("initializeMongoSqlTranslateLibrary");
+        initMethod.setAccessible(true);
+        initMethod.invoke(null);
+
+        assertTrue(
+                MongoDriver.isMongoSqlTranslateLibraryLoaded(),
+                "Library should be loaded when MONGOSQL_TRANSLATE_PATH is set");
+
+        MongosqlLibTest test = new MongosqlLibTest();
+        test.testRunCommand();
+    }
 }

--- a/src/test/java/com/mongodb/jdbc/MongoSQLTranslateLibTest.java
+++ b/src/test/java/com/mongodb/jdbc/MongoSQLTranslateLibTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2024-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.jdbc;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class MongoSQLTranslateLibTest {
+    @BeforeEach
+    void setup() throws Exception {
+        Field field = MongoDriver.class.getDeclaredField("mongoSqlTranslateLibraryLoaded");
+        field.setAccessible(true);
+        field.set(null, false);
+    }
+
+    @Test
+    void testLibraryLoadingFromDriverPath() throws Exception {
+        assertNull(
+                System.getenv(MongoDriver.MONGOSQL_TRANSLATE_PATH),
+                "MONGOSQL_TRANSLATE_PATH should not be set");
+
+        Method initMethod =
+                MongoDriver.class.getDeclaredMethod("initializeMongoSqlTranslateLibrary");
+        initMethod.setAccessible(true);
+        initMethod.invoke(null);
+
+        assertTrue(
+                MongoDriver.isMongoSqlTranslateLibraryLoaded(),
+                "Library should be loaded successfully from the driver directory");
+
+        MongosqlLibTest test = new MongosqlLibTest();
+        test.testRunCommand();
+    }
+
+    @Test
+    void testLibraryLoadingWithEnvironmentVariable() throws Exception {
+        String envPath = System.getenv(MongoDriver.MONGOSQL_TRANSLATE_PATH);
+        assertNotNull(envPath, "MONGOSQL_TRANSLATE_PATH should be set");
+
+        // Test initializeMongoSqlTranslateLibrary, with Environment variable set it should find the library
+        Method initMethod =
+                MongoDriver.class.getDeclaredMethod("initializeMongoSqlTranslateLibrary");
+        initMethod.setAccessible(true);
+        initMethod.invoke(null);
+
+        assertTrue(
+                MongoDriver.isMongoSqlTranslateLibraryLoaded(),
+                "Library should be loaded when MONGOSQL_TRANSLATE_PATH is set");
+
+        MongosqlLibTest test = new MongosqlLibTest();
+        test.testRunCommand();
+    }
+}

--- a/src/test/java/com/mongodb/jdbc/MongosqlLibTest.java
+++ b/src/test/java/com/mongodb/jdbc/MongosqlLibTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.jdbc;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+class MongosqlLibTest {
+    private native String runCommand(String command);
+
+    public void testRunCommand() {
+        try {
+            String result = runCommand("SELECT * FROM test");
+            assert result.contains("mongosql translation test result success");
+        } catch (UnsatisfiedLinkError e) {
+            System.err.println("Error: Unable to link with native library");
+            e.printStackTrace();
+            fail("UnsatisfiedLinkError: Native library could not be loaded");
+        }
+    }
+}


### PR DESCRIPTION
Loads library with name `libmongosqltranslate` from the same directory as where the Driver is located.  If that is not found it then loads from the path specified by the `MONGOSQL_TRANSLATE_PATH` env variable.  

I added a JNI test that I was using to confirm it was working, and added the library itself built on Ubuntu x86.  

If the library cannot be loaded, the `mongoSqlTranslateLibraryLoaded` variable will be false.  This can be checked in future implementations that intend to use the library and can at that point error out and report that the library is not loaded. 

```
use jni::JNIEnv;
use jni::objects::{JClass, JString};
use jni::sys::jstring;

#[no_mangle]
pub extern "system" fn Java_com_mongodb_jdbc_MongosqlLibTest_runCommand(
    mut env: JNIEnv,
    _class: JClass,
    input: JString,
) -> jstring {
    let input: String = env.get_string(&input).expect("Couldn't get java string!").into();
    let output = format!("{{\"result\": \"mongosql translation test result success for input: {}\"}}", input);
    env.new_string(output).expect("Couldn't create java string!").into_raw()
}
```