### PR TITLE
SQL-2423: correctly report db version

### DIFF
--- a/src/main/java/com/mongodb/jdbc/BuildInfo.java
+++ b/src/main/java/com/mongodb/jdbc/BuildInfo.java
@@ -16,48 +16,62 @@
 
 package com.mongodb.jdbc;
 
-import java.util.Optional;
+import java.util.List;
 import java.util.Set;
 import org.bson.codecs.pojo.annotations.BsonCreator;
 import org.bson.codecs.pojo.annotations.BsonProperty;
 
 public class BuildInfo {
-    public String version;
+    private String fullVersion;
+    private List<Integer> versionArray;
     public Set<String> modules;
     public int ok;
+
     public DataLake dataLake;
 
     @BsonCreator
     public BuildInfo(
             @BsonProperty("version") String version,
+            @BsonProperty("versionArray") List<Integer> versionArray,
             @BsonProperty("modules") Set<String> modules,
             @BsonProperty("ok") int ok,
-            @BsonProperty("dataLake") DataLake dataLake) {
-        this.version = version;
-        this.modules = modules;
-        this.ok = ok;
+            @BsonProperty("dataLake") DataLake dataLake)
+            throws IndexOutOfBoundsException {
+        this.fullVersion = version;
+        this.versionArray = versionArray;
+        if (dataLake != null) {
+            this.fullVersion += "." + dataLake.version + "." + dataLake.mongoSQLVersion;
+        }
         this.dataLake = dataLake;
+        this.ok = ok;
+        this.modules = modules;
     }
 
-    public Optional<DataLake> getDataLakePresence() {
-        return Optional.ofNullable(dataLake);
+    public String getFullVersion() {
+        return this.fullVersion;
     }
 
-    public String getDataLakeVersion() {
-        return getDataLakePresence().map(dl -> "." + dl.version).orElse("");
+    public int getMajorVersion() throws IndexOutOfBoundsException {
+        return this.versionArray.get(0);
     }
 
-    public String getDataLakeMongoSQLVersion() {
-        return getDataLakePresence().map(dl -> "." + dl.mongoSQLVersion).orElse("");
+    public int getMinorVersion() throws IndexOutOfBoundsException {
+        return this.versionArray.get(1);
     }
 
     // Override toString for logging
     @Override
     public String toString() {
         return "BuildInfo{"
-                + "version='"
-                + version
+                + "fullVersion='"
+                + fullVersion
                 + '\''
+                + ", versionArray="
+                + versionArray
+                + ", majorVersion="
+                + this.getMajorVersion()
+                + ", minorVersion="
+                + this.getMinorVersion()
                 + ", modules="
                 + modules
                 + ", ok="

--- a/src/main/java/com/mongodb/jdbc/BuildInfo.java
+++ b/src/main/java/com/mongodb/jdbc/BuildInfo.java
@@ -16,10 +16,10 @@
 
 package com.mongodb.jdbc;
 
+import java.util.Optional;
+import java.util.Set;
 import org.bson.codecs.pojo.annotations.BsonCreator;
 import org.bson.codecs.pojo.annotations.BsonProperty;
-import java.util.Set;
-import java.util.Optional;
 
 public class BuildInfo {
     public String version;
@@ -28,7 +28,11 @@ public class BuildInfo {
     public DataLake dataLake;
 
     @BsonCreator
-    public BuildInfo(@BsonProperty("version") String version, @BsonProperty("modules") Set<String> modules, @BsonProperty("ok") int ok, @BsonProperty("dataLake") DataLake dataLake) {
+    public BuildInfo(
+            @BsonProperty("version") String version,
+            @BsonProperty("modules") Set<String> modules,
+            @BsonProperty("ok") int ok,
+            @BsonProperty("dataLake") DataLake dataLake) {
         this.version = version;
         this.modules = modules;
         this.ok = ok;
@@ -40,22 +44,26 @@ public class BuildInfo {
     }
 
     public String getDataLakeVersion() {
-        return getDataLakePresence().map(dl -> "." +  dl.version).orElse("");
+        return getDataLakePresence().map(dl -> "." + dl.version).orElse("");
     }
 
     public String getDataLakeMongoSQLVersion() {
-        return getDataLakePresence().map(dl -> "." +  dl.mongoSQLVersion).orElse("");
+        return getDataLakePresence().map(dl -> "." + dl.mongoSQLVersion).orElse("");
     }
-
 
     // Override toString for logging
     @Override
     public String toString() {
-        return "BuildInfo{" +
-                "version='" + version + '\'' +
-                ", modules=" + modules +
-                ", ok=" + ok +
-                ", dataLake=" + dataLake +
-                '}';
+        return "BuildInfo{"
+                + "version='"
+                + version
+                + '\''
+                + ", modules="
+                + modules
+                + ", ok="
+                + ok
+                + ", dataLake="
+                + dataLake
+                + '}';
     }
 }

--- a/src/main/java/com/mongodb/jdbc/DataLake.java
+++ b/src/main/java/com/mongodb/jdbc/DataLake.java
@@ -16,20 +16,9 @@
 
 package com.mongodb.jdbc;
 
-import org.bson.codecs.pojo.annotations.BsonCreator;
-import org.bson.codecs.pojo.annotations.BsonProperty;
-
 public class DataLake {
     public String version;
     public String mongoSQLVersion;
-
-    @BsonCreator
-    public DataLake(
-            @BsonProperty("version") String version,
-            @BsonProperty("mongoSQLVersion") String mongoSQLVersion) {
-        this.version = version;
-        this.mongoSQLVersion = mongoSQLVersion;
-    }
 
     // Override toString for logging
     @Override

--- a/src/main/java/com/mongodb/jdbc/DataLake.java
+++ b/src/main/java/com/mongodb/jdbc/DataLake.java
@@ -18,44 +18,25 @@ package com.mongodb.jdbc;
 
 import org.bson.codecs.pojo.annotations.BsonCreator;
 import org.bson.codecs.pojo.annotations.BsonProperty;
-import java.util.Set;
-import java.util.Optional;
 
-public class BuildInfo {
+public class DataLake {
     public String version;
-    public Set<String> modules;
-    public int ok;
-    public DataLake dataLake;
+    public String mongoSQLVersion;
 
     @BsonCreator
-    public BuildInfo(@BsonProperty("version") String version, @BsonProperty("modules") Set<String> modules, @BsonProperty("ok") int ok, @BsonProperty("dataLake") DataLake dataLake) {
+    public DataLake(@BsonProperty("version") String version, @BsonProperty("mongoSQLVersion") String mongoSQLVersion) {
         this.version = version;
-        this.modules = modules;
-        this.ok = ok;
-        this.dataLake = dataLake;
+        this.mongoSQLVersion = mongoSQLVersion;
     }
-
-    public Optional<DataLake> getDataLakePresence() {
-        return Optional.ofNullable(dataLake);
-    }
-
-    public String getDataLakeVersion() {
-        return getDataLakePresence().map(dl -> "." +  dl.version).orElse("");
-    }
-
-    public String getDataLakeMongoSQLVersion() {
-        return getDataLakePresence().map(dl -> "." +  dl.mongoSQLVersion).orElse("");
-    }
-
 
     // Override toString for logging
     @Override
     public String toString() {
-        return "BuildInfo{" +
+        return "DataLake{" +
                 "version='" + version + '\'' +
-                ", modules=" + modules +
-                ", ok=" + ok +
-                ", dataLake=" + dataLake +
+                ", mongoSQLVersion=" + mongoSQLVersion +
                 '}';
     }
 }
+
+

--- a/src/main/java/com/mongodb/jdbc/DataLake.java
+++ b/src/main/java/com/mongodb/jdbc/DataLake.java
@@ -24,7 +24,9 @@ public class DataLake {
     public String mongoSQLVersion;
 
     @BsonCreator
-    public DataLake(@BsonProperty("version") String version, @BsonProperty("mongoSQLVersion") String mongoSQLVersion) {
+    public DataLake(
+            @BsonProperty("version") String version,
+            @BsonProperty("mongoSQLVersion") String mongoSQLVersion) {
         this.version = version;
         this.mongoSQLVersion = mongoSQLVersion;
     }
@@ -32,11 +34,12 @@ public class DataLake {
     // Override toString for logging
     @Override
     public String toString() {
-        return "DataLake{" +
-                "version='" + version + '\'' +
-                ", mongoSQLVersion=" + mongoSQLVersion +
-                '}';
+        return "DataLake{"
+                + "version='"
+                + version
+                + '\''
+                + ", mongoSQLVersion="
+                + mongoSQLVersion
+                + '}';
     }
 }
-
-

--- a/src/main/java/com/mongodb/jdbc/MongoConnection.java
+++ b/src/main/java/com/mongodb/jdbc/MongoConnection.java
@@ -16,8 +16,6 @@
 
 package com.mongodb.jdbc;
 
-import static java.lang.Integer.parseInt;
-
 import com.google.common.base.Preconditions;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoCredential;
@@ -218,23 +216,19 @@ public class MongoConnection implements Connection {
             return MongoClusterType.UnknownTarget;
         }
 
-        logger.log(Level.FINER, buildInfoRes.toString());
+        logger.log(Level.FINE, buildInfoRes.toString());
 
-        this.serverVersion =
-                buildInfoRes.version
-                        + buildInfoRes.getDataLakeVersion()
-                        + buildInfoRes.getDataLakeMongoSQLVersion();
+        this.serverVersion = buildInfoRes.getFullVersion();
 
         try {
-            String[] versionParts = buildInfoRes.version.split("\\.");
-            this.serverMajorVersion = parseInt(versionParts[0], 10);
-            this.serverMinorVersion = parseInt(versionParts[1], 10);
-        } catch (NumberFormatException e) {
-            logger.log(Level.WARNING, e.toString());
+            this.serverMajorVersion = buildInfoRes.getMajorVersion();
+            this.serverMinorVersion = buildInfoRes.getMinorVersion();
+        } catch (IndexOutOfBoundsException e) {
+            logger.log(Level.SEVERE, e.toString());
         }
 
         // If the "dataLake" field is present, it must be an ADF cluster.
-        if (buildInfoRes.getDataLakePresence().isPresent()) {
+        if (buildInfoRes.dataLake != null) {
             // append datalake and mongosql version to server version
             return MongoClusterType.AtlasDataFederation;
         } else if (buildInfoRes.modules != null) {

--- a/src/main/java/com/mongodb/jdbc/MongoConnection.java
+++ b/src/main/java/com/mongodb/jdbc/MongoConnection.java
@@ -16,6 +16,8 @@
 
 package com.mongodb.jdbc;
 
+import static java.lang.Integer.parseInt;
+
 import com.google.common.base.Preconditions;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoCredential;
@@ -31,10 +33,6 @@ import com.mongodb.jdbc.logging.MongoSimpleFormatter;
 import com.mongodb.jdbc.mongosql.MongoSQLException;
 import com.mongodb.jdbc.mongosql.MongoSQLTranslate;
 import com.mongodb.jdbc.oidc.JdbcOidcCallback;
-import org.bson.BsonDocument;
-import org.bson.BsonInt32;
-import org.bson.UuidRepresentation;
-
 import java.io.File;
 import java.io.IOException;
 import java.sql.*;
@@ -45,8 +43,9 @@ import java.util.Properties;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.*;
-
-import static java.lang.Integer.parseInt;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.UuidRepresentation;
 
 @AutoLoggable
 public class MongoConnection implements Connection {
@@ -219,7 +218,10 @@ public class MongoConnection implements Connection {
             return MongoClusterType.UnknownTarget;
         }
 
-        this.serverVersion = this.serverVersion + buildInfoRes.getDataLakeVersion() + buildInfoRes.getDataLakeMongoSQLVersion();
+        this.serverVersion =
+                this.serverVersion
+                        + buildInfoRes.getDataLakeVersion()
+                        + buildInfoRes.getDataLakeMongoSQLVersion();
 
         try {
             String[] versionParts = buildInfoRes.version.split("\\.");

--- a/src/main/java/com/mongodb/jdbc/MongoConnection.java
+++ b/src/main/java/com/mongodb/jdbc/MongoConnection.java
@@ -31,10 +31,6 @@ import com.mongodb.jdbc.logging.MongoSimpleFormatter;
 import com.mongodb.jdbc.mongosql.MongoSQLException;
 import com.mongodb.jdbc.mongosql.MongoSQLTranslate;
 import com.mongodb.jdbc.oidc.JdbcOidcCallback;
-import org.bson.BsonDocument;
-import org.bson.BsonInt32;
-import org.bson.UuidRepresentation;
-
 import java.io.File;
 import java.io.IOException;
 import java.sql.*;
@@ -45,6 +41,9 @@ import java.util.Properties;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.*;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.UuidRepresentation;
 
 @AutoLoggable
 public class MongoConnection implements Connection {

--- a/src/main/java/com/mongodb/jdbc/MongoConnection.java
+++ b/src/main/java/com/mongodb/jdbc/MongoConnection.java
@@ -218,8 +218,10 @@ public class MongoConnection implements Connection {
             return MongoClusterType.UnknownTarget;
         }
 
+        logger.log(Level.FINER, buildInfoRes.toString());
+
         this.serverVersion =
-                this.serverVersion
+                buildInfoRes.version
                         + buildInfoRes.getDataLakeVersion()
                         + buildInfoRes.getDataLakeMongoSQLVersion();
 
@@ -569,6 +571,12 @@ public class MongoConnection implements Connection {
         @Override
         public Void call() throws SQLException, MongoSQLException, MongoSerializationException {
             MongoClusterType actualClusterType = determineClusterType();
+            String serverInfo =
+                    "Connecting to cluster type "
+                            + actualClusterType.toString()
+                            + " with server version "
+                            + serverVersion;
+            logger.log(Level.INFO, serverInfo);
 
             switch (actualClusterType) {
                 case AtlasDataFederation:

--- a/src/main/java/com/mongodb/jdbc/MongoConnection.java
+++ b/src/main/java/com/mongodb/jdbc/MongoConnection.java
@@ -31,6 +31,10 @@ import com.mongodb.jdbc.logging.MongoSimpleFormatter;
 import com.mongodb.jdbc.mongosql.MongoSQLException;
 import com.mongodb.jdbc.mongosql.MongoSQLTranslate;
 import com.mongodb.jdbc.oidc.JdbcOidcCallback;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.UuidRepresentation;
+
 import java.io.File;
 import java.io.IOException;
 import java.sql.*;
@@ -41,9 +45,6 @@ import java.util.Properties;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.*;
-import org.bson.BsonDocument;
-import org.bson.BsonInt32;
-import org.bson.UuidRepresentation;
 
 @AutoLoggable
 public class MongoConnection implements Connection {
@@ -223,7 +224,8 @@ public class MongoConnection implements Connection {
         try {
             this.serverMajorVersion = buildInfoRes.getMajorVersion();
             this.serverMinorVersion = buildInfoRes.getMinorVersion();
-        } catch (IndexOutOfBoundsException e) {
+            // Only log issues happening while trying to compute the server version as this is not a blocker.
+        } catch (Exception e) {
             logger.log(Level.SEVERE, e.toString());
         }
 

--- a/src/main/java/com/mongodb/jdbc/MongoConnection.java
+++ b/src/main/java/com/mongodb/jdbc/MongoConnection.java
@@ -279,8 +279,15 @@ public class MongoConnection implements Connection {
         BsonDocument command = new BsonDocument();
         command.put("buildInfo", new BsonInt32(1));
         try {
-            Document result = mongoClient.getDatabase("admin").runCommand(command);
-            return (String) result.get("version");
+            Document result = mongoClient.getDatabase(currentDB).runCommand(command);
+            Document maybeDataLake = (Document) result.get("dataLake");
+            String serverVersion;
+            if (maybeDataLake != null) {
+                serverVersion = (String) maybeDataLake.get("version");
+            } else {
+                serverVersion = (String) result.get("version");
+            }
+            return serverVersion;
         } catch (Exception e) {
             throw new SQLException(e);
         }

--- a/src/main/java/com/mongodb/jdbc/MongoDatabaseMetaData.java
+++ b/src/main/java/com/mongodb/jdbc/MongoDatabaseMetaData.java
@@ -24,7 +24,6 @@ import com.mongodb.client.MongoDatabase;
 import com.mongodb.jdbc.logging.AutoLoggable;
 import com.mongodb.jdbc.logging.MongoLogger;
 import com.mongodb.jdbc.mongosql.MongoSQLException;
-
 import java.sql.*;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/main/java/com/mongodb/jdbc/MongoDatabaseMetaData.java
+++ b/src/main/java/com/mongodb/jdbc/MongoDatabaseMetaData.java
@@ -17,7 +17,6 @@
 package com.mongodb.jdbc;
 
 import static com.mongodb.jdbc.BsonTypeInfo.*;
-import static java.lang.Integer.parseInt;
 
 import com.mongodb.client.ListIndexesIterable;
 import com.mongodb.client.MongoDatabase;
@@ -575,17 +574,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
 
     @Override
     public String getDatabaseProductVersion() throws SQLException {
-        if (serverVersion != null) {
-            return serverVersion;
-        }
-        serverVersion = conn.getServerVersion();
-        String[] versionParts = serverVersion.split("\\.");
-        if (versionParts.length != 3) {
-            throw new SQLException("Unable to determine Database version");
-        }
-        serverMajorVersion = parseInt(versionParts[0]);
-        serverMinorVersion = parseInt(versionParts[1]);
-        return serverVersion;
+        return conn.getServerVersion();
     }
 
     @Override
@@ -1259,12 +1248,12 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
 
     @Override
     public int getDatabaseMajorVersion() throws SQLException {
-        return serverMajorVersion;
+        return conn.getServerMajorVersion();
     }
 
     @Override
     public int getDatabaseMinorVersion() throws SQLException {
-        return serverMinorVersion;
+        return conn.getServerMinorVersion();
     }
 
     @Override

--- a/src/main/java/com/mongodb/jdbc/MongoDatabaseMetaData.java
+++ b/src/main/java/com/mongodb/jdbc/MongoDatabaseMetaData.java
@@ -17,6 +17,7 @@
 package com.mongodb.jdbc;
 
 import static com.mongodb.jdbc.BsonTypeInfo.*;
+import static java.lang.Integer.parseInt;
 
 import com.mongodb.client.ListIndexesIterable;
 import com.mongodb.client.MongoDatabase;
@@ -187,6 +188,9 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
     private static final int APPROXIMATE_DOC_SIZE = 16777000;
     private static final String FUNC_DEFAULT_CATALOG = "def";
     private static final String YES = "YES";
+
+    private int serverMajorVersion;
+    private int serverMinorVersion;
 
     private static final List<SortableBsonDocument.SortSpec> GET_TABLES_SORT_SPECS =
             Arrays.asList(
@@ -581,6 +585,9 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
             return serverVersion;
         }
         serverVersion = conn.getServerVersion();
+        String[] versionParts = serverVersion.split("\\.");
+        serverMajorVersion = parseInt(versionParts[0]);
+        serverMinorVersion = parseInt(versionParts[1]);
         return serverVersion;
     }
 
@@ -1255,12 +1262,12 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
 
     @Override
     public int getDatabaseMajorVersion() throws SQLException {
-        return MongoDriver.MAJOR_VERSION;
+        return serverMajorVersion;
     }
 
     @Override
     public int getDatabaseMinorVersion() throws SQLException {
-        return MongoDriver.MINOR_VERSION;
+        return serverMinorVersion;
     }
 
     @Override

--- a/src/main/java/com/mongodb/jdbc/MongoDatabaseMetaData.java
+++ b/src/main/java/com/mongodb/jdbc/MongoDatabaseMetaData.java
@@ -24,13 +24,8 @@ import com.mongodb.client.MongoDatabase;
 import com.mongodb.jdbc.logging.AutoLoggable;
 import com.mongodb.jdbc.logging.MongoLogger;
 import com.mongodb.jdbc.mongosql.MongoSQLException;
-import java.sql.Connection;
-import java.sql.DatabaseMetaData;
-import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
-import java.sql.RowIdLifetime;
-import java.sql.SQLException;
-import java.sql.Types;
+
+import java.sql.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -586,6 +581,9 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
         }
         serverVersion = conn.getServerVersion();
         String[] versionParts = serverVersion.split("\\.");
+        if (versionParts.length != 3) {
+            throw new SQLException("Unable to determine Database version");
+        }
         serverMajorVersion = parseInt(versionParts[0]);
         serverMinorVersion = parseInt(versionParts[1]);
         return serverVersion;


### PR DESCRIPTION
We now correctly report the major and minor version. I've also updated it to work a bit better with adf version info, and report both adf version and mongosql version. Sample log output of internals:

```sh
[2024-11-06 13:19:23.453] [INFO] [c-2] com.mongodb.jdbc.MongoConnection initConnectionLogger: Connecting using MongoDB Atlas SQL interface JDBC Driver 3.0.0-alpha-libv1.0.0-alpha-11-g56f9799-dirty
[2024-11-06 13:19:25.355] [FINE] [c-2] com.mongodb.jdbc.MongoConnection determineClusterType: BuildInfo{version='7.2.0.v20241030.1.5.1', modules=null, ok=1, dataLake=DataLake{version='v20241030', mongoSQLVersion=1.5.1}}
[2024-11-06 13:19:25.356] [INFO] [c-2] com.mongodb.jdbc.MongoConnection$ConnValidation call: Connecting to cluster type AtlasDataFederation with server version 7.2.0.v20241030.1.5.1
[2024-11-06 13:23:11.157] [INFO] [c-1] com.mongodb.jdbc.MongoConnection initConnectionLogger: Connecting using MongoDB Atlas SQL interface JDBC Driver 3.0.0-alpha-libv1.0.0-alpha-11-g56f9799-dirty
[2024-11-06 13:23:12.993] [FINE] [c-1] com.mongodb.jdbc.MongoConnection determineClusterType: BuildInfo{fullVersion='7.2.0.v20241030.1.5.1', versionArray=[7, 2, 0, 0], majorVersion=7, minorVersion=2, modules=null, ok=1, dataLake=DataLake{version='v20241030', mongoSQLVersion=1.5.1}}
[2024-11-06 13:23:12.994] [INFO] [c-1] com.mongodb.jdbc.MongoConnection$ConnValidation call: Connecting to cluster type AtlasDataFederation with server version 7.2.0.v20241030.1.5.1
[2024-11-06 13:23:40.161] [INFO] [c-2] com.mongodb.jdbc.MongoConnection initConnectionLogger: Connecting using MongoDB Atlas SQL interface JDBC Driver 3.0.0-alpha-libv1.0.0-alpha-11-g56f9799-dirty
[2024-11-06 13:23:41.827] [FINE] [c-2] com.mongodb.jdbc.MongoConnection determineClusterType: BuildInfo{fullVersion='8.0.3', versionArray=[8, 0, 3, 0], majorVersion=8, minorVersion=0, modules=[enterprise], ok=1, dataLake=null}
[2024-11-06 13:23:41.828] [INFO] [c-2] com.mongodb.jdbc.MongoConnection$ConnValidation call: Connecting to cluster type Enterprise with server version 8.0.3
[2024-11-06 13:23:41.834] [INFO] [c-2] com.mongodb.jdbc.mongosql.MongoSQLTranslate getMongosqlTranslateVersion: mongosqlTranslateVersion: v1.0.0
[2024-11-06 13:23:41.835] [INFO] [c-2] com.mongodb.jdbc.mongosql.MongoSQLTranslate checkDriverVersion: Driver Compatibility Status: true
```