### PR TITLE
SQL-2833:  Guard MongoStatement#setFetchSize against invalid arguments - Signed commit

### DIFF
--- a/src/main/java/com/mongodb/jdbc/MongoStatement.java
+++ b/src/main/java/com/mongodb/jdbc/MongoStatement.java
@@ -359,6 +359,9 @@ public class MongoStatement implements Statement {
     @Override
     public void setFetchSize(int rows) throws SQLException {
         checkClosed();
+        if (rows < 0) {
+            throw new SQLException("Invalid fetch size: " + rows + ". Fetch size must be >= 0.");
+        }
         fetchSize = rows;
     }
 

--- a/src/test/java/com/mongodb/jdbc/MongoStatementTest.java
+++ b/src/test/java/com/mongodb/jdbc/MongoStatementTest.java
@@ -282,7 +282,7 @@ class MongoStatementTest extends MongoMock {
 
     @Test
     void testSetGetFetchSize() throws SQLException {
-        assertThrows(SQLException.class, () ->mongoStatement.setFetchSize(-1));
+        assertThrows(SQLException.class, () -> mongoStatement.setFetchSize(-1));
 
         int fetchSize = 10;
         mongoStatement.setFetchSize(fetchSize);

--- a/src/test/java/com/mongodb/jdbc/MongoStatementTest.java
+++ b/src/test/java/com/mongodb/jdbc/MongoStatementTest.java
@@ -282,6 +282,8 @@ class MongoStatementTest extends MongoMock {
 
     @Test
     void testSetGetFetchSize() throws SQLException {
+        assertThrows(SQLException.class, () ->mongoStatement.setFetchSize(-1));
+
         int fetchSize = 10;
         mongoStatement.setFetchSize(fetchSize);
         assertEquals(fetchSize, mongoStatement.getFetchSize());


### PR DESCRIPTION
Based on user PR https://github.com/mongodb/mongo-jdbc-driver/pull/355.