### PR TITLE
Fix possible NPE on MongoDriver#connect()

### DIFF
--- a/src/main/java/com/mongodb/jdbc/MongoDriver.java
+++ b/src/main/java/com/mongodb/jdbc/MongoDriver.java
@@ -278,7 +278,7 @@ public class MongoDriver implements Driver {
             Enumeration keys = info.propertyNames();
             while (keys.hasMoreElements()) {
                 String key = keys.nextElement().toString();
-                lowerCaseprops.put(key.toLowerCase(), info.getProperty(key));
+                lowerCaseprops.put(key.toLowerCase(), info.get(key));
             }
         }
         MongoConnection conn = getUnvalidatedConnection(url, lowerCaseprops);


### PR DESCRIPTION
The properties can contain non-string values. If connect() is called with such a property (e.g. intended for a different JDBC driver, as can happen in the context of `DriverManager.getConnection()`), the attempt to lower-case the keys in the MongoDriver results in an NPE, because getProperty() returns null for non-string properties.

The simplest patch is to use get() rather than getProperty(). Alternatively, to avoid the lower-casing if the URL is not actually intended for the MongoDriver, we could add a guard clause that uses acceptsURL().