### PR TITLE
SQL-2397: evergreen updates

### DIFF
--- a/.evg.yml
+++ b/.evg.yml
@@ -133,9 +133,10 @@ tasks:
   - name: sbom
     commands:
       - func: "generate sbom"
-      - func: "upload sbom"
-      - func: "push SBOM Lite to Silk"
-      - func: "pull augmented SBOM from Silk"
+      # TODO: uncomment this before merging branch back into master, to ensure we still upload to silk from the main branch
+      # - func: "upload sbom"
+      # - func: "push SBOM Lite to Silk"
+      # - func: "pull augmented SBOM from Silk"
       - func: "scan sbom"
 
   - name: ssdlc-artifacts-release

--- a/.evg.yml
+++ b/.evg.yml
@@ -7,11 +7,11 @@ variables:
     params:
       role_arn: ${assume_role_arn}
       duration_seconds: 3600
-  - &aws_std_config
+  - &evg_bucket_config
     aws_key: ${AWS_ACCESS_KEY_ID}
     aws_secret: ${AWS_SECRET_ACCESS_KEY}
     aws_session_token: ${AWS_SESSION_TOKEN}
-    bucket: mongo-jdbc-driver-eap
+    bucket: evg-bucket-mongo-jdbc-driver
 
 pre:
   - func: "fetch source"
@@ -152,6 +152,8 @@ tasks:
       - func: "scan sbom"
 
   - name: ssdlc-artifacts-release
+    # TODO: remove this before merging eap branch back into main branch, to allow download center to update.
+    disable: true
     run_on: ubuntu2204-small
     git_tag_only: true
     depends_on:
@@ -233,7 +235,7 @@ functions:
           ls -lrt $SSDLC_DIR
     - command: s3.put
       params:
-        <<: *aws_std_config
+        <<: *evg_bucket_config
         local_file: mongo-jdbc-driver/artifacts/ssdlc/${AUGMENTED_SBOM_NAME}
         remote_file: artifacts/${version_id}/ssdlc/${AUGMENTED_SBOM_NAME}
         content_type: application/json
@@ -243,7 +245,7 @@ functions:
     - *assume_role_cmd
     - command: s3.get
       params:
-        <<: *aws_std_config
+        <<: *evg_bucket_config
         local_file: artifacts/ssdlc/mongodb-jdbc-${MDBJDBC_VER}.sbom.json
         remote_file: artifacts/${version_id}/ssdlc/${AUGMENTED_SBOM_NAME}
         content_type: application/json
@@ -307,7 +309,7 @@ functions:
     - *assume_role_cmd
     - command: s3.put
       params:
-        <<: *aws_std_config
+        <<: *evg_bucket_config
         local_files_include_filter:
           - ${SBOM_LITE_NAME}
         remote_file: artifacts/${version_id}/ssdlc/
@@ -666,7 +668,7 @@ functions:
     - command: s3.get
       params:
         working_dir: mongo-jdbc-driver
-        <<: *aws_std_config
+        <<: *evg_bucket_config
         local_file: mongo-jdbc-driver/build/libs/mongodb-jdbc-eap-${MDBJDBC_VER}.jar
         remote_file: ${S3_ARTIFACTS_DIR}/mongodb-jdbc-eap-${MDBJDBC_VER}.jar
 
@@ -686,7 +688,7 @@ functions:
     - command: s3.put
       params:
         silent: true
