### PR TITLE
SQL-2437:  Set release version

### DIFF
--- a/.evg.yml
+++ b/.evg.yml
@@ -494,7 +494,10 @@ functions:
       working_dir: mongo-jdbc-driver
       script: |
         ${PREPARE_SHELL}
-        ./gradlew -Dorg.gradle.java.home=${JAVA_HOME} clean -x test -x integrationTest spotlessApply build shadowjar --rerun-tasks
+        if [[ "${triggered_by_git_tag}" != "" ]]; then
+          EXTRA_PROP="-PisTagTriggered"
+        fi
+        ./gradlew -Dorg.gradle.java.home=${JAVA_HOME} $EXTRA_PROP clean -x test -x integrationTest spotlessApply build shadowjar --rerun-tasks
 
   "check spotless":
     command: shell.exec

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 if (project.hasProperty('isTagTriggered')) {
-    version = getAbbreviatedGitVersion()()
+    version = getAbbreviatedGitVersion()
 } else {
     version = getGitVersion()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,9 @@ if (project.hasProperty('isTagTriggered')) {
 }
 
 ext {
+    println("Driver version = " + version)
     releaseVersion = getReleaseVersion()
-    println(releaseVersion)
+    println("Artifacts version" + releaseVersion)
     javaDataLoader = "com.mongodb.jdbc.integration.testharness.DataLoader"
     javaTestGenerator = "com.mongodb.jdbc.integration.testharness.TestGenerator"
     aspectjVersion = '1.9.7'

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 if (project.hasProperty('isTagTriggered')) {
-    version = getReleaseVersion()
+    version = getAbbreviatedGitVersion()()
 } else {
     version = getGitVersion()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -7,10 +7,15 @@ plugins {
     id "org.cyclonedx.bom" version "1.8.2"
 }
 
-version =  getGitVersion()
+if (project.hasProperty('isTagTriggered')) {
+    version = getReleaseVersion()
+} else {
+    version = getGitVersion()
+}
 
 ext {
     releaseVersion = getReleaseVersion()
+    println(releaseVersion)
     javaDataLoader = "com.mongodb.jdbc.integration.testharness.DataLoader"
     javaTestGenerator = "com.mongodb.jdbc.integration.testharness.TestGenerator"
     aspectjVersion = '1.9.7'
@@ -222,30 +227,10 @@ dependencies {
 }
 
 def getReleaseVersion() {
-	def snapshot = isDirtyVersion() || !isTaggedVersion()
-	if (snapshot) {
+    if (!project.hasProperty('isTagTriggered')) {
 		return getAbbreviatedGitVersion() + "-SNAPSHOT"
 	} else {
-		return getGitVersion()
-	}
-}
-
-def isDirtyVersion() {
-	getGitVersion().endsWith("dirty")
-}
-
-def isTaggedVersion() {
-	def out = new ByteArrayOutputStream()
-	def result = exec {
-		commandLine 'git', 'describe', '--exact'
-		ignoreExitValue true
-		standardOutput out
-		errorOutput out
-	}
-	if (result.getExitValue() == 0) {
-		return true
-	} else {
-		return false
+		return getAbbreviatedGitVersion()
 	}
 }
 


### PR DESCRIPTION
If the property "isTagTriggered" is set, then:
- The release version (jar names) is the abbreviated git version. For example "3.0.0-alpha-libv1.0.0-alpha".
- The driver version (reported by the driver) is also the abbreviated git version.
If the property "isTagTriggered" is not set, then:
- The release version (jar names) is the abbreviated git version followed by `-SNAPSHOT`. For example "3.0.0-alpha-libv1.0.0-alpha-SNAPSHOT".
- The driver version (reported by the driver) is the full git version. For example "3.0.0-alpha-libv1.0.0-alpha-2-gbe21c46-dirty".