### PR TITLE
SQL-2534: Add THIRDPARTY-LICENSE notice

### DIFF
--- a/.evg.yml
+++ b/.evg.yml
@@ -556,7 +556,9 @@ functions:
         if [[ "${triggered_by_git_tag}" != "" ]]; then
           EXTRA_PROP="-PisTagTriggered"
         fi
-        ./gradlew -Dorg.gradle.java.home=${JAVA_HOME} $EXTRA_PROP clean -x test -x integrationTest spotlessApply build shadowjar --rerun-tasks
+        ./gradlew clean generateLicenseReport --rerun-tasks && \
+        echo -e "$(cat resources/third_party_header.txt)\n$(cat build/reports/dependency-license/THIRD-PARTY-LICENSE.txt)" > build/reports/dependency-license/THIRD-PARTY-LICENSE.txt && \
+        ./gradlew -Dorg.gradle.java.home=${JAVA_HOME} $EXTRA_PROP -x test -x integrationTest spotlessApply build shadowjar --rerun-tasks
 
   "check spotless":
     command: shell.exec

--- a/build.gradle
+++ b/build.gradle
@@ -218,13 +218,6 @@ task runCallbackWithBadRefreshToken(type: JavaExec) {
     main = 'com.mongodb.jdbc.oidc.manualtests.TestOidcCallbackWithBadRefreshToken'
 }
 
-
-
-tasks.register('copyThirdPartyLicenseNotice', Copy) {
-    from layout.buildDirectory.file("reports/dependency-license/THIRD-PARTY-LICENSE.txt")
-    into layout.projectDirectory.dir("src/main/resources/META-INF/licenses")
-}
-
 jar {
     // Add the THIRD-PARTY-LICENSE to our jar
     // Note that in order for this to work, the file must be present
@@ -249,12 +242,6 @@ shadowJar  {
         into 'META-INF/licenses'
     }
 }
-
-tasks.named('copyThirdPartyLicenseNotice') {
-    dependsOn generateLicenseReport
-}
-
-
 
 dependencies {
     integrationTestImplementation "org.yaml:snakeyaml:$snakeYamlVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,10 @@ plugins {
     id "de.marcphilipp.nexus-publish" version "0.3.0"
     id "com.github.johnrengelman.shadow" version "5.2.0"
     id "org.cyclonedx.bom" version "1.8.2"
+    id 'com.github.jk1.dependency-license-report' version '1.17'
 }
+
+import com.github.jk1.license.render.TextReportRenderer
 
 if (project.hasProperty('isTagTriggered')) {
     version = getAbbreviatedGitVersion()
@@ -27,6 +30,10 @@ spotless {
         googleJavaFormat('1.1').aosp()
         licenseHeaderFile('resources/license_header.txt')
     }
+}
+
+licenseReport {
+    renderers = [new TextReportRenderer('THIRD-PARTY-LICENSE.txt')]
 }
 
 cyclonedxBom {
@@ -101,8 +108,6 @@ allprojects {
         testCompile  group: 'org.mockito', name: 'mockito-core', version: mockitoVersion
         testCompile  group: 'org.mockito', name: 'mockito-junit-jupiter', version: mockitoVersion
     }
-
-    //ant.lifecycleLogLevel = AntBuilder.AntMessagePriority.VERBOSE
 
     compileJava {
         doLast {
@@ -213,12 +218,43 @@ task runCallbackWithBadRefreshToken(type: JavaExec) {
     main = 'com.mongodb.jdbc.oidc.manualtests.TestOidcCallbackWithBadRefreshToken'
 }
 
+
+
+tasks.register('copyThirdPartyLicenseNotice', Copy) {
+    from layout.buildDirectory.file("reports/dependency-license/THIRD-PARTY-LICENSE.txt")
+    into layout.projectDirectory.dir("src/main/resources/META-INF/licenses")
+}
+
 jar {
+    // Add the THIRD-PARTY-LICENSE to our jar
+    // Note that in order for this to work, the file must be present
+    // To generate it, run generateLicenseReport. However, ':generateLicenseReport' has a dependecy on `:jar`
+    // which makes it impossible to generate and bundle the THIRD-PARTY-LICENSE in one pass.
+    from('build/reports/dependency-license/THIRD-PARTY-LICENSE.txt') {
+        into 'META-INF/licenses'
+    }
+
     manifest {
         attributes('Implementation-Title': project.name,
                 'Implementation-Version': project.version)
     }
 }
+
+shadowJar  {
+    // Add the THIRD-PARTY-LICENSE to our jar
+    // Note that in order for this to work, the file must be present
+    // To generate it, run generateLicenseReport. However, ':generateLicenseReport' has a dependecy on `:jar`
+    // which makes it impossible to generate and bundle the THIRD-PARTY-LICENSE in one pass.
+    from('build/reports/dependency-license/THIRD-PARTY-LICENSE.txt') {
+        into 'META-INF/licenses'
+    }
+}
+
+tasks.named('copyThirdPartyLicenseNotice') {
+    dependsOn generateLicenseReport
+}
+
+
 
 dependencies {
     integrationTestImplementation "org.yaml:snakeyaml:$snakeYamlVersion"

--- a/resources/third_party_header.txt
+++ b/resources/third_party_header.txt
@@ -1,0 +1,13 @@
+MongoDB uses third-party libraries or other resources that may
+be distributed under licenses different than the MongoDB software.
+
+In the event that we accidentally failed to list a required notice,
+please bring it to our attention through our JIRA system at:
+
+    https://jira.mongodb.org
+
+The attached notices are provided for information only.
+
+
+                --------------------------
+


### PR DESCRIPTION
The file is copied in `META-INF/licenses`.

Merge check passed before cleaning  : https://spruce.mongodb.com/task/mongo_jdbc_driver_eap_release_build_patch_4b1bd9a6f9c32002e1cba7e78f655a2eba7da14c_679d6f3c0e788400079daf21_25_02_01_00_47_58/logs?execution=0