### PR TITLE
SQL-2375: Implement column metadata logic for Direct Cluster

### DIFF
--- a/src/main/java/com/mongodb/jdbc/MongoDatabaseMetaData.java
+++ b/src/main/java/com/mongodb/jdbc/MongoDatabaseMetaData.java
@@ -1536,7 +1536,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
     // Helper for getting column data for all columns from all tables from a specific
     // database. Used by getColumns and getColumnPrivileges. The caller specifies how
     // to serialize the column info into BSON documents for the result set.
-    Stream<BsonDocument> getColumnsFromDB(
+    private Stream<BsonDocument> getColumnsFromDB(
             String dbName,
             Pattern tableNamePatternRE,
             Pattern columnNamePatternRE,

--- a/src/main/java/com/mongodb/jdbc/MongoDatabaseMetaData.java
+++ b/src/main/java/com/mongodb/jdbc/MongoDatabaseMetaData.java
@@ -17,11 +17,13 @@
 package com.mongodb.jdbc;
 
 import static com.mongodb.jdbc.BsonTypeInfo.*;
+import static com.mongodb.jdbc.mongosql.MongoSQLTranslate.SQL_SCHEMAS_COLLECTION;
 
 import com.mongodb.client.ListIndexesIterable;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.jdbc.logging.AutoLoggable;
 import com.mongodb.jdbc.logging.MongoLogger;
+import com.mongodb.jdbc.mongosql.MongoSQLException;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
@@ -66,7 +68,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
     private static final String INDEX_KEY_KEY = "key";
     private static final String INDEX_NAME_KEY = "name";
 
-    private static final List<String> UNIQUE_KEY_PATH = Arrays.asList("options", "unique");
+    private static final List<String> UNIQUE_KEY_PATH = Collections.singletonList("unique");
 
     private static final String PROCEDURE_CAT = "PROCEDURE_CAT";
     private static final String PROCEDURE_SCHEM = "PROCEDURE_SCHEM";
@@ -1534,7 +1536,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
     // Helper for getting column data for all columns from all tables from a specific
     // database. Used by getColumns and getColumnPrivileges. The caller specifies how
     // to serialize the column info into BSON documents for the result set.
-    private Stream<BsonDocument> getColumnsFromDB(
+    Stream<BsonDocument> getColumnsFromDB(
             String dbName,
             Pattern tableNamePatternRE,
             Pattern columnNamePatternRE,
@@ -1546,21 +1548,26 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
                 .collect(Collectors.toList())
                 .stream()
 
-                // filter only for collections matching the pattern
+                // filter only for collections matching the pattern, and exclude the `__sql_schemas` collection
                 .filter(
                         tableName ->
-                                tableNamePatternRE == null
-                                        || tableNamePatternRE.matcher(tableName).matches())
+                                (tableNamePatternRE == null
+                                                || tableNamePatternRE.matcher(tableName).matches())
+                                        && !tableName.equals(SQL_SCHEMAS_COLLECTION))
 
                 // map the collection names into triples of (dbName, tableName, tableSchema)
                 .map(
-                        tableName ->
-                                new Pair<>(
+                        tableName -> {
+                            try {
+                                return new Pair<>(
                                         new Pair<>(dbName, tableName),
-                                        db.runCommand(
-                                                new BsonDocument(
-                                                        "sqlGetSchema", new BsonString(tableName)),
-                                                MongoJsonSchemaResult.class)))
+                                        getSchemaByClusterType(db, tableName));
+                            } catch (MongoSQLException | MongoSerializationException e) {
+                                throw new RuntimeException(
+                                        "Error retrieving schema for: " + dbName + "." + tableName,
+                                        e);
+                            }
+                        })
 
                 // filter only for collections that have schemas
                 .filter(p -> isValidSchema(p.right()))
@@ -1601,6 +1608,20 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
                                                                     entry.getValue(),
                                                                     idx.getAndIncrement())));
                         });
+    }
+
+    private MongoJsonSchemaResult getSchemaByClusterType(MongoDatabase db, String tableName)
+            throws MongoSQLException, MongoSerializationException {
+        if (conn.getClusterType() == MongoConnection.MongoClusterType.AtlasDataFederation) {
+            return db.runCommand(
+                    new BsonDocument("sqlGetSchema", new BsonString(tableName)),
+                    MongoJsonSchemaResult.class);
+        } else if (conn.getClusterType() == MongoConnection.MongoClusterType.Enterprise) {
+            return conn.getMongosqlTranslate().getSchema(db, tableName);
+        } else {
+            throw new UnsupportedOperationException(
+                    "Unsupported cluster type: " + conn.getClusterType());
+        }
     }
 
     @Override
@@ -1864,12 +1885,13 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
 
         // We've found the first unique index. At this point, we get the schema for this
         // collection and create a result set based on this index's keys.
-        MongoJsonSchemaResult r =
-                this.conn
-                        .getDatabase(namespace.left())
-                        .runCommand(
-                                new BsonDocument("sqlGetSchema", new BsonString(namespace.right())),
-                                MongoJsonSchemaResult.class);
+        MongoJsonSchemaResult r;
+        try {
+            r = getSchemaByClusterType(conn.getDatabase(namespace.left()), namespace.right());
+        } catch (MongoSQLException | MongoSerializationException e) {
+            throw new RuntimeException(
+                    "Error retrieving schema for collection: " + namespace.right(), e);
+        }
 
         Document keys = indexInfo.get(INDEX_KEY_KEY, Document.class);
         try {

--- a/src/main/java/com/mongodb/jdbc/mongosql/MongoSQLTranslate.java
+++ b/src/main/java/com/mongodb/jdbc/mongosql/MongoSQLTranslate.java
@@ -309,7 +309,7 @@ public class MongoSQLTranslate {
                                 Projections.fields(
                                         Projections.exclude("_id"),
                                         Projections.computed("schema.jsonSchema", "$schema"),
-                                        Projections.computed("schema.version", new BsonInt64(1)))),
+                                        Projections.computed("schema.version", new BsonInt32(1)))),
                         Aggregates.addFields(new Field<>("ok", new BsonInt32(1))));
 
         MongoCollection<BsonDocument> schemasCollection =


### PR DESCRIPTION
Added a function that formats the collection schema from `__sql_schemas` in a similar way to sqlGetSchemas and use that for direct cluster mode when processing column metadata.  Seemed most straightforward way with how the existing logic is, processing each collection. 

Tested manually against mongod using the `com.mongodb.jdbc.demo` package
```
            ResultSet db_rs = dbm.getColumns("build", "%", "testcol", "%");
            printResultSet(db_rs);
            ResultSet row_rs = dbm.getBestRowIdentifier("build", null, "testcol", 0, true);
            printResultSet(row_rs);
```
Output for getSchema():
```
{"schema": {"jsonSchema": {"bsonType": "object", "properties": {"_id": {"bsonType": "objectId"}, "a": {"bsonType": "int"}}, "required": ["_id", "a"], "additionalProperties": false}}, "ok": 1}
```
Output for printResultSet():
```
+------------|-------------|------------|-------------|------------|------------|-------------|---------------|----------------|----------------|------------|------------|------------|---------------|------------------|-------------------|------------------|-------------|---------------|--------------|-------------|------------------|------------------|--------------------+
| TABLE_CAT  | TABLE_SCHEM | TABLE_NAME | COLUMN_NAME | DATA_TYPE  | TYPE_NAME  | COLUMN_SIZE | BUFFER_LENGTH | DECIMAL_DIGITS | NUM_PREC_RADIX | NULLABLE   | REMARKS    | COLUMN_DEF | SQL_DATA_TYPE | SQL_DATETIME_SUB | CHAR_OCTET_LENGTH | ORDINAL_POSITION | IS_NULLABLE | SCOPE_CATALOG | SCOPE_SCHEMA | SCOPE_TABLE | SOURCE_DATA_TYPE | IS_AUTOINCREMENT | IS_GENERATEDCOLUMN |
+------------|-------------|------------|-------------|------------|------------|-------------|---------------|----------------|----------------|------------|------------|------------|---------------|------------------|-------------------|------------------|-------------|---------------|--------------|-------------|------------------|------------------|--------------------+
| build      | null        | testcol    | _id         | 1111       | objectId   | null        | 0             | null           | 0              | 0          |            | null       | 0             | 0                | null              | 0                | NO          | null          | null         | null        | 0                | NO               |                    |
| build      | null        | testcol    | a           | 4          | int        | null        | 0             | null           | 2              | 0          |            | null       | 0             | 0                | null              | 1                | NO          | null          | null         | null        | 0                | NO               |                    |
+------------|-------------|------------|-------------|------------|------------|-------------|---------------|----------------|----------------|------------|------------|------------|---------------|------------------|-------------------|------------------|-------------|---------------|--------------|-------------|------------------|------------------|--------------------+

+------------|-------------|------------|------------|-------------|---------------|----------------|---------------+
| SCOPE      | COLUMN_NAME | DATA_TYPE  | TYPE_NAME  | COLUMN_SIZE | BUFFER_LENGTH | DECIMAL_DIGITS | PSEUDO_COLUMN |
+------------|-------------|------------|------------|-------------|---------------|----------------|---------------+
| null       | a           | 4          | int        | 10          | null          | null           | 1             |
+------------|-------------|------------|------------|-------------|---------------|----------------|---------------+
```