### PR TITLE
SQL-2460: Add handling for non-integer indexes

### DIFF
--- a/src/main/java/com/mongodb/jdbc/MongoDatabaseMetaData.java
+++ b/src/main/java/com/mongodb/jdbc/MongoDatabaseMetaData.java
@@ -223,7 +223,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
     private static final List<SortableBsonDocument.SortSpec> GET_INDEX_INFO_SORT_SPECS =
             Arrays.asList(
                     new SortableBsonDocument.SortSpec(
-                            NON_UNIQUE, SortableBsonDocument.ValueType.String),
+                            NON_UNIQUE, SortableBsonDocument.ValueType.Boolean),
                     new SortableBsonDocument.SortSpec(
                             INDEX_NAME, SortableBsonDocument.ValueType.String),
                     new SortableBsonDocument.SortSpec(

--- a/src/main/java/com/mongodb/jdbc/MongoDatabaseMetaData.java
+++ b/src/main/java/com/mongodb/jdbc/MongoDatabaseMetaData.java
@@ -2664,8 +2664,17 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
                 .stream()
                 .map(
                         key -> {
-                            BsonValue ascOrDesc =
-                                    new BsonString(keys.getInteger(key) > 0 ? "A" : "D");
+
+                            // If the index is not an integer (e.g., a geospatial index), `keys.getInteger(key)`
+                            // will throw a ClassCastException. In this case, we set `ascOrDesc` to null since these
+                            // sort sequences are not supported by JDBC.
+                            BsonValue ascOrDesc;
+                            try {
+                                ascOrDesc =
+                                        new BsonString(keys.getInteger(key) > 0 ? "A" : "D");
+                            } catch (ClassCastException e){
+                                ascOrDesc = null;
+                            }
 
                             return createSortableBottomBson(
                                     // Per JDBC spec, sort by  NON_UNIQUE, TYPE, INDEX_NAME, and ORDINAL_POSITION.

--- a/src/main/java/com/mongodb/jdbc/MongoDatabaseMetaData.java
+++ b/src/main/java/com/mongodb/jdbc/MongoDatabaseMetaData.java
@@ -2670,10 +2670,9 @@ public class MongoDatabaseMetaData implements DatabaseMetaData {
                             // sort sequences are not supported by JDBC.
                             BsonValue ascOrDesc;
                             try {
-                                ascOrDesc =
-                                        new BsonString(keys.getInteger(key) > 0 ? "A" : "D");
-                            } catch (ClassCastException e){
-                                ascOrDesc = null;
+                                ascOrDesc = new BsonString(keys.getInteger(key) > 0 ? "A" : "D");
+                            } catch (ClassCastException e) {
+                                ascOrDesc = new BsonString("");
                             }
 
                             return createSortableBottomBson(

--- a/src/main/java/com/mongodb/jdbc/SortableBsonDocument.java
+++ b/src/main/java/com/mongodb/jdbc/SortableBsonDocument.java
@@ -34,6 +34,7 @@ public class SortableBsonDocument extends BsonDocument implements Comparable<Sor
     enum ValueType {
         String,
         Int,
+        Boolean,
     }
 
     List<SortSpec> sortSpecs;
@@ -62,6 +63,12 @@ public class SortableBsonDocument extends BsonDocument implements Comparable<Sor
                             this.nestedDocValue
                                     .getInt32(sortSpec.key)
                                     .compareTo(o.nestedDocValue.getInt32(sortSpec.key));
+                    break;
+                case Boolean:
+                    r =
+                            this.nestedDocValue
+                                    .getBoolean(sortSpec.key)
+                                    .compareTo(o.nestedDocValue.getBoolean(sortSpec.key));
                     break;
             }
 


### PR DESCRIPTION
This PR filters out non-integer indexes. At first, I tried to set `ASC_OR_DESC` to null for non-integer indexes as [the spec](https://download.oracle.com/otn_hosted_doc/jdeveloper/905/jdbc-javadoc/oracle/jdbc/OracleDatabaseMetaData.html#getIndexInfo(java.lang.String,%20java.lang.String,%20java.lang.String,%20boolean,%20boolean)) says, "`ASC_OR_DESC String => column sort sequence, "A" => ascending, "D" => descending, may be null if sort sequence is not supported`". However, I then got the following DBeaver error: `Error reading table indexes: SQL Error: java.lang.IllegalArgumentException: The value for key ASC_OR_DESC can not be null`. So in the end, I filtered out all the non-integer indexes which works fine.