### PR TITLE
SQL-2538: Renaming build artifacts is only necessary for snapshot builds

### DIFF
--- a/.evg.yml
+++ b/.evg.yml
@@ -1084,17 +1084,19 @@ functions:
         working_dir: mongo-jdbc-driver
         script: |
           ${PREPARE_SHELL}
-          if [ -d "build/libs" ]; then
-            # A sanity check to see if expected files are indeed here
-            ls -lrt build/libs
-            # Rename files according to our naming scheme
-            for f in ./build/libs/mongodb-jdbc-*.jar; do
-              if [[ "$f" == *"-all"* ]]; then
-                mv "$f" build/libs/mongodb-jdbc-${MDBJDBC_VER}-all.jar
-              else
-                mv "$f" build/libs/mongodb-jdbc-${MDBJDBC_VER}.jar
-              fi
-            done
+          if [[ "${triggered_by_git_tag}" == "" ]]; then
+            if [ -d "build/libs" ]; then
+              # A sanity check to see if expected files are indeed here
+              ls -lrt build/libs
+              # Rename files according to our naming scheme
+              for f in ./build/libs/mongodb-jdbc-*.jar; do
+                if [[ "$f" == *"-all"* ]]; then
+                  mv "$f" build/libs/mongodb-jdbc-${MDBJDBC_VER}-all.jar
+                else
+                  mv "$f" build/libs/mongodb-jdbc-${MDBJDBC_VER}.jar
+                fi
+              done
+            fi
           fi
     - command: s3.put
       params:


### PR DESCRIPTION
This shows that if there is no tag, then the renaming happens: https://spruce.mongodb.com/task/mongo_jdbc_driver_release_build_patch_0d6972d2d8cffb9da601f998d7303816970af416_67edd161edd63400073c8ce5_25_04_03_00_08_09/logs?execution=0

Hopefully, all will be good this time when the release is done!