-        <<: *aws_std_config
+        <<: *evg_bucket_config
         local_files_include_filter:
             - mongo-jdbc-driver/build/reports/tests/test/classes/*.html
         remote_file: ${S3_ARTIFACTS_DIR}/test/classes/
@@ -700,7 +702,7 @@ functions:
     - command: s3.put
       params:
         silent: true
-        <<: *aws_std_config
+        <<: *evg_bucket_config
         local_files_include_filter:
             - mongo-jdbc-driver/build/reports/tests/integrationTest/classes/*.html
         remote_file: ${S3_ARTIFACTS_DIR}/integrationTest/classes/
@@ -714,7 +716,7 @@ functions:
     - command: s3.put
       params:
         silent: true
-        <<: *aws_std_config
+        <<: *evg_bucket_config
         local_files_include_filter:
             - mongo-jdbc-driver/build/reports/tests/test/packages/*.html
         remote_file: ${S3_ARTIFACTS_DIR}/test/packages/
@@ -728,7 +730,7 @@ functions:
     - command: s3.put
       params:
         silent: true
-        <<: *aws_std_config
+        <<: *evg_bucket_config
         local_files_include_filter:
             - mongo-jdbc-driver/build/reports/tests/integrationTest/packages/*.html
         remote_file: ${S3_ARTIFACTS_DIR}/integrationTest/packages/
@@ -742,7 +744,7 @@ functions:
     - command: s3.put
       params:
         silent: true
-        <<: *aws_std_config
+        <<: *evg_bucket_config
         local_file: mongo-jdbc-driver/build/reports/tests/test/index.html
         remote_file: ${S3_ARTIFACTS_DIR}/test/index.html
         content_type: text/html
@@ -754,7 +756,7 @@ functions:
     - command: s3.put
       params:
         silent: true
-        <<: *aws_std_config
+        <<: *evg_bucket_config
         local_file: mongo-jdbc-driver/build/reports/tests/integrationTest/index.html
         remote_file: ${S3_ARTIFACTS_DIR}/integrationTest/index.html
         content_type: text/html
@@ -766,7 +768,7 @@ functions:
     - command: s3.put
       params:
         silent: true
-        <<: *aws_std_config
+        <<: *evg_bucket_config
         local_files_include_filter:
             - mongo-jdbc-driver/build/reports/tests/test/css/*.css
         remote_file: ${S3_ARTIFACTS_DIR}/test/css/
@@ -780,7 +782,7 @@ functions:
     - command: s3.put
       params:
         silent: true
-        <<: *aws_std_config
+        <<: *evg_bucket_config
         local_files_include_filter:
             - mongo-jdbc-driver/build/reports/tests/integrationTest/css/*.css
         remote_file: ${S3_ARTIFACTS_DIR}/integrationTest/css/
@@ -794,7 +796,7 @@ functions:
     - command: s3.put
       params:
         silent: true
-        <<: *aws_std_config
+        <<: *evg_bucket_config
         local_files_include_filter:
             - mongo-jdbc-driver/build/reports/tests/test/js/*.js
         remote_file: ${S3_ARTIFACTS_DIR}/test/js/
@@ -808,7 +810,7 @@ functions:
     - command: s3.put
       params:
         silent: true
-        <<: *aws_std_config
+        <<: *evg_bucket_config
         local_files_include_filter:
             - mongo-jdbc-driver/build/reports/tests/integrationTest/js/*.js
         remote_file: ${S3_ARTIFACTS_DIR}/integrationTest/js/
@@ -838,7 +840,7 @@ functions:
     - command: s3.put
       params:
         silent: true
-        <<: *aws_std_config
+        <<: *evg_bucket_config
         local_files_include_filter:
           - mongo-jdbc-driver/build/libs/*.jar
         remote_file: ${S3_ARTIFACTS_DIR}/
@@ -911,7 +913,7 @@ functions:
           exit $SCAN_RESULT
     - command: s3.put
       params:
-        <<: *aws_std_config
+        <<: *evg_bucket_config
         local_files_include_filter:
           - mongo-jdbc-driver.sast.*
         remote_file: artifacts/${version_id}/ssdlc/
@@ -922,7 +924,7 @@ functions:
     - *assume_role_cmd
     - command: s3.get
       params:
-        <<: *aws_std_config
+        <<: *evg_bucket_config
         local_file: artifacts/ssdlc/mongodb-jdbc-${MDBJDBC_VER}.sast.sarif
         remote_file: artifacts/${version_id}/ssdlc/${STATIC_CODE_ANALYSIS_NAME}
         content_type: application/json
@@ -985,7 +987,7 @@ functions:
     - *assume_role_cmd
     - command: s3.put
       params:
-        <<: *aws_std_config
+        <<: *evg_bucket_config
         local_file: mongo-jdbc-driver/${COMPLIANCE_REPORT_NAME}
         remote_file: artifacts/${version_id}/ssdlc/${COMPLIANCE_REPORT_NAME}
         content_type: text/markdown
@@ -995,7 +997,7 @@ functions:
     - *assume_role_cmd
     - command: s3.get
       params:
-        <<: *aws_std_config
+        <<: *evg_bucket_config
         local_file: artifacts/ssdlc/mongodb-jdbc-${MDBJDBC_VER}-compliance-report.md
         remote_file: artifacts/${version_id}/ssdlc/${COMPLIANCE_REPORT_NAME}
         content_type: text/markdown

--- a/.evg.yml
+++ b/.evg.yml
@@ -1,6 +1,18 @@
 stepback: true
 command_type: system
 
+variables:
+  - &assume_role_cmd
+    command: ec2.assume_role
+    params:
+      role_arn: ${assume_role_arn}
+      duration_seconds: 3600
+  - &aws_std_config
+    aws_key: ${AWS_ACCESS_KEY_ID}
+    aws_secret: ${AWS_SECRET_ACCESS_KEY}
+    aws_session_token: ${AWS_SESSION_TOKEN}
+    bucket: evg-bucket-mongo-jdbc-driver
+
 pre:
   - func: "fetch source"
   - func: "export variables"
@@ -164,10 +176,11 @@ tasks:
         variant: code-quality-and-correctness
     exec_timeout_secs: 300 # 5m
     commands:
-      - func: "publish augmented SBOM"
-      - func: "publish static code analysis"
+      # TODO: undo these comments before merging back into main
+      # - func: "publish augmented SBOM"
+      # - func: "publish static code analysis"
       - func: "generate compliance report"
-      - func: "publish compliance report"
+      # - func: "publish compliance report"
 
 functions:
   "push SBOM Lite to Silk":
@@ -195,10 +208,7 @@ functions:
           echo "-------------------------------"
 
   "pull augmented SBOM from Silk":
-    - command: ec2.assume_role
-      params:
-        role_arn: ${assume_role_arn}
-        duration_seconds: 3600
+    - *assume_role_cmd
     - command: shell.exec
       type: test
       params:
@@ -223,9 +233,7 @@ functions:
           ls -lrt $SSDLC_DIR
     - command: s3.put
       params:
-        aws_key: ${AWS_ACCESS_KEY_ID}
-        aws_secret: ${AWS_SECRET_ACCESS_KEY}
-        aws_session_token: ${AWS_SESSION_TOKEN}
+        <<: *aws_std_config
         local_file: mongo-jdbc-driver/artifacts/ssdlc/${AUGMENTED_SBOM_NAME}
         remote_file: artifacts/${version_id}/ssdlc/${AUGMENTED_SBOM_NAME}
         content_type: application/json
@@ -233,15 +241,10 @@ functions:
         permissions: public-read
 
   "publish augmented SBOM":
-    - command: ec2.assume_role
-      params:
-        role_arn: ${assume_role_arn}
-        duration_seconds: 3600
+    - *assume_role_cmd
     - command: s3.get
       params:
-        aws_key: ${AWS_ACCESS_KEY_ID}
-        aws_secret: ${AWS_SECRET_ACCESS_KEY}
-        aws_session_token: ${AWS_SESSION_TOKEN}
+        <<: *aws_std_config
         local_file: artifacts/ssdlc/mongodb-jdbc-${MDBJDBC_VER}.sbom.json
         remote_file: artifacts/${version_id}/ssdlc/${AUGMENTED_SBOM_NAME}
         content_type: application/json
@@ -303,15 +306,10 @@ functions:
           echo "------------------------------------"
 
   "upload sbom":
-    - command: ec2.assume_role
-      params:
-        role_arn: ${assume_role_arn}
-        duration_seconds: 3600
+    - *assume_role_cmd
     - command: s3.put
       params:
-        aws_key: ${AWS_ACCESS_KEY_ID}
-        aws_secret: ${AWS_SECRET_ACCESS_KEY}
-        aws_session_token: ${AWS_SESSION_TOKEN}
+        <<: *aws_std_config
         local_files_include_filter:
           - ${SBOM_LITE_NAME}
         remote_file: artifacts/${version_id}/ssdlc/
@@ -667,16 +665,11 @@ functions:
         file: mongo-jdbc-driver/artifacts/expansions.yml
 
   "fetch jdbc files":
-    - command: ec2.assume_role
-      params:
-        role_arn: ${assume_role_arn}
-        duration_seconds: 3600
+    - *assume_role_cmd
     - command: s3.get
       params:
         working_dir: mongo-jdbc-driver
-        aws_key: ${AWS_ACCESS_KEY_ID}
-        aws_secret: ${AWS_SECRET_ACCESS_KEY}
-        aws_session_token: ${AWS_SESSION_TOKEN}
+        <<: *aws_std_config
         local_file: mongo-jdbc-driver/build/libs/mongodb-jdbc-eap-${MDBJDBC_VER}.jar
         remote_file: ${S3_ARTIFACTS_DIR}/mongodb-jdbc-eap-${MDBJDBC_VER}.jar
         bucket: mongo-jdbc-driver-eap
@@ -693,16 +686,11 @@ functions:
         directory: mongo-jdbc-driver
 
   "upload unit test classes":
-    - command: ec2.assume_role
-      params:
-        role_arn: ${assume_role_arn}
-        duration_seconds: 3600
+    - *assume_role_cmd
     - command: s3.put
       params:
         silent: true
-        aws_key: ${AWS_ACCESS_KEY_ID}
-        aws_secret: ${AWS_SECRET_ACCESS_KEY}
-        aws_session_token: ${AWS_SESSION_TOKEN}
+        <<: *aws_std_config
         local_files_include_filter:
             - mongo-jdbc-driver/build/reports/tests/test/classes/*.html
         remote_file: ${S3_ARTIFACTS_DIR}/test/classes/
@@ -713,16 +701,11 @@ functions:
         visibility: none
 
   "upload integration test classes":
-    - command: ec2.assume_role
-      params:
-        role_arn: ${assume_role_arn}
-        duration_seconds: 3600
+    - *assume_role_cmd
     - command: s3.put
       params:
         silent: true
-        aws_key: ${AWS_ACCESS_KEY_ID}
-        aws_secret: ${AWS_SECRET_ACCESS_KEY}
-        aws_session_token: ${AWS_SESSION_TOKEN}
+        <<: *aws_std_config
         local_files_include_filter:
             - mongo-jdbc-driver/build/reports/tests/integrationTest/classes/*.html
         remote_file: ${S3_ARTIFACTS_DIR}/integrationTest/classes/
@@ -733,16 +716,11 @@ functions:
         visibility: none
 
   "upload unit test packages":
-    - command: ec2.assume_role
-      params:
-        role_arn: ${assume_role_arn}
-        duration_seconds: 3600
+    - *assume_role_cmd
     - command: s3.put
       params:
         silent: true
-        aws_key: ${AWS_ACCESS_KEY_ID}
-        aws_secret: ${AWS_SECRET_ACCESS_KEY}
-        aws_session_token: ${AWS_SESSION_TOKEN}
+        <<: *aws_std_config
         local_files_include_filter:
             - mongo-jdbc-driver/build/reports/tests/test/packages/*.html
         remote_file: ${S3_ARTIFACTS_DIR}/test/packages/
@@ -753,16 +731,11 @@ functions:
         visibility: none
 
   "upload integration test packages":
-    - command: ec2.assume_role
-      params:
-        role_arn: ${assume_role_arn}
-        duration_seconds: 3600
+    - *assume_role_cmd
     - command: s3.put
       params:
         silent: true
-        aws_key: ${AWS_ACCESS_KEY_ID}
-        aws_secret: ${AWS_SECRET_ACCESS_KEY}
-        aws_session_token: ${AWS_SESSION_TOKEN}
+        <<: *aws_std_config
         local_files_include_filter:
             - mongo-jdbc-driver/build/reports/tests/integrationTest/packages/*.html
         remote_file: ${S3_ARTIFACTS_DIR}/integrationTest/packages/
@@ -773,16 +746,11 @@ functions:
         visibility: none
 
   "upload unit test index":
-    - command: ec2.assume_role
-      params:
-        role_arn: ${assume_role_arn}
-        duration_seconds: 3600
+    - *assume_role_cmd
     - command: s3.put
       params:
         silent: true
-        aws_key: ${AWS_ACCESS_KEY_ID}
-        aws_secret: ${AWS_SECRET_ACCESS_KEY}
-        aws_session_token: ${AWS_SESSION_TOKEN}
+        <<: *aws_std_config
         local_file: mongo-jdbc-driver/build/reports/tests/test/index.html
         remote_file: ${S3_ARTIFACTS_DIR}/test/index.html
         content_type: text/html
@@ -791,16 +759,11 @@ functions:
         display_name: "Unit Test Results"
 
   "upload integration test index":
-    - command: ec2.assume_role
-      params:
-        role_arn: ${assume_role_arn}
-        duration_seconds: 3600
+    - *assume_role_cmd
     - command: s3.put
       params:
         silent: true
-        aws_key: ${AWS_ACCESS_KEY_ID}
-        aws_secret: ${AWS_SECRET_ACCESS_KEY}
-        aws_session_token: ${AWS_SESSION_TOKEN}
+        <<: *aws_std_config
         local_file: mongo-jdbc-driver/build/reports/tests/integrationTest/index.html
         remote_file: ${S3_ARTIFACTS_DIR}/integrationTest/index.html
         content_type: text/html
@@ -809,16 +772,11 @@ functions:
         display_name: "Integration Test Results"
 
   "upload unit test css ":
-    - command: ec2.assume_role
-      params:
-        role_arn: ${assume_role_arn}
-        duration_seconds: 3600
+    - *assume_role_cmd
     - command: s3.put
       params:
         silent: true
-        aws_key: ${AWS_ACCESS_KEY_ID}
-        aws_secret: ${AWS_SECRET_ACCESS_KEY}
-        aws_session_token: ${AWS_SESSION_TOKEN}
+        <<: *aws_std_config
         local_files_include_filter:
             - mongo-jdbc-driver/build/reports/tests/test/css/*.css
         remote_file: ${S3_ARTIFACTS_DIR}/test/css/
@@ -829,16 +787,11 @@ functions:
         visibility: none
 
   "upload integration test css ":
-    - command: ec2.assume_role
-      params:
-        role_arn: ${assume_role_arn}
-        duration_seconds: 3600
+    - *assume_role_cmd
     - command: s3.put
       params:
         silent: true
-        aws_key: ${AWS_ACCESS_KEY_ID}
-        aws_secret: ${AWS_SECRET_ACCESS_KEY}
-        aws_session_token: ${AWS_SESSION_TOKEN}
+        <<: *aws_std_config
         local_files_include_filter:
             - mongo-jdbc-driver/build/reports/tests/integrationTest/css/*.css
         remote_file: ${S3_ARTIFACTS_DIR}/integrationTest/css/
@@ -849,16 +802,11 @@ functions:
         visibility: none
 
   "upload unit test js":
-    - command: ec2.assume_role
-      params:
-        role_arn: ${assume_role_arn}
-        duration_seconds: 3600
+    - *assume_role_cmd
     - command: s3.put
       params:
         silent: true
-        aws_key: ${AWS_ACCESS_KEY_ID}
-        aws_secret: ${AWS_SECRET_ACCESS_KEY}
-        aws_session_token: ${AWS_SESSION_TOKEN}
+        <<: *aws_std_config
         local_files_include_filter:
             - mongo-jdbc-driver/build/reports/tests/test/js/*.js
         remote_file: ${S3_ARTIFACTS_DIR}/test/js/
@@ -869,16 +817,11 @@ functions:
         visibility: none
 
   "upload integration test js":
-    - command: ec2.assume_role
-      params:
-        role_arn: ${assume_role_arn}
-        duration_seconds: 3600
+    - *assume_role_cmd
     - command: s3.put
       params:
         silent: true
-        aws_key: ${AWS_ACCESS_KEY_ID}
-        aws_secret: ${AWS_SECRET_ACCESS_KEY}
-        aws_session_token: ${AWS_SESSION_TOKEN}
+        <<: *aws_std_config
         local_files_include_filter:
             - mongo-jdbc-driver/build/reports/tests/integrationTest/js/*.js
         remote_file: ${S3_ARTIFACTS_DIR}/integrationTest/js/
@@ -895,10 +838,7 @@ functions:
         file: mongo-jdbc-driver/build/test-results/*/TEST-*.xml
 
   "upload jar file":
-    - command: ec2.assume_role
-      params:
-        role_arn: ${assume_role_arn}
-        duration_seconds: 3600
+    - *assume_role_cmd
     - command: shell.exec
       type: test
       params:
@@ -906,13 +846,13 @@ functions:
         working_dir: mongo-jdbc-driver
         script: |
           ${PREPARE_SHELL}
-          mv "build/libs/$(ls -AU build/libs | head -1)" build/libs/mongodb-jdbc-eap-${MDBJDBC_VER}.jar
+          if [ -d "build/libs" ]; then
+            mv "build/libs/$(ls -AU build/libs | head -1)" build/libs/mongodb-jdbc-eap-${MDBJDBC_VER}.jar
+          fi
     - command: s3.put
       params:
         silent: true
-        aws_key: ${AWS_ACCESS_KEY_ID}
-        aws_secret: ${AWS_SECRET_ACCESS_KEY}
-        aws_session_token: ${AWS_SESSION_TOKEN}
+        <<: *aws_std_config
         local_files_include_filter:
           - mongo-jdbc-driver/build/libs/*.jar
         remote_file: ${S3_ARTIFACTS_DIR}/
@@ -952,10 +892,7 @@ functions:
         content_type: application/json
 
   "static code analysis":
-    - command: ec2.assume_role
-      params:
-        role_arn: ${assume_role_arn}
-        duration_seconds: 3600
+    - *assume_role_cmd
     - command: shell.exec
       type: test
       params:
@@ -989,9 +926,7 @@ functions:
           exit $SCAN_RESULT
     - command: s3.put
       params:
-        aws_key: ${AWS_ACCESS_KEY_ID}
-        aws_secret: ${AWS_SECRET_ACCESS_KEY}
-        aws_session_token: ${AWS_SESSION_TOKEN}
+        <<: *aws_std_config
         local_files_include_filter:
           - mongo-jdbc-driver.sast.*
         remote_file: artifacts/${version_id}/ssdlc/
@@ -1000,15 +935,10 @@ functions:
         permissions: public-read
 
   "publish static code analysis":
-    - command: ec2.assume_role
-      params:
-        role_arn: ${assume_role_arn}
-        duration_seconds: 3600
+    - *assume_role_cmd
     - command: s3.get
       params:
-        aws_key: ${AWS_ACCESS_KEY_ID}
-        aws_secret: ${AWS_SECRET_ACCESS_KEY}
-        aws_session_token: ${AWS_SESSION_TOKEN}
+        <<: *aws_std_config
         local_file: artifacts/ssdlc/mongodb-jdbc-${MDBJDBC_VER}.sast.sarif
         remote_file: artifacts/${version_id}/ssdlc/${STATIC_CODE_ANALYSIS_NAME}
         content_type: application/json
@@ -1069,15 +999,10 @@ functions:
           echo "sed -i.bu "s,%AUTHOR_EMAIL%,${author_email},g" ${COMPLIANCE_REPORT_NAME}"
           sed -i.bu "s,%AUTHOR_EMAIL%,${author_email},g" ${COMPLIANCE_REPORT_NAME}
           echo "---------------------------"
-    - command: ec2.assume_role
-      params:
-        role_arn: ${assume_role_arn}
-        duration_seconds: 3600
+    - *assume_role_cmd
     - command: s3.put
       params:
-        aws_key: ${AWS_ACCESS_KEY_ID}
-        aws_secret: ${AWS_SECRET_ACCESS_KEY}
-        aws_session_token: ${AWS_SESSION_TOKEN}
+        <<: *aws_std_config
         local_file: mongo-jdbc-driver/${COMPLIANCE_REPORT_NAME}
         remote_file: artifacts/${version_id}/ssdlc/${COMPLIANCE_REPORT_NAME}
         content_type: text/markdown
@@ -1085,15 +1010,10 @@ functions:
         permissions: public-read
 
   "publish compliance report":
-    - command: ec2.assume_role
-      params:
-        role_arn: ${assume_role_arn}
-        duration_seconds: 3600
+    - *assume_role_cmd
     - command: s3.get
       params:
-        aws_key: ${AWS_ACCESS_KEY_ID}
-        aws_secret: ${AWS_SECRET_ACCESS_KEY}
-        aws_session_token: ${AWS_SESSION_TOKEN}
+        <<: *aws_std_config
         local_file: artifacts/ssdlc/mongodb-jdbc-${MDBJDBC_VER}-compliance-report.md
         remote_file: artifacts/${version_id}/ssdlc/${COMPLIANCE_REPORT_NAME}
         content_type: text/markdown

--- a/.evg.yml
+++ b/.evg.yml
@@ -719,7 +719,6 @@ functions:
             - mongo-jdbc-driver/build/reports/tests/test/packages/*.html
         remote_file: ${S3_ARTIFACTS_DIR}/test/packages/
         content_type: text/html
-        bucket: mongo-jdbc-driver-eap
         permissions: public-read
         display_name: "Unit Test Packages"
         visibility: none

--- a/.evg.yml
+++ b/.evg.yml
@@ -11,7 +11,7 @@ variables:
     aws_key: ${AWS_ACCESS_KEY_ID}
     aws_secret: ${AWS_SECRET_ACCESS_KEY}
     aws_session_token: ${AWS_SESSION_TOKEN}
-    bucket: evg-bucket-mongo-jdbc-driver
+    bucket: mongo-jdbc-driver-eap
 
 pre:
   - func: "fetch source"
@@ -146,7 +146,7 @@ tasks:
     commands:
       - func: "generate sbom"
       # TODO: uncomment this before merging branch back into master, to ensure we still upload to silk from the main branch
-      # - func: "upload sbom"
+      - func: "upload sbom"
       # - func: "push SBOM Lite to Silk"
       # - func: "pull augmented SBOM from Silk"
       - func: "scan sbom"
@@ -237,7 +237,6 @@ functions:
         local_file: mongo-jdbc-driver/artifacts/ssdlc/${AUGMENTED_SBOM_NAME}
         remote_file: artifacts/${version_id}/ssdlc/${AUGMENTED_SBOM_NAME}
         content_type: application/json
-        bucket: mongo-jdbc-driver-eap
         permissions: public-read
 
   "publish augmented SBOM":
@@ -248,7 +247,6 @@ functions:
         local_file: artifacts/ssdlc/mongodb-jdbc-${MDBJDBC_VER}.sbom.json
         remote_file: artifacts/${version_id}/ssdlc/${AUGMENTED_SBOM_NAME}
         content_type: application/json
-        bucket: mongo-jdbc-driver-eap
     - command: s3.put
       params:
         aws_key: ${release_aws_key}
@@ -314,7 +312,6 @@ functions:
           - ${SBOM_LITE_NAME}
         remote_file: artifacts/${version_id}/ssdlc/
         content_type: application/json
-        bucket: mongo-jdbc-driver-eap
         permissions: public-read
 
   "scan sbom":
@@ -672,7 +669,6 @@ functions:
         <<: *aws_std_config
         local_file: mongo-jdbc-driver/build/libs/mongodb-jdbc-eap-${MDBJDBC_VER}.jar
         remote_file: ${S3_ARTIFACTS_DIR}/mongodb-jdbc-eap-${MDBJDBC_VER}.jar
-        bucket: mongo-jdbc-driver-eap
 
   "fetch source":
     - command: shell.exec
@@ -695,7 +691,6 @@ functions:
             - mongo-jdbc-driver/build/reports/tests/test/classes/*.html
         remote_file: ${S3_ARTIFACTS_DIR}/test/classes/
         content_type: text/html
-        bucket: mongo-jdbc-driver-eap
         permissions: public-read
         display_name: "Unit Test Classes"
         visibility: none
@@ -710,7 +705,6 @@ functions:
             - mongo-jdbc-driver/build/reports/tests/integrationTest/classes/*.html
         remote_file: ${S3_ARTIFACTS_DIR}/integrationTest/classes/
         content_type: text/html
-        bucket: mongo-jdbc-driver-eap
         permissions: public-read
         display_name: "Integration Test Classes"
         visibility: none
@@ -740,7 +734,6 @@ functions:
             - mongo-jdbc-driver/build/reports/tests/integrationTest/packages/*.html
         remote_file: ${S3_ARTIFACTS_DIR}/integrationTest/packages/
         content_type: text/html
-        bucket: mongo-jdbc-driver-eap
         permissions: public-read
         display_name: "Integration Test Packages"
         visibility: none
@@ -754,7 +747,6 @@ functions:
         local_file: mongo-jdbc-driver/build/reports/tests/test/index.html
         remote_file: ${S3_ARTIFACTS_DIR}/test/index.html
         content_type: text/html
-        bucket: mongo-jdbc-driver-eap
         permissions: public-read
         display_name: "Unit Test Results"
 
@@ -767,7 +759,6 @@ functions:
         local_file: mongo-jdbc-driver/build/reports/tests/integrationTest/index.html
         remote_file: ${S3_ARTIFACTS_DIR}/integrationTest/index.html
         content_type: text/html
-        bucket: mongo-jdbc-driver-eap
         permissions: public-read
         display_name: "Integration Test Results"
 
@@ -781,7 +772,6 @@ functions:
             - mongo-jdbc-driver/build/reports/tests/test/css/*.css
         remote_file: ${S3_ARTIFACTS_DIR}/test/css/
         content_type: text/css
-        bucket: mongo-jdbc-driver-eap
         permissions: public-read
         display_name: "Unit Test CSS"
         visibility: none
@@ -796,7 +786,6 @@ functions:
             - mongo-jdbc-driver/build/reports/tests/integrationTest/css/*.css
         remote_file: ${S3_ARTIFACTS_DIR}/integrationTest/css/
         content_type: text/css
-        bucket: mongo-jdbc-driver-eap
         permissions: public-read
         display_name: "Integration Test CSS"
         visibility: none
@@ -811,7 +800,6 @@ functions:
             - mongo-jdbc-driver/build/reports/tests/test/js/*.js
         remote_file: ${S3_ARTIFACTS_DIR}/test/js/
         content_type: application/javascript
-        bucket: mongo-jdbc-driver-eap
         permissions: public-read
         display_name: "Unit Test JS"
         visibility: none
@@ -826,7 +814,6 @@ functions:
             - mongo-jdbc-driver/build/reports/tests/integrationTest/js/*.js
         remote_file: ${S3_ARTIFACTS_DIR}/integrationTest/js/
         content_type: application/javascript
-        bucket: mongo-jdbc-driver-eap
         permissions: public-read
         display_name: "Integration Test JS"
         visibility: none
@@ -857,7 +844,6 @@ functions:
           - mongo-jdbc-driver/build/libs/*.jar
         remote_file: ${S3_ARTIFACTS_DIR}/
         content_type: application/java-archive
-        bucket: mongo-jdbc-driver-eap
         permissions: public-read
 
   "publish maven":
@@ -931,7 +917,6 @@ functions:
           - mongo-jdbc-driver.sast.*
         remote_file: artifacts/${version_id}/ssdlc/
         content_type: application/json
-        bucket: mongo-jdbc-driver-eap
         permissions: public-read
 
   "publish static code analysis":
@@ -942,7 +927,6 @@ functions:
         local_file: artifacts/ssdlc/mongodb-jdbc-${MDBJDBC_VER}.sast.sarif
         remote_file: artifacts/${version_id}/ssdlc/${STATIC_CODE_ANALYSIS_NAME}
         content_type: application/json
-        bucket: mongo-jdbc-driver-eap
     - command: s3.put
       params:
         aws_key: ${release_aws_key}
@@ -1006,7 +990,6 @@ functions:
         local_file: mongo-jdbc-driver/${COMPLIANCE_REPORT_NAME}
         remote_file: artifacts/${version_id}/ssdlc/${COMPLIANCE_REPORT_NAME}
         content_type: text/markdown
-        bucket: mongo-jdbc-driver-eap
         permissions: public-read
 
   "publish compliance report":
@@ -1017,7 +1000,6 @@ functions:
         local_file: artifacts/ssdlc/mongodb-jdbc-${MDBJDBC_VER}-compliance-report.md
         remote_file: artifacts/${version_id}/ssdlc/${COMPLIANCE_REPORT_NAME}
         content_type: text/markdown
-        bucket: mongo-jdbc-driver-eap
     - command: s3.put
       params:
         aws_key: ${release_aws_key}

--- a/.evg.yml
+++ b/.evg.yml
@@ -116,6 +116,8 @@ tasks:
       - func: "check spotless"
 
   - name: download-center-update
+    # TODO: remove this before merging eap branch back into main branch, to allow download center to update.
+    disable: true
     git_tag_only: true
     depends_on:
       - name: "publish-maven"
@@ -664,14 +666,19 @@ functions:
         file: mongo-jdbc-driver/artifacts/expansions.yml
 
   "fetch jdbc files":
+    - command: ec2.assume_role
+      params:
+        role_arn: ${assume_role_arn}
+        duration_seconds: 3600
     - command: s3.get
       params:
         working_dir: mongo-jdbc-driver
-        aws_key: ${aws_key}
-        aws_secret: ${aws_secret}
+        aws_key: ${AWS_ACCESS_KEY_ID}
+        aws_secret: ${AWS_SECRET_ACCESS_KEY}
+        aws_session_token: ${AWS_SESSION_TOKEN}
         local_file: mongo-jdbc-driver/build/libs/mongodb-jdbc-eap-${MDBJDBC_VER}.jar
         remote_file: ${S3_ARTIFACTS_DIR}/mongodb-jdbc-eap-${MDBJDBC_VER}.jar
-        bucket: mciuploads
+        bucket: evg-bucket-mongo-jdbc-driver
 
   "fetch source":
     - command: shell.exec
@@ -685,147 +692,197 @@ functions:
         directory: mongo-jdbc-driver
 
   "upload unit test classes":
+    - command: ec2.assume_role
+      params:
+        role_arn: ${assume_role_arn}
+        duration_seconds: 3600
     - command: s3.put
       params:
         silent: true
-        aws_key: ${aws_key}
-        aws_secret: ${aws_secret}
+        aws_key: ${AWS_ACCESS_KEY_ID}
+        aws_secret: ${AWS_SECRET_ACCESS_KEY}
+        aws_session_token: ${AWS_SESSION_TOKEN}
         local_files_include_filter:
             - mongo-jdbc-driver/build/reports/tests/test/classes/*.html
         remote_file: ${S3_ARTIFACTS_DIR}/test/classes/
         content_type: text/html
-        bucket: mciuploads
+        bucket: evg-bucket-mongo-jdbc-driver
         permissions: public-read
         display_name: "Unit Test Classes"
         visibility: none
 
   "upload integration test classes":
+    - command: ec2.assume_role
+      params:
+        role_arn: ${assume_role_arn}
+        duration_seconds: 3600
     - command: s3.put
       params:
         silent: true
-        aws_key: ${aws_key}
-        aws_secret: ${aws_secret}
+        aws_key: ${AWS_ACCESS_KEY_ID}
+        aws_secret: ${AWS_SECRET_ACCESS_KEY}
+        aws_session_token: ${AWS_SESSION_TOKEN}
         local_files_include_filter:
             - mongo-jdbc-driver/build/reports/tests/integrationTest/classes/*.html
         remote_file: ${S3_ARTIFACTS_DIR}/integrationTest/classes/
         content_type: text/html
-        bucket: mciuploads
+        bucket: evg-bucket-mongo-jdbc-driver
         permissions: public-read
         display_name: "Integration Test Classes"
         visibility: none
 
   "upload unit test packages":
+    - command: ec2.assume_role
+      params:
+        role_arn: ${assume_role_arn}
+        duration_seconds: 3600
     - command: s3.put
       params:
         silent: true
-        aws_key: ${aws_key}
-        aws_secret: ${aws_secret}
+        aws_key: ${AWS_ACCESS_KEY_ID}
+        aws_secret: ${AWS_SECRET_ACCESS_KEY}
+        aws_session_token: ${AWS_SESSION_TOKEN}
         local_files_include_filter:
             - mongo-jdbc-driver/build/reports/tests/test/packages/*.html
         remote_file: ${S3_ARTIFACTS_DIR}/test/packages/
         content_type: text/html
-        bucket: mciuploads
+        bucket: evg-bucket-mongo-jdbc-driver
         permissions: public-read
         display_name: "Unit Test Packages"
         visibility: none
 
   "upload integration test packages":
+    - command: ec2.assume_role
+      params:
+        role_arn: ${assume_role_arn}
+        duration_seconds: 3600
     - command: s3.put
       params:
         silent: true
-        aws_key: ${aws_key}
-        aws_secret: ${aws_secret}
+        aws_key: ${AWS_ACCESS_KEY_ID}
+        aws_secret: ${AWS_SECRET_ACCESS_KEY}
+        aws_session_token: ${AWS_SESSION_TOKEN}
         local_files_include_filter:
             - mongo-jdbc-driver/build/reports/tests/integrationTest/packages/*.html
         remote_file: ${S3_ARTIFACTS_DIR}/integrationTest/packages/
         content_type: text/html
-        bucket: mciuploads
+        bucket: evg-bucket-mongo-jdbc-driver
         permissions: public-read
         display_name: "Integration Test Packages"
         visibility: none
 
   "upload unit test index":
+    - command: ec2.assume_role
+      params:
+        role_arn: ${assume_role_arn}
+        duration_seconds: 3600
     - command: s3.put
       params:
         silent: true
-        aws_key: ${aws_key}
-        aws_secret: ${aws_secret}
+        aws_key: ${AWS_ACCESS_KEY_ID}
+        aws_secret: ${AWS_SECRET_ACCESS_KEY}
+        aws_session_token: ${AWS_SESSION_TOKEN}
         local_file: mongo-jdbc-driver/build/reports/tests/test/index.html
         remote_file: ${S3_ARTIFACTS_DIR}/test/index.html
         content_type: text/html
-        bucket: mciuploads
+        bucket: evg-bucket-mongo-jdbc-driver
         permissions: public-read
         display_name: "Unit Test Results"
 
   "upload integration test index":
+    - command: ec2.assume_role
+      params:
+        role_arn: ${assume_role_arn}
+        duration_seconds: 3600
     - command: s3.put
       params:
         silent: true
-        aws_key: ${aws_key}
-        aws_secret: ${aws_secret}
+        aws_key: ${AWS_ACCESS_KEY_ID}
+        aws_secret: ${AWS_SECRET_ACCESS_KEY}
+        aws_session_token: ${AWS_SESSION_TOKEN}
         local_file: mongo-jdbc-driver/build/reports/tests/integrationTest/index.html
         remote_file: ${S3_ARTIFACTS_DIR}/integrationTest/index.html
         content_type: text/html
-        bucket: mciuploads
+        bucket: evg-bucket-mongo-jdbc-driver
         permissions: public-read
         display_name: "Integration Test Results"
 
   "upload unit test css ":
+    - command: ec2.assume_role
+      params:
+        role_arn: ${assume_role_arn}
+        duration_seconds: 3600
     - command: s3.put
       params:
         silent: true
-        aws_key: ${aws_key}
-        aws_secret: ${aws_secret}
+        aws_key: ${AWS_ACCESS_KEY_ID}
+        aws_secret: ${AWS_SECRET_ACCESS_KEY}
+        aws_session_token: ${AWS_SESSION_TOKEN}
         local_files_include_filter:
             - mongo-jdbc-driver/build/reports/tests/test/css/*.css
         remote_file: ${S3_ARTIFACTS_DIR}/test/css/
         content_type: text/css
-        bucket: mciuploads
+        bucket: evg-bucket-mongo-jdbc-driver
         permissions: public-read
         display_name: "Unit Test CSS"
         visibility: none
 
   "upload integration test css ":
+    - command: ec2.assume_role
+      params:
+        role_arn: ${assume_role_arn}
+        duration_seconds: 3600
     - command: s3.put
       params:
         silent: true
-        aws_key: ${aws_key}
-        aws_secret: ${aws_secret}
+        aws_key: ${AWS_ACCESS_KEY_ID}
+        aws_secret: ${AWS_SECRET_ACCESS_KEY}
+        aws_session_token: ${AWS_SESSION_TOKEN}
         local_files_include_filter:
             - mongo-jdbc-driver/build/reports/tests/integrationTest/css/*.css
         remote_file: ${S3_ARTIFACTS_DIR}/integrationTest/css/
         content_type: text/css
-        bucket: mciuploads
+        bucket: evg-bucket-mongo-jdbc-driver
         permissions: public-read
         display_name: "Integration Test CSS"
         visibility: none
 
   "upload unit test js":
+    - command: ec2.assume_role
+      params:
+        role_arn: ${assume_role_arn}
+        duration_seconds: 3600
     - command: s3.put
       params:
         silent: true
-        aws_key: ${aws_key}
-        aws_secret: ${aws_secret}
+        aws_key: ${AWS_ACCESS_KEY_ID}
+        aws_secret: ${AWS_SECRET_ACCESS_KEY}
+        aws_session_token: ${AWS_SESSION_TOKEN}
         local_files_include_filter:
             - mongo-jdbc-driver/build/reports/tests/test/js/*.js
         remote_file: ${S3_ARTIFACTS_DIR}/test/js/
         content_type: application/javascript
-        bucket: mciuploads
+        bucket: evg-bucket-mongo-jdbc-driver
         permissions: public-read
         display_name: "Unit Test JS"
         visibility: none
 
   "upload integration test js":
+    - command: ec2.assume_role
+      params:
+        role_arn: ${assume_role_arn}
+        duration_seconds: 3600
     - command: s3.put
       params:
         silent: true
-        aws_key: ${aws_key}
-        aws_secret: ${aws_secret}
+        aws_key: ${AWS_ACCESS_KEY_ID}
+        aws_secret: ${AWS_SECRET_ACCESS_KEY}
+        aws_session_token: ${AWS_SESSION_TOKEN}
         local_files_include_filter:
             - mongo-jdbc-driver/build/reports/tests/integrationTest/js/*.js
         remote_file: ${S3_ARTIFACTS_DIR}/integrationTest/js/
         content_type: application/javascript
-        bucket: mciuploads
+        bucket: evg-bucket-mongo-jdbc-driver
         permissions: public-read
         display_name: "Integration Test JS"
         visibility: none
@@ -837,17 +894,30 @@ functions:
         file: mongo-jdbc-driver/build/test-results/*/TEST-*.xml
 
   "upload jar file":
+    - command: ec2.assume_role
+      params:
+        role_arn: ${assume_role_arn}
+        duration_seconds: 3600
+    - command: shell.exec
+      type: test
+      params:
+        shell: bash
+        working_dir: mongo-jdbc-driver
+        script: |
+          ${PREPARE_SHELL}
+          mv "build/libs/$(ls -AU build/libs | head -1)" build/libs/mongodb-jdbc-eap-${MDBJDBC_VER}.jar
     - command: s3.put
       params:
         silent: true
-        aws_key: ${aws_key}
-        aws_secret: ${aws_secret}
-        local_file: mongo-jdbc-driver/build/libs/mongodb-jdbc-eap-${MDBJDBC_VER}.jar
-        remote_file: ${S3_ARTIFACTS_DIR}/mongodb-jdbc-eap-${MDBJDBC_VER}.jar
+        aws_key: ${AWS_ACCESS_KEY_ID}
+        aws_secret: ${AWS_SECRET_ACCESS_KEY}
+        aws_session_token: ${AWS_SESSION_TOKEN}
+        local_files_include_filter:
+          - mongo-jdbc-driver/build/libs/*.jar
+        remote_file: ${S3_ARTIFACTS_DIR}/
         content_type: application/java-archive
-        bucket: mciuploads
+        bucket: evg-bucket-mongo-jdbc-driver
         permissions: public-read
-        display_name: "JDBC Driver (.jar)"
 
   "publish maven":
     - command: shell.exec

--- a/.evg.yml
+++ b/.evg.yml
@@ -229,7 +229,7 @@ functions:
         local_file: mongo-jdbc-driver/artifacts/ssdlc/${AUGMENTED_SBOM_NAME}
         remote_file: artifacts/${version_id}/ssdlc/${AUGMENTED_SBOM_NAME}
         content_type: application/json
-        bucket: evg-bucket-mongo-jdbc-driver
+        bucket: mongo-jdbc-driver-eap
         permissions: public-read
 
   "publish augmented SBOM":
@@ -245,7 +245,7 @@ functions:
         local_file: artifacts/ssdlc/mongodb-jdbc-${MDBJDBC_VER}.sbom.json
         remote_file: artifacts/${version_id}/ssdlc/${AUGMENTED_SBOM_NAME}
         content_type: application/json
-        bucket: evg-bucket-mongo-jdbc-driver
+        bucket: mongo-jdbc-driver-eap
     - command: s3.put
       params:
         aws_key: ${release_aws_key}
@@ -316,7 +316,7 @@ functions:
           - ${SBOM_LITE_NAME}
         remote_file: artifacts/${version_id}/ssdlc/
         content_type: application/json
-        bucket: evg-bucket-mongo-jdbc-driver
+        bucket: mongo-jdbc-driver-eap
         permissions: public-read
 
   "scan sbom":
@@ -679,7 +679,7 @@ functions:
         aws_session_token: ${AWS_SESSION_TOKEN}
         local_file: mongo-jdbc-driver/build/libs/mongodb-jdbc-eap-${MDBJDBC_VER}.jar
         remote_file: ${S3_ARTIFACTS_DIR}/mongodb-jdbc-eap-${MDBJDBC_VER}.jar
-        bucket: evg-bucket-mongo-jdbc-driver
+        bucket: mongo-jdbc-driver-eap
 
   "fetch source":
     - command: shell.exec
@@ -707,7 +707,7 @@ functions:
             - mongo-jdbc-driver/build/reports/tests/test/classes/*.html
         remote_file: ${S3_ARTIFACTS_DIR}/test/classes/
         content_type: text/html
-        bucket: evg-bucket-mongo-jdbc-driver
+        bucket: mongo-jdbc-driver-eap
         permissions: public-read
         display_name: "Unit Test Classes"
         visibility: none
@@ -727,7 +727,7 @@ functions:
             - mongo-jdbc-driver/build/reports/tests/integrationTest/classes/*.html
         remote_file: ${S3_ARTIFACTS_DIR}/integrationTest/classes/
         content_type: text/html
-        bucket: evg-bucket-mongo-jdbc-driver
+        bucket: mongo-jdbc-driver-eap
         permissions: public-read
         display_name: "Integration Test Classes"
         visibility: none
@@ -747,7 +747,7 @@ functions:
             - mongo-jdbc-driver/build/reports/tests/test/packages/*.html
         remote_file: ${S3_ARTIFACTS_DIR}/test/packages/
         content_type: text/html
-        bucket: evg-bucket-mongo-jdbc-driver
+        bucket: mongo-jdbc-driver-eap
         permissions: public-read
         display_name: "Unit Test Packages"
         visibility: none
@@ -767,7 +767,7 @@ functions:
             - mongo-jdbc-driver/build/reports/tests/integrationTest/packages/*.html
         remote_file: ${S3_ARTIFACTS_DIR}/integrationTest/packages/
         content_type: text/html
-        bucket: evg-bucket-mongo-jdbc-driver
+        bucket: mongo-jdbc-driver-eap
         permissions: public-read
         display_name: "Integration Test Packages"
         visibility: none
@@ -786,7 +786,7 @@ functions:
         local_file: mongo-jdbc-driver/build/reports/tests/test/index.html
         remote_file: ${S3_ARTIFACTS_DIR}/test/index.html
         content_type: text/html
-        bucket: evg-bucket-mongo-jdbc-driver
+        bucket: mongo-jdbc-driver-eap
         permissions: public-read
         display_name: "Unit Test Results"
 
@@ -804,7 +804,7 @@ functions:
         local_file: mongo-jdbc-driver/build/reports/tests/integrationTest/index.html
         remote_file: ${S3_ARTIFACTS_DIR}/integrationTest/index.html
         content_type: text/html
-        bucket: evg-bucket-mongo-jdbc-driver
+        bucket: mongo-jdbc-driver-eap
         permissions: public-read
         display_name: "Integration Test Results"
 
@@ -823,7 +823,7 @@ functions:
             - mongo-jdbc-driver/build/reports/tests/test/css/*.css
         remote_file: ${S3_ARTIFACTS_DIR}/test/css/
         content_type: text/css
-        bucket: evg-bucket-mongo-jdbc-driver
+        bucket: mongo-jdbc-driver-eap
         permissions: public-read
         display_name: "Unit Test CSS"
         visibility: none
@@ -843,7 +843,7 @@ functions:
             - mongo-jdbc-driver/build/reports/tests/integrationTest/css/*.css
         remote_file: ${S3_ARTIFACTS_DIR}/integrationTest/css/
         content_type: text/css
-        bucket: evg-bucket-mongo-jdbc-driver
+        bucket: mongo-jdbc-driver-eap
         permissions: public-read
         display_name: "Integration Test CSS"
         visibility: none
@@ -863,7 +863,7 @@ functions:
             - mongo-jdbc-driver/build/reports/tests/test/js/*.js
         remote_file: ${S3_ARTIFACTS_DIR}/test/js/
         content_type: application/javascript
-        bucket: evg-bucket-mongo-jdbc-driver
+        bucket: mongo-jdbc-driver-eap
         permissions: public-read
         display_name: "Unit Test JS"
         visibility: none
@@ -883,7 +883,7 @@ functions:
             - mongo-jdbc-driver/build/reports/tests/integrationTest/js/*.js
         remote_file: ${S3_ARTIFACTS_DIR}/integrationTest/js/
         content_type: application/javascript
-        bucket: evg-bucket-mongo-jdbc-driver
+        bucket: mongo-jdbc-driver-eap
         permissions: public-read
         display_name: "Integration Test JS"
         visibility: none
@@ -917,7 +917,7 @@ functions:
           - mongo-jdbc-driver/build/libs/*.jar
         remote_file: ${S3_ARTIFACTS_DIR}/
         content_type: application/java-archive
-        bucket: evg-bucket-mongo-jdbc-driver
+        bucket: mongo-jdbc-driver-eap
         permissions: public-read
 
   "publish maven":
@@ -996,7 +996,7 @@ functions:
           - mongo-jdbc-driver.sast.*
         remote_file: artifacts/${version_id}/ssdlc/
         content_type: application/json
-        bucket: evg-bucket-mongo-jdbc-driver
+        bucket: mongo-jdbc-driver-eap
         permissions: public-read
 
   "publish static code analysis":
@@ -1012,7 +1012,7 @@ functions:
         local_file: artifacts/ssdlc/mongodb-jdbc-${MDBJDBC_VER}.sast.sarif
         remote_file: artifacts/${version_id}/ssdlc/${STATIC_CODE_ANALYSIS_NAME}
         content_type: application/json
-        bucket: evg-bucket-mongo-jdbc-driver
+        bucket: mongo-jdbc-driver-eap
     - command: s3.put
       params:
         aws_key: ${release_aws_key}
@@ -1081,7 +1081,7 @@ functions:
         local_file: mongo-jdbc-driver/${COMPLIANCE_REPORT_NAME}
         remote_file: artifacts/${version_id}/ssdlc/${COMPLIANCE_REPORT_NAME}
         content_type: text/markdown
-        bucket: evg-bucket-mongo-jdbc-driver
+        bucket: mongo-jdbc-driver-eap
         permissions: public-read
 
   "publish compliance report":
@@ -1097,7 +1097,7 @@ functions:
         local_file: artifacts/ssdlc/mongodb-jdbc-${MDBJDBC_VER}-compliance-report.md
         remote_file: artifacts/${version_id}/ssdlc/${COMPLIANCE_REPORT_NAME}
         content_type: text/markdown
-        bucket: evg-bucket-mongo-jdbc-driver
+        bucket: mongo-jdbc-driver-eap
     - command: s3.put
       params:
         aws_key: ${release_aws_key}

--- a/.evg.yml
+++ b/.evg.yml
@@ -99,6 +99,8 @@ tasks:
       - func: "run smoke test"
 
   - name: "publish-maven"
+    # TODO: remove this before merging eap branch back into main branch, to allow download center to update.
+    disable: true
     git_tag_only: true
     depends_on:
       - name: "test-smoke"
@@ -667,8 +669,8 @@ functions:
         working_dir: mongo-jdbc-driver
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: mongo-jdbc-driver/build/libs/mongodb-jdbc-${MDBJDBC_VER}.jar
-        remote_file: ${S3_ARTIFACTS_DIR}/mongodb-jdbc-${MDBJDBC_VER}.jar
+        local_file: mongo-jdbc-driver/build/libs/mongodb-jdbc-eap-${MDBJDBC_VER}.jar
+        remote_file: ${S3_ARTIFACTS_DIR}/mongodb-jdbc-eap-${MDBJDBC_VER}.jar
         bucket: mciuploads
 
   "fetch source":
@@ -840,8 +842,8 @@ functions:
         silent: true
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: mongo-jdbc-driver/build/libs/mongodb-jdbc-${MDBJDBC_VER}.jar
-        remote_file: ${S3_ARTIFACTS_DIR}/mongodb-jdbc-${MDBJDBC_VER}.jar
+        local_file: mongo-jdbc-driver/build/libs/mongodb-jdbc-eap-${MDBJDBC_VER}.jar
+        remote_file: ${S3_ARTIFACTS_DIR}/mongodb-jdbc-eap-${MDBJDBC_VER}.jar
         content_type: application/java-archive
         bucket: mciuploads
         permissions: public-read


### PR DESCRIPTION
Note all the s3 put changes -- see [DEVPROD-6958](https://jira.mongodb.org/browse/DEVPROD-6958) for context. All of these have been failing for as long as we have evergreen history on this project (eg see [this](https://spruce.mongodb.com/task/mongo_jdbc_driver_amazon2_arm64_jdk_11_build_670aa4089b0a9b0008a950e0_24_10_12_16_30_00/logs?execution=0) run).

[Here](https://spruce.mongodb.com/task/mongo_jdbc_driver_amazon2_arm64_jdk_11_build_patch_85ef3aa7a1eb6cc96f9dda3f1a175ae32ca775c5_670d9414dbe83d00074a371c_24_10_14_21_58_56/logs?execution=0) is a successful build run showing the eap jar with the correct name as an artifact.