### PR TITLE
Guard MongoStatement#setFetchSize against invalid arguments.

### DIFF
--- a/src/main/java/com/mongodb/jdbc/MongoStatement.java
+++ b/src/main/java/com/mongodb/jdbc/MongoStatement.java
@@ -359,6 +359,9 @@ public class MongoStatement implements Statement {
     @Override
     public void setFetchSize(int rows) throws SQLException {
         checkClosed();
+        if (rows < 0) {
+            throw new IllegalArgumentException("Invalid fetch size");
+        }
         fetchSize = rows;
     }
 


### PR DESCRIPTION
If a negative value is passed to `setFetchSize`, it leads to an internal error down the road when the driver tries to fetch results, which masks the original issue. To avoid this and give immediate feedback to the client, this PR suggests to throw an `IllegalArgumentException` instead immediately when setting an invalid fetch size.

This problem occurred when migrating JDBC code from the Mongo BI Connector (which used the MySQL JDBC driver) to MongoDB Atlas - the MySql JDBC connector interprets `Integer.MIN_VALUE` as a "magic number" for `setFetchSize` to enable streaming response rows.