### PR TITLE
SQL-2506: Update browser invocation method for different platforms

### DIFF
--- a/src/main/java/com/mongodb/jdbc/oidc/OidcAuthFlow.java
+++ b/src/main/java/com/mongodb/jdbc/oidc/OidcAuthFlow.java
@@ -186,7 +186,7 @@ public class OidcAuthFlow {
      */
     private void openURL(String url) throws Exception {
         String osName = System.getProperty("os.name").toLowerCase();
-        logger.log(Level.INFO, "osName: "+osName);
+        logger.log(Level.INFO, "osName: " + osName);
         Runtime runtime = Runtime.getRuntime();
 
         if (osName.startsWith("mac os")) {


### PR DESCRIPTION
Updated how a browser is invoked to open the URL. 

This fixes an issue on Mac where OIDC authentication was failing when desktop operations could not be executed. 

Tested OIDC authentication on Mac and Windows against `sqlenginesoidctest-lxonw.a.query.mongodb-dev.net` using Tableau.