### PR TITLE
SQL-2514: Report authentication failure and expected SQLSTATE

### DIFF
--- a/src/integration-test/java/com/mongodb/jdbc/integration/DCIntegrationTest.java
+++ b/src/integration-test/java/com/mongodb/jdbc/integration/DCIntegrationTest.java
@@ -262,4 +262,25 @@ public class DCIntegrationTest {
             rs.close();
         }
     }
+
+    @Test
+    public void testInvalidCredentialsOnEnterpriseServer() throws SQLException {
+        Pair<String, Properties> info = createLocalMongodConnInfo("LOCAL_MDB_PORT_ENT");
+        info.right().setProperty("password", "invalid-password");
+
+        SQLException thrown =
+                assertThrows(
+                        SQLException.class,
+                        () -> DriverManager.getConnection(info.left(), info.right()),
+                        "A SQLException should be thrown due to invalid credentials.");
+
+        String message = thrown.getMessage().toLowerCase();
+        assertTrue(
+                message.contains("authentication failed"),
+                "The error message should indicate that authentication failed.");
+        assertEquals(
+                "28000",
+                thrown.getSQLState(),
+                "SQLSTATE should indicate an authentication failure (28000).");
+    }
 }

--- a/src/integration-test/java/com/mongodb/jdbc/integration/DCIntegrationTest.java
+++ b/src/integration-test/java/com/mongodb/jdbc/integration/DCIntegrationTest.java
@@ -16,6 +16,7 @@
 
 package com.mongodb.jdbc.integration;
 
+import static com.mongodb.jdbc.MongoDriver.AUTHENTICATION_ERROR_SQLSTATE;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.mongodb.jdbc.MongoConnection;
@@ -279,8 +280,10 @@ public class DCIntegrationTest {
                 message.contains("authentication failed"),
                 "The error message should indicate that authentication failed.");
         assertEquals(
-                "28000",
+                AUTHENTICATION_ERROR_SQLSTATE,
                 thrown.getSQLState(),
-                "SQLSTATE should indicate an authentication failure (28000).");
+                "SQLSTATE should indicate an authentication failure ("
+                        + AUTHENTICATION_ERROR_SQLSTATE
+                        + ")");
     }
 }

--- a/src/main/java/com/mongodb/jdbc/MongoDriver.java
+++ b/src/main/java/com/mongodb/jdbc/MongoDriver.java
@@ -285,7 +285,7 @@ public class MongoDriver implements Driver {
                     if (cause instanceof com.mongodb.MongoSecurityException) {
                         throw new SQLException(
                                 "Authentication failed. Verify that the credentials are correct.",
-                                "28000",
+                                AUTHENTICATION_ERROR_SQLSTATE,
                                 e);
                     }
                     cause = cause.getCause();

--- a/src/main/java/com/mongodb/jdbc/MongoDriver.java
+++ b/src/main/java/com/mongodb/jdbc/MongoDriver.java
@@ -142,7 +142,7 @@ public class MongoDriver implements Driver {
 
     public static final String LOG_TO_CONSOLE = "console";
     protected static final String CONNECTION_ERROR_SQLSTATE = "08000";
-    protected static final String AUTHENTICATION_ERROR_SQLSTATE = "28000";
+    public static final String AUTHENTICATION_ERROR_SQLSTATE = "28000";
 
     private static ConcurrentHashMap<Integer, WeakReference<MongoClient>> mongoClientCache =
             new ConcurrentHashMap<>();

--- a/src/main/java/com/mongodb/jdbc/MongoDriver.java
+++ b/src/main/java/com/mongodb/jdbc/MongoDriver.java
@@ -278,6 +278,18 @@ public class MongoDriver implements Driver {
                         "Couldn't connect due to a timeout. Please check your hostname and port. If necessary, set a "
                                 + "longer connection timeout in the MongoDB URI.");
             } catch (Exception e) {
+                // Unwrap the cause to detect authentication failures
+                Throwable cause = e;
+                while (cause != null) {
+                    if (cause instanceof com.mongodb.MongoSecurityException) {
+                        throw new SQLException(
+                                "Authentication failed. Verify that the credentials are correct.",
+                                "28000",
+                                e);
+                    }
+                    cause = cause.getCause();
+                }
+
                 throw new SQLException("Connection failed.", e);
             }
         }

--- a/src/main/java/com/mongodb/jdbc/MongoDriver.java
+++ b/src/main/java/com/mongodb/jdbc/MongoDriver.java
@@ -142,6 +142,7 @@ public class MongoDriver implements Driver {
 
     public static final String LOG_TO_CONSOLE = "console";
     protected static final String CONNECTION_ERROR_SQLSTATE = "08000";
+    protected static final String AUTHENTICATION_ERROR_SQLSTATE = "28000";
 
     private static ConcurrentHashMap<Integer, WeakReference<MongoClient>> mongoClientCache =
             new ConcurrentHashMap<>();


### PR DESCRIPTION
Added change to detect when a `MongoSecurityException` is hit in `connect()` to return SQLSTATE 28000 and an updated error message that authentication failed. 

Tested in Tableau and the error dialogue reports `Invalid username or password` as expected.  
Steps are in their [QA doc](https://tableau.github.io/connector-plugin-sdk/docs/manual-test#test-your-connector-with-tableau-desktop) under the section "Connect to the correct database with the wrong credentials".

Here's the output with the changes in this PR:
<img width="515" alt="Tableau_Error_Invalid_creds" src="https://github.com/user-attachments/assets/0d6f9eb6-cdd9-422e-94a7-d07881f7bf8b" />
