### PR TITLE
SQL-2299: Use github token for cloning instead of ssh

### DIFF
--- a/.evg.yml
+++ b/.evg.yml
@@ -84,10 +84,12 @@ tasks:
 
   - name: "test-integration"
     commands:
+      - func: "generate github token"
       - func: "run integration test"
 
   - name: "test-smoke"
     commands:
+      - func: "generate github token"
       - func: "run smoke test"
 
   - name: "publish-maven"
@@ -377,10 +379,19 @@ functions:
         # Test loading library from same directory as where the JDBC driver is located
         ./gradlew runMongoSQLTranslateLibTest -PtestMethod=testLibraryLoadingFromDriverPath
 
+  "generate github token":
+    command: github.generate_token
+    params:
+      owner: 10gen
+      repo: mongohouse
+      expansion_name: github_token
+
   "run integration test":
     command: shell.exec
     type: test
     params:
+      env:
+        GITHUB_TOKEN: "${github_token}"
       shell: bash
       working_dir: mongo-jdbc-driver
       script: |
@@ -453,6 +464,8 @@ functions:
     command: shell.exec
     type: test
     params:
+      env:
+        GITHUB_TOKEN: "${github_token}"
       working_dir: mongo-jdbc-driver
       script: |
         ${PREPARE_SHELL}

--- a/resources/run_adf.sh
+++ b/resources/run_adf.sh
@@ -49,9 +49,18 @@ GO="$GOBINDIR/go"
 
 PATH=$GOBINDIR:$PATH
 
+# GITHUB_TOKEN must be set for cloning 10gen/mongohouse repository from Evergreen hosts, and the
+# dependencies needed to built it.
+# If unset, it will default to using the SSH private key on the local system.
+if [[ ${GITHUB_TOKEN} ]]; then
+  MONGOHOUSE_URI=https://x-access-token:${GITHUB_TOKEN}@github.com/10gen/mongohouse.git
+  git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
+else
+  MONGOHOUSE_URI=git@github.com:10gen/mongohouse.git
+fi
+
 MACHINE_ARCH=$(uname -m)
 LOCAL_INSTALL_DIR=$(pwd)/local_adf
-MONGOHOUSE_URI=git@github.com:10gen/mongohouse.git
 MONGO_DB_PATH=$LOCAL_INSTALL_DIR/test_db
 LOGS_PATH=$LOCAL_INSTALL_DIR/logs
 DB_CONFIG_PATH=$(pwd)/resources/integration_test/testdata/adf_db_config.json

--- a/resources/run_adf.sh
+++ b/resources/run_adf.sh
@@ -50,7 +50,7 @@ GO="$GOBINDIR/go"
 PATH=$GOBINDIR:$PATH
 
 # GITHUB_TOKEN must be set for cloning 10gen/mongohouse repository from Evergreen hosts, and the
-# dependencies needed to built it.
+# dependencies needed to build it.
 # If unset, it will default to using the SSH private key on the local system.
 if [[ ${GITHUB_TOKEN} ]]; then
   MONGOHOUSE_URI=https://x-access-token:${GITHUB_TOKEN}@github.com/10gen/mongohouse.git


### PR DESCRIPTION
Generates the github token for cloning mongohouse.  The token also has permissions for mongohouse dependencies ie mongoast, sqlproxy, bsonutil.  If `GITHUB_TOKEN` is set `run_adf.sh` will use that token, otherwise revert to the way git clone is done currently (in case user does have the ssh key on local system). 

Here's a [patch](https://spruce.mongodb.com/version/66dc88eda92a3900071e48f5/tasks?page=0&sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC&variant=%5Eubuntu2204-64-jdk-8%24) with the github token change, it was run on a host with the ssh key removed that the devprod team provided to test the changes.
+    run_on: DEVPROD-5742-ubuntu2204-small

When approved I'll add similar changes to the other repos that need it: mongo-odbc-driver, mongo-powerbi-connector