### PR TITLE
Add option to allow disabling the MongoClient cache.

### DIFF
--- a/src/main/java/com/mongodb/jdbc/MongoConnection.java
+++ b/src/main/java/com/mongodb/jdbc/MongoConnection.java
@@ -69,6 +69,7 @@ public class MongoConnection implements Connection {
     private static Map<String, FileHandler> fileHandlers = new HashMap<String, FileHandler>();
     private String logDirPath;
     private boolean extJsonMode;
+    private boolean mongoClientCacheEnabled;
     private UuidRepresentation uuidRepresentation;
     private String appName;
     private MongoSQLTranslate mongosqlTranslate;
@@ -147,6 +148,7 @@ public class MongoConnection implements Connection {
         this.user = connectionProperties.getConnectionString().getUsername();
         this.currentDB = connectionProperties.getDatabase();
         this.extJsonMode = connectionProperties.getExtJsonMode();
+        this.mongoClientCacheEnabled = connectionProperties.getMongoClientCacheEnabled();
         this.uuidRepresentation =
                 connectionProperties.getConnectionString().getUuidRepresentation();
         this.appName = buildAppName(connectionProperties);
@@ -376,6 +378,11 @@ public class MongoConnection implements Connection {
     public void close() {
         if (isClosed()) {
             return;
+        }
+
+        if (!mongoClientCacheEnabled) {
+            // The MongoClient is owned by this connection.
+            mongoClient.close();
         }
 
         // Decrement fileHandlerCount and delete entry

--- a/src/main/java/com/mongodb/jdbc/MongoConnectionProperties.java
+++ b/src/main/java/com/mongodb/jdbc/MongoConnectionProperties.java
@@ -28,6 +28,7 @@ public class MongoConnectionProperties {
     private String clientInfo;
     private boolean extJsonMode;
     private String x509PemPath;
+    private boolean mongoClientCacheEnabled;
 
     public MongoConnectionProperties(
             ConnectionString connectionString,
@@ -36,7 +37,8 @@ public class MongoConnectionProperties {
             File logDir,
             String clientInfo,
             boolean extJsonMode,
-            String x509PemPath) {
+            String x509PemPath,
+            boolean mongoClientCacheEnabled) {
         this.connectionString = connectionString;
         this.database = database;
         this.logLevel = logLevel;
@@ -44,6 +46,7 @@ public class MongoConnectionProperties {
         this.clientInfo = clientInfo;
         this.extJsonMode = extJsonMode;
         this.x509PemPath = x509PemPath;
+        this.mongoClientCacheEnabled = mongoClientCacheEnabled;
     }
 
     public ConnectionString getConnectionString() {
@@ -72,6 +75,10 @@ public class MongoConnectionProperties {
 
     public String getX509PemPath() {
         return x509PemPath;
+    }
+
+    public boolean getMongoClientCacheEnabled() {
+        return mongoClientCacheEnabled;
     }
 
     /*

--- a/src/main/java/com/mongodb/jdbc/MongoDriver.java
+++ b/src/main/java/com/mongodb/jdbc/MongoDriver.java
@@ -99,7 +99,8 @@ public class MongoDriver implements Driver {
         LOG_LEVEL("loglevel"),
         LOG_DIR("logdir"),
         EXT_JSON_MODE("extjsonmode"),
-        X509_PEM_PATH("x509pempath");
+        X509_PEM_PATH("x509pempath"),
+        MONGO_CLIENT_CACHE_ENABLED("mongoclientcacheenabled");
 
         private final String propertyName;
 
@@ -441,6 +442,9 @@ public class MongoDriver implements Driver {
             }
         }
 
+        String mongoClientCacheEnabledVal = info.getProperty(MONGO_CLIENT_CACHE_ENABLED.getPropertyName(), "true");
+        boolean mongoClientCacheEnabled = mongoClientCacheEnabledVal.equalsIgnoreCase("true");
+
         MongoConnectionProperties mongoConnectionProperties =
                 new MongoConnectionProperties(
                         cs,
@@ -449,7 +453,12 @@ public class MongoDriver implements Driver {
                         logDir,
                         clientInfo,
                         extJsonMode,
-                        info.getProperty(X509_PEM_PATH.getPropertyName()));
+                        info.getProperty(X509_PEM_PATH.getPropertyName()),
+                        mongoClientCacheEnabled);
+
+        if (!mongoClientCacheEnabled) {
+            return new MongoConnection(mongoConnectionProperties, x509Passphrase);
+        }
 
         Integer key = mongoConnectionProperties.generateKey();
 


### PR DESCRIPTION
In a server environment where the mongo-jdbc driver is used to connect to a variable number of customer databases to run queries at varying frequencies, it is not desirable to keep the MongoClients alive/open across JDBC connections, especially since every MongoClient comes with a background server monitoring thread.

This PR adds an option to disable the mongo client cache, so that the client is owned by the JDBC connection and closed together with it, as was the case before the cache was introduced in https://github.com/mongodb/mongo-jdbc-driver/pull/260.