### PR TITLE
SQL-2293: Differentiate cluster type upon connection

### DIFF
--- a/.evg.yml
+++ b/.evg.yml
@@ -471,11 +471,15 @@ functions:
         ;;
         esac
         
+        # Move library file to where MongoDriver class is located
+        mkdir -p build/classes/java/
+        mv -f src/test/resources/MongoSqlLibraryTest/libmongosqltranslate.so build/classes/java/
+        
         # Download and run local community and enterprise mongods.
         ./resources/start_local_mdb.sh $mdb_version_com $mdb_version_ent $arch
         
         # Run the tests.
-        ./gradlew -Dorg.gradle.java.home=${JAVA_HOME} clean integrationTest \
+        ./gradlew -Dorg.gradle.java.home=${JAVA_HOME} integrationTest \
             -x test --tests DCIntegrationTest > gradle_output.log 2>&1 &
         GRADLE_PID=$!
 

--- a/.evg.yml
+++ b/.evg.yml
@@ -58,7 +58,6 @@ buildvariants:
       - name: "build"
       - name: "test-unit"
       - name: "test-adf-integration"
-      - name: "test-dc-integration"
 
   - name: release
     display_name: "Release"

--- a/.evg.yml
+++ b/.evg.yml
@@ -46,7 +46,8 @@ buildvariants:
       - name: "build"
       - name: "test-unit"
       - name: "test-mongo-sql-translate"
-      - name: "test-integration"
+      - name: "test-adf-integration"
+      - name: "test-dc-integration"
 
   - name: amazon2-arm64-jdk-11
     display_name: Amazon Linux 2 ARM64 jdk-11
@@ -56,7 +57,8 @@ buildvariants:
     tasks:
       - name: "build"
       - name: "test-unit"
-      - name: "test-integration"
+      - name: "test-adf-integration"
+      - name: "test-dc-integration"
 
   - name: release
     display_name: "Release"
@@ -82,9 +84,13 @@ tasks:
     commands:
       - func: "run mongosqltranslate library load test"
 
-  - name: "test-integration"
+  - name: "test-adf-integration"
     commands:
-      - func: "run integration test"
+      - func: "run adf integration test"
+
+  - name: "test-dc-integration"
+    commands:
+      - func: "run dc integration test"
 
   - name: "test-smoke"
     commands:
@@ -377,7 +383,7 @@ functions:
         # Test loading library from same directory as where the JDBC driver is located
         ./gradlew runMongoSQLTranslateLibTest -PtestMethod=testLibraryLoadingFromDriverPath
 
-  "run integration test":
+  "run adf integration test":
     command: shell.exec
     type: test
     params:
@@ -388,7 +394,7 @@ functions:
           ./resources/run_adf.sh start &&
           ./gradlew -Dorg.gradle.java.home=${JAVA_HOME} runDataLoader &&
           ./gradlew -Dorg.gradle.java.home=${JAVA_HOME} clean integrationTest \
-              -x test  > gradle_output.log 2>&1 &
+              -x test --tests ADFIntegrationTest > gradle_output.log 2>&1 &
           GRADLE_PID=$!
 
           echo "Gradle process started with PID $GRADLE_PID"
@@ -437,6 +443,88 @@ functions:
           
           echo "Integration test exit code: $EXITCODE"
           exit $EXITCODE
+
+  "run dc integration test":
+    command: shell.exec
+    type: test
+    params:
+      shell: bash
+      working_dir: mongo-jdbc-driver
+      script: |
+        ${PREPARE_SHELL}
+
+        case ${_platform} in
+        ubuntu2204-64-jdk-8 | ubuntu2204-64-jdk-11)
+          mdb_version_com="mongodb-linux-x86_64-ubuntu2204-7.0.14"
+          mdb_version_ent="mongodb-linux-x86_64-enterprise-ubuntu2204-7.0.14"
+          arch="x64"
+        ;;
+        amazon2-arm64-jdk-11)
+          mdb_version_com="mongodb-linux-aarch64-amazon2-7.0.14"
+          mdb_version_ent="mongodb-linux-aarch64-enterprise-amazon2-7.0.14"
+          arch="arm64"
+        ;;
+        *)
+          echo "ERROR: invalid value for \${_platform}: '$_platform'"
+          echo "Allowed values: 'amazon2-arm64-jdk-11', 'ubuntu2204-64-jdk-8', 'ubuntu2204-64-jdk-11'"
+          exit 1
+        ;;
+        esac
+        
+        # Download and run local community and enterprise mongods.
+        ./resources/start_local_mdb.sh $mdb_version_com $mdb_version_ent $arch
+        
+        # Run the tests.
+        ./gradlew -Dorg.gradle.java.home=${JAVA_HOME} clean integrationTest \
+            -x test --tests DCIntegrationTest > gradle_output.log 2>&1 &
+        GRADLE_PID=$!
+
+        echo "Gradle process started with PID $GRADLE_PID"
+
+        # On Amazon Linux 2 hosts, the gradlew integrationTest command was hanging indefinitely.
+        # This monitoring approach will detect build completion or failure even when the Gradle 
+        # process doesn't terminate properly and allows the task to complete.
+        SECONDS=0
+        TIMEOUT=1800  # 30 minute timeout
+
+        while true; do
+          if grep -q "BUILD SUCCESSFUL" gradle_output.log; then
+              echo "Build successful!"
+              EXITCODE=0
+              break
+          fi
+
+          if grep -q "BUILD FAILED" gradle_output.log; then
+              echo "Build failed!"
+              EXITCODE=1
+              break
+          fi
+    
+          if (( SECONDS > TIMEOUT )); then
+              echo "$TIMEOUT second timeout reached. Exiting with failure."
+              EXITCODE=1
+              break
+          fi
+    
+          # Check if Gradle process is still running
+          if ! kill -0 $GRADLE_PID 2>/dev/null; then
+              echo "Gradle process has finished."
+              wait $GRADLE_PID
+              EXITCODE=$?
+              break
+          fi
+    
+          sleep 5
+        done
+
+        cat gradle_output.log
+      
+        kill $GRADLE_PID 2>/dev/null || true
+      
+        pkill mongod
+      
+        echo "Integration test exit code: $EXITCODE"
+        exit $EXITCODE
 
   "trace artifacts":
     command: papertrail.trace
@@ -540,6 +628,10 @@ functions:
             export SRV_TEST_USER=${srv_test_user}
             export SRV_TEST_PWD=${srv_test_pwd}
             export SRV_TEST_AUTH_DB=${srv_test_auth_db}
+            export LOCAL_MDB_PORT_COM=${local_mdb_port_com}
+            export LOCAL_MDB_PORT_ENT=${local_mdb_port_ent}
+            export LOCAL_MDB_USER=${local_mdb_user}
+            export LOCAL_MDB_PWD=${local_mdb_pwd}
             export JAVA_HOME=${JAVA_HOME}
             export PROJECT_DIRECTORY=${PROJECT_DIRECTORY}
             export MDBJDBC_VER=${MDBJDBC_VER}

--- a/.evg.yml
+++ b/.evg.yml
@@ -476,9 +476,42 @@ functions:
         ./gradlew integrationTest \
             -x test --tests DCIntegrationTest > gradle_output.log 2>&1 &
         GRADLE_PID=$!
-        EXITCODE=$?
 
         echo "Gradle process started with PID $GRADLE_PID"
+        
+        # On Amazon Linux 2 hosts, the gradlew integrationTest command was hanging indefinitely.
+        # This monitoring approach will detect build completion or failure even when the Gradle 
+        # process doesn't terminate properly and allows the task to complete.
+        SECONDS=0
+        TIMEOUT=1800  # 30 minute timeout
+        while true; do
+          if grep -q "BUILD SUCCESSFUL" gradle_output.log; then
+              echo "Build successful!"
+              EXITCODE=0
+              break
+          fi
+          if grep -q "BUILD FAILED" gradle_output.log; then
+              echo "Build failed!"
+              EXITCODE=1
+              break
+          fi
+        
+          if (( SECONDS > TIMEOUT )); then
+              echo "$TIMEOUT second timeout reached. Exiting with failure."
+              EXITCODE=1
+              break
+          fi
+
+          # Check if Gradle process is still running
+          if ! kill -0 $GRADLE_PID 2>/dev/null; then
+              echo "Gradle process has finished."
+              wait $GRADLE_PID
+              EXITCODE=$?
+              break
+          fi
+
+          sleep 5
+        done
 
         cat gradle_output.log
       

--- a/.evg.yml
+++ b/.evg.yml
@@ -458,14 +458,9 @@ functions:
           mdb_version_ent="mongodb-linux-x86_64-enterprise-ubuntu2204-7.0.14"
           arch="x64"
         ;;
-        amazon2-arm64-jdk-11)
-          mdb_version_com="mongodb-linux-aarch64-amazon2-7.0.14"
-          mdb_version_ent="mongodb-linux-aarch64-enterprise-amazon2-7.0.14"
-          arch="arm64"
-        ;;
         *)
           echo "ERROR: invalid value for \${_platform}: '$_platform'"
-          echo "Allowed values: 'amazon2-arm64-jdk-11', 'ubuntu2204-64-jdk-8', 'ubuntu2204-64-jdk-11'"
+          echo "Allowed values: 'ubuntu2204-64-jdk-8', 'ubuntu2204-64-jdk-11'"
           exit 1
         ;;
         esac
@@ -478,47 +473,12 @@ functions:
         ./resources/start_local_mdb.sh $mdb_version_com $mdb_version_ent $arch
         
         # Run the tests.
-        ./gradlew -Dorg.gradle.java.home=${JAVA_HOME} integrationTest \
+        ./gradlew integrationTest \
             -x test --tests DCIntegrationTest > gradle_output.log 2>&1 &
         GRADLE_PID=$!
+        EXITCODE=$?
 
         echo "Gradle process started with PID $GRADLE_PID"
-
-        # On Amazon Linux 2 hosts, the gradlew integrationTest command was hanging indefinitely.
-        # This monitoring approach will detect build completion or failure even when the Gradle 
-        # process doesn't terminate properly and allows the task to complete.
-        SECONDS=0
-        TIMEOUT=1800  # 30 minute timeout
-
-        while true; do
-          if grep -q "BUILD SUCCESSFUL" gradle_output.log; then
-              echo "Build successful!"
-              EXITCODE=0
-              break
-          fi
-
-          if grep -q "BUILD FAILED" gradle_output.log; then
-              echo "Build failed!"
-              EXITCODE=1
-              break
-          fi
-    
-          if (( SECONDS > TIMEOUT )); then
-              echo "$TIMEOUT second timeout reached. Exiting with failure."
-              EXITCODE=1
-              break
-          fi
-    
-          # Check if Gradle process is still running
-          if ! kill -0 $GRADLE_PID 2>/dev/null; then
-              echo "Gradle process has finished."
-              wait $GRADLE_PID
-              EXITCODE=$?
-              break
-          fi
-    
-          sleep 5
-        done
 
         cat gradle_output.log
       

--- a/resources/start_local_mdb.sh
+++ b/resources/start_local_mdb.sh
@@ -45,7 +45,10 @@ start_mdb_and_create_user() {
   mkdir -p $db_path
   $5/bin/mongod --dbpath $db_path --port $2 &
 
-  echo "creating user"
+  echo "waiting 5 seconds to allow mongod to finish starting before connecting"
+  sleep 5
+
+  echo "creating user for $1"
   ./mongosh test --port $2 --eval "db.createUser({user: '$3', pwd: '$4', roles: ['readWrite']})"
 }
 

--- a/resources/start_local_mdb.sh
+++ b/resources/start_local_mdb.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+#
+# Usage start_local_mdb.sh <community version> <enterprise version> <architecture>
+# architecture: "arm64" or "x64"
+#
+# This script will download each version of mongodb, start a mongod
+# for each, and create a user for each.
+
+# Usage: download_and_extract_tgz <root url> <file base name>
+download_and_extract_tgz() {
+  tgz_file="$2.tgz"
+  full_url="$1$tgz_file"
+
+  echo "downloading $3 from $full_url"
+  curl -O $full_url
+
+  echo "extracting $tgz_file"
+  tar zxvf $tgz_file
+}
+
+# Usage: download_mongod <download_host> <file base name> <type>
+# type: "community" or "enterprise"
+download_mongod() {
+  root_url="https://$1/linux/"
+  download_and_extract_tgz $root_url $2 $3
+}
+
+# Usage: download_mongosh <architecture>
+# architecture: "arm64" or "x64"
+download_mongosh() {
+  root_url="https://downloads.mongodb.com/compass/"
+  file_name="mongosh-2.3.0-linux-$1"
+  download_and_extract_tgz $root_url $file_name "mongosh"
+
+  # copy mongosh to the current directory and ensure it is executable
+  cp $file_name/bin/mongosh .
+  chmod +x mongosh
+}
+
+# Usage: start_mdb_and_create_user <type> <port> <user> <pwd> <mongod dir>
+# type: "community" or "enterprise"
+start_mdb_and_create_user() {
+  echo "starting mongodb $1 on port $2"
+  db_path="$1_db"
+  mkdir -p $db_path
+  $5/bin/mongod --dbpath $db_path --port $2 &
+
+  echo "creating user"
+  ./mongosh test --eval "db.createUser({user: '$3', pwd: '$4', roles: ['readWrite']})"
+}
+
+community_mdb_version="$1"
+enterprise_mdb_version="$2"
+arch="$3"
+
+community_base_url="fastdl.mongodb.org"
+enterprise_base_url="downloads.mongodb.com"
+
+download_mongod $community_base_url $community_mdb_version "community"
+download_mongod $enterprise_base_url $enterprise_mdb_version "enterprise"
+
+download_mongosh $arch
+
+start_mdb_and_create_user "community" $LOCAL_MDB_PORT_COM $LOCAL_MDB_USER $LOCAL_MDB_PWD $community_mdb_version
+start_mdb_and_create_user "enterprise" $LOCAL_MDB_PORT_ENT $LOCAL_MDB_USER $LOCAL_MDB_PWD $enterprise_mdb_version

--- a/resources/start_local_mdb.sh
+++ b/resources/start_local_mdb.sh
@@ -46,7 +46,7 @@ start_mdb_and_create_user() {
   $5/bin/mongod --dbpath $db_path --port $2 &
 
   echo "creating user"
-  ./mongosh test --eval "db.createUser({user: '$3', pwd: '$4', roles: ['readWrite']})"
+  ./mongosh test --port $2 --eval "db.createUser({user: '$3', pwd: '$4', roles: ['readWrite']})"
 }
 
 community_mdb_version="$1"

--- a/src/integration-test/java/com/mongodb/jdbc/integration/ADFIntegrationTest.java
+++ b/src/integration-test/java/com/mongodb/jdbc/integration/ADFIntegrationTest.java
@@ -18,8 +18,6 @@ package com.mongodb.jdbc.integration;
 
 import static com.mongodb.jdbc.MongoDriver.MongoJDBCProperty.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 

--- a/src/integration-test/java/com/mongodb/jdbc/integration/ADFIntegrationTest.java
+++ b/src/integration-test/java/com/mongodb/jdbc/integration/ADFIntegrationTest.java
@@ -55,7 +55,7 @@ import org.junit.jupiter.api.TestFactory;
 import org.junit.jupiter.api.TestInstance;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class MongoIntegrationTest {
+public class ADFIntegrationTest {
     private static final String CURRENT_DIR =
             Paths.get(".").toAbsolutePath().normalize().toString();
 
@@ -230,9 +230,9 @@ public class MongoIntegrationTest {
     private void addSimpleQueryExecTasks(List<Callable<Void>> tasks, Connection conn)
             throws SQLException {
         // Connection with no logging and a valid query to execute.
-        tasks.add(new MongoIntegrationTest.SimpleQueryExecutor(conn, "SELECT 1"));
+        tasks.add(new ADFIntegrationTest.SimpleQueryExecutor(conn, "SELECT 1"));
         // Connection with no logging and an invalid query to execute.
-        tasks.add(new MongoIntegrationTest.SimpleQueryExecutor(conn, "INVALID QUERY TO EXECUTE"));
+        tasks.add(new ADFIntegrationTest.SimpleQueryExecutor(conn, "INVALID QUERY TO EXECUTE"));
     }
 
     /**
@@ -391,38 +391,5 @@ public class MongoIntegrationTest {
             }
         }
         assertEquals(4, uuidValues.size(), "Expected 4 different UUID values (including standard)");
-    }
-
-    /** Tests that the driver can work with SRV-style URIs. */
-    @Test
-    public void testConnectWithSRVURI() throws SQLException {
-        String mongoHost = System.getenv("SRV_TEST_HOST");
-        assertNotNull(mongoHost, "SRV_TEST_HOST variable not set in environment");
-        String mongoURI =
-                "mongodb+srv://"
-                        + mongoHost
-                        + "/?readPreference=secondaryPreferred&connectTimeoutMS=300000";
-        String fullURI = "jdbc:" + mongoURI;
-
-        String user = System.getenv("SRV_TEST_USER");
-        assertNotNull(user, "SRV_TEST_USER variable not set in environment");
-        String pwd = System.getenv("SRV_TEST_PWD");
-        assertNotNull(pwd, "SRV_TEST_PWD variable not set in environment");
-        String authSource = System.getenv("SRV_TEST_AUTH_DB");
-        assertNotNull(authSource, "SRV_TEST_AUTH_DB variable not set in environment");
-
-        Properties p = new java.util.Properties();
-        p.setProperty("user", user);
-        p.setProperty("password", pwd);
-        p.setProperty("authSource", authSource);
-        p.setProperty("database", "test");
-
-        // TODO: SQL-2294: Support direct cluster mode (This should no longer expect an exception after that).
-        assertThrows(
-                java.sql.SQLException.class,
-                () -> {
-                    MongoConnection conn =
-                            (MongoConnection) DriverManager.getConnection(fullURI, p);
-                });
     }
 }

--- a/src/integration-test/java/com/mongodb/jdbc/integration/DCIntegrationTest.java
+++ b/src/integration-test/java/com/mongodb/jdbc/integration/DCIntegrationTest.java
@@ -1,0 +1,53 @@
+package com.mongodb.jdbc.integration;
+
+
+import com.mongodb.jdbc.MongoConnection;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class DCIntegrationTest {
+
+    /** Tests that the driver can work with SRV-style URIs. */
+    @Test
+    public void testConnectWithSRVURI() throws SQLException {
+        String mongoHost = System.getenv("SRV_TEST_HOST");
+        assertNotNull(mongoHost, "SRV_TEST_HOST variable not set in environment");
+        String mongoURI =
+                "mongodb+srv://"
+                        + mongoHost
+                        + "/?readPreference=secondaryPreferred&connectTimeoutMS=300000";
+        String fullURI = "jdbc:" + mongoURI;
+
+        String user = System.getenv("SRV_TEST_USER");
+        assertNotNull(user, "SRV_TEST_USER variable not set in environment");
+        String pwd = System.getenv("SRV_TEST_PWD");
+        assertNotNull(pwd, "SRV_TEST_PWD variable not set in environment");
+        String authSource = System.getenv("SRV_TEST_AUTH_DB");
+        assertNotNull(authSource, "SRV_TEST_AUTH_DB variable not set in environment");
+
+        Properties p = new java.util.Properties();
+        p.setProperty("user", user);
+        p.setProperty("password", pwd);
+        p.setProperty("authSource", authSource);
+        p.setProperty("database", "test");
+
+        // TODO: SQL-2294: Support direct cluster mode (This should no longer expect an exception after that).
+        assertThrows(
+                java.sql.SQLException.class,
+                () -> {
+                    MongoConnection conn =
+                            (MongoConnection) DriverManager.getConnection(fullURI, p);
+                });
+    }
+
+    // todo:
+    //   - test community cluster expects SQLException
+    //   - test enterprise cluster expects successful connection
+}

--- a/src/integration-test/java/com/mongodb/jdbc/integration/DCIntegrationTest.java
+++ b/src/integration-test/java/com/mongodb/jdbc/integration/DCIntegrationTest.java
@@ -77,7 +77,7 @@ public class DCIntegrationTest {
         Properties p = new java.util.Properties();
         p.setProperty("user", user);
         p.setProperty("password", pwd);
-        p.setProperty("authSource", "admin");
+        p.setProperty("authSource", "test");
         p.setProperty("database", "test");
 
         return new Pair<>(uri, p);

--- a/src/integration-test/java/com/mongodb/jdbc/integration/DCIntegrationTest.java
+++ b/src/integration-test/java/com/mongodb/jdbc/integration/DCIntegrationTest.java
@@ -18,7 +18,7 @@ public class DCIntegrationTest {
 
     /** Tests that the driver can work with SRV-style URIs. */
     @Test
-    public void testConnectWithSRVURI() {
+    public void testConnectWithSRVURI() throws SQLException {
         String mongoHost = System.getenv("SRV_TEST_HOST");
         assertNotNull(mongoHost, "SRV_TEST_HOST variable not set in environment");
         String mongoURI =
@@ -40,13 +40,8 @@ public class DCIntegrationTest {
         p.setProperty("authSource", authSource);
         p.setProperty("database", "test");
 
-        // TODO: SQL-2294: Support direct cluster mode (This should no longer expect an exception after that).
-        assertThrows(
-                java.sql.SQLException.class,
-                () -> {
-                    MongoConnection conn =
-                            (MongoConnection) DriverManager.getConnection(fullURI, p);
-                });
+        MongoConnection conn = (MongoConnection) DriverManager.getConnection(fullURI, p);
+        conn.close();
     }
 
     /**

--- a/src/integration-test/java/com/mongodb/jdbc/integration/DCIntegrationTest.java
+++ b/src/integration-test/java/com/mongodb/jdbc/integration/DCIntegrationTest.java
@@ -56,10 +56,10 @@ public class DCIntegrationTest {
 
         String uri = "jdbc:mongodb://localhost:" + mongoPort + "/test";
 
-        String user = System.getenv("MDB_LOCAL_USER");
-        assertNotNull(user, "MDB_LOCAL_USER variable not set in environment");
-        String pwd = System.getenv("MDB_LOCAL_PWD");
-        assertNotNull(pwd, "MDB_LOCAL_PWD variable not set in environment");
+        String user = System.getenv("LOCAL_MDB_USER");
+        assertNotNull(user, "LOCAL_MDB_USER variable not set in environment");
+        String pwd = System.getenv("LOCAL_MDB_PWD");
+        assertNotNull(pwd, "LOCAL_MDB_PWD variable not set in environment");
 
         Properties p = new java.util.Properties();
         p.setProperty("user", user);

--- a/src/integration-test/java/com/mongodb/jdbc/integration/DCIntegrationTest.java
+++ b/src/integration-test/java/com/mongodb/jdbc/integration/DCIntegrationTest.java
@@ -1,17 +1,30 @@
+/*
+ * Copyright 2024-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc.integration;
 
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.mongodb.jdbc.MongoConnection;
 import com.mongodb.jdbc.Pair;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.function.Executable;
-
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Properties;
-
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class DCIntegrationTest {
@@ -79,7 +92,8 @@ public class DCIntegrationTest {
                 java.sql.SQLException.class,
                 () -> {
                     MongoConnection conn =
-                            (MongoConnection) DriverManager.getConnection(info.left(), info.right());
+                            (MongoConnection)
+                                    DriverManager.getConnection(info.left(), info.right());
                 });
     }
 
@@ -87,7 +101,8 @@ public class DCIntegrationTest {
     @Test
     public void testConnectionToEnterpriseServerSucceeds() throws SQLException {
         Pair<String, Properties> info = createLocalMongodConnInfo("LOCAL_MDB_PORT_ENT");
-        MongoConnection conn = (MongoConnection) DriverManager.getConnection(info.left(), info.right());
+        MongoConnection conn =
+                (MongoConnection) DriverManager.getConnection(info.left(), info.right());
         conn.close();
     }
 }

--- a/src/integration-test/java/com/mongodb/jdbc/integration/DCIntegrationTest.java
+++ b/src/integration-test/java/com/mongodb/jdbc/integration/DCIntegrationTest.java
@@ -2,8 +2,10 @@ package com.mongodb.jdbc.integration;
 
 
 import com.mongodb.jdbc.MongoConnection;
+import com.mongodb.jdbc.Pair;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.function.Executable;
 
 import java.sql.DriverManager;
 import java.sql.SQLException;
@@ -16,7 +18,7 @@ public class DCIntegrationTest {
 
     /** Tests that the driver can work with SRV-style URIs. */
     @Test
-    public void testConnectWithSRVURI() throws SQLException {
+    public void testConnectWithSRVURI() {
         String mongoHost = System.getenv("SRV_TEST_HOST");
         assertNotNull(mongoHost, "SRV_TEST_HOST variable not set in environment");
         String mongoURI =
@@ -47,7 +49,50 @@ public class DCIntegrationTest {
                 });
     }
 
-    // todo:
-    //   - test community cluster expects SQLException
-    //   - test enterprise cluster expects successful connection
+    /**
+     * Gets information from the environment to create a connection to a local mongod.
+     *
+     * @param typeEnvVar Either "MDB_LOCAL_PORT_COM" or "MDB_LOCAL_PORT_ENT"
+     * @return A (jdbc_uri, properties) pair with which to create a MongoConnection
+     */
+    private Pair<String, Properties> createLocalMongodConnInfo(String typeEnvVar) {
+        String mongoPort = System.getenv(typeEnvVar);
+        assertNotNull(mongoPort, typeEnvVar + " variable not set in environment");
+
+        String uri = "jdbc:mongodb://localhost:" + mongoPort + "/test";
+
+        String user = System.getenv("MDB_LOCAL_USER");
+        assertNotNull(user, "MDB_LOCAL_USER variable not set in environment");
+        String pwd = System.getenv("MDB_LOCAL_PWD");
+        assertNotNull(pwd, "MDB_LOCAL_PWD variable not set in environment");
+
+        Properties p = new java.util.Properties();
+        p.setProperty("user", user);
+        p.setProperty("password", pwd);
+        p.setProperty("authSource", "admin");
+        p.setProperty("database", "test");
+
+        return new Pair<>(uri, p);
+    }
+
+    /** Tests that the driver rejects the community edition of the server. */
+    @Test
+    public void testConnectionToCommunityServerFails() {
+        Pair<String, Properties> info = createLocalMongodConnInfo("LOCAL_MDB_PORT_COM");
+
+        assertThrows(
+                java.sql.SQLException.class,
+                () -> {
+                    MongoConnection conn =
+                            (MongoConnection) DriverManager.getConnection(info.left(), info.right());
+                });
+    }
+
+    /** Tests that the driver connects to the enterprise edition of the server. */
+    @Test
+    public void testConnectionToEnterpriseServerSucceeds() throws SQLException {
+        Pair<String, Properties> info = createLocalMongodConnInfo("LOCAL_MDB_PORT_ENT");
+        MongoConnection conn = (MongoConnection) DriverManager.getConnection(info.left(), info.right());
+        conn.close();
+    }
 }

--- a/src/integration-test/java/com/mongodb/jdbc/integration/testharness/TestGenerator.java
+++ b/src/integration-test/java/com/mongodb/jdbc/integration/testharness/TestGenerator.java
@@ -17,7 +17,7 @@
 package com.mongodb.jdbc.integration.testharness;
 
 import com.mongodb.jdbc.MongoResultSetMetaData;
-import com.mongodb.jdbc.integration.MongoIntegrationTest;
+import com.mongodb.jdbc.integration.ADFIntegrationTest;
 import com.mongodb.jdbc.integration.testharness.models.TestEntry;
 import java.io.File;
 import java.io.FileWriter;
@@ -151,9 +151,9 @@ public class TestGenerator {
 
     public static void main(String[] args)
             throws SQLException, IOException, InvocationTargetException, IllegalAccessException {
-        MongoIntegrationTest integrationTest = new MongoIntegrationTest();
+        ADFIntegrationTest integrationTest = new ADFIntegrationTest();
         List<TestEntry> tests =
-                IntegrationTestUtils.loadTestConfigs(MongoIntegrationTest.TEST_DIRECTORY);
+                IntegrationTestUtils.loadTestConfigs(ADFIntegrationTest.TEST_DIRECTORY);
         for (TestEntry testEntry : tests) {
             try (Connection conn = integrationTest.getBasicConnection(testEntry.db, null)) {
                 if (testEntry.skip_reason != null) {

--- a/src/main/java/com/mongodb/jdbc/BuildInfo.java
+++ b/src/main/java/com/mongodb/jdbc/BuildInfo.java
@@ -24,4 +24,5 @@ public class BuildInfo {
     public String version;
     public Set<String> modules;
     public BsonValue dataLake;
+    public int ok;
 }

--- a/src/main/java/com/mongodb/jdbc/BuildInfo.java
+++ b/src/main/java/com/mongodb/jdbc/BuildInfo.java
@@ -1,8 +1,23 @@
+/*
+ * Copyright 2024-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.jdbc;
 
-import org.bson.BsonValue;
-
 import java.util.Set;
+import org.bson.BsonValue;
 
 // Simple POJO for deserializing buildInfo results.
 public class BuildInfo {

--- a/src/main/java/com/mongodb/jdbc/BuildInfo.java
+++ b/src/main/java/com/mongodb/jdbc/BuildInfo.java
@@ -1,0 +1,12 @@
+package com.mongodb.jdbc;
+
+import org.bson.BsonValue;
+
+import java.util.Set;
+
+// Simple POJO for deserializing buildInfo results.
+public class BuildInfo {
+    public String version;
+    public Set<String> modules;
+    public BsonValue dataLake;
+}

--- a/src/main/java/com/mongodb/jdbc/MongoConnection.java
+++ b/src/main/java/com/mongodb/jdbc/MongoConnection.java
@@ -94,7 +94,8 @@ public class MongoConnection implements Connection {
     protected enum MongoClusterType {
         AtlasDataFederation,
         Community,
-        Enterprise
+        Enterprise,
+        UnknownTarget
     }
 
     public MongoConnection(
@@ -208,6 +209,11 @@ public class MongoConnection implements Connection {
                         .getDatabase("admin")
                         .withCodecRegistry(MongoDriver.registry)
                         .runCommand(buildInfoCmd, BuildInfo.class);
+
+        // if "ok" is not 1, then the target type could not be determined.
+        if (buildInfoRes.ok != 1) {
+            return MongoClusterType.UnknownTarget;
+        }
 
         // If the "dataLake" field is present, it must be an ADF cluster.
         if (buildInfoRes.dataLake != null) {

--- a/src/main/java/com/mongodb/jdbc/MongoConnection.java
+++ b/src/main/java/com/mongodb/jdbc/MongoConnection.java
@@ -78,6 +78,7 @@ public class MongoConnection implements Connection {
     protected String url;
     protected String user;
     protected boolean isClosed;
+    protected MongoClusterType clusterType;
     private MongoLogger logger;
     protected int connectionId;
     private static AtomicInteger connectionCounter = new AtomicInteger();
@@ -89,6 +90,12 @@ public class MongoConnection implements Connection {
     private boolean extJsonMode;
     private UuidRepresentation uuidRepresentation;
     private String appName;
+
+    protected enum MongoClusterType {
+        AtlasDataFederation,
+        Community,
+        Enterprise
+    }
 
     public MongoConnection(
             MongoClient mongoClient, MongoConnectionProperties connectionProperties) {
@@ -524,6 +531,9 @@ public class MongoConnection implements Connection {
     class ConnValidation implements Callable<Void> {
         @Override
         public Void call() throws SQLException {
+            // TODO: Update this to call BuildInfo and determine the cluster type.
+            //   - Community is disallowed (throw SQLException("community disallowed"))
+            //   - Enterprise and ADF are ok; store in clusterType field
             Statement statement = createStatement();
             boolean resultExists = statement.execute("SELECT 1");
             if (!resultExists) {

--- a/src/main/java/com/mongodb/jdbc/MongoConnection.java
+++ b/src/main/java/com/mongodb/jdbc/MongoConnection.java
@@ -580,6 +580,10 @@ public class MongoConnection implements Connection {
                                 "Enterprise edition detected, but mongosqltranslate library not found");
                     }
                     break;
+                case UnknownTarget:
+                    // Target could not be determined.
+                    throw new SQLException(
+                            "Unknown cluster/target type detected. The JDBC driver is intended for use with MongoDB Enterprise edition or Atlas Data Federation.");
             }
 
             // Set the cluster type.


### PR DESCRIPTION
This PR updates `MongoConnection` to use a `buildInfo` command instead of a `SELECT 1` query to test the connection, and to determine and store the cluster type based on the `buildInfo` result. It also updates the integration tests to be split into `ADFIntegrationTest` and `DCIntegrationTest` (direct cluster), and adds tests demonstrating community server is disallowed but enterprise server is allowed. I'm still working out any kinks in the evergreen and script updates/additions so bear with me on those!