### PR TITLE
SQL-2850: JDBC OIDC default scope improvement

### DIFF
--- a/src/main/java/com/mongodb/jdbc/oidc/OidcAuthFlow.java
+++ b/src/main/java/com/mongodb/jdbc/oidc/OidcAuthFlow.java
@@ -86,7 +86,7 @@ public class OidcAuthFlow {
         // Add custom scopes from request that are supported by the IdP
         List<String> requestedScopes = idpServerInfo.getRequestScopes();
         if (requestedScopes != null) {
-            // Always add clientID/.default if it's in requestedScopes
+            // Always add clientID/.default if it's in requestedScopes, this was needed for Azure OIDC.
             String clientIDDefault = clientID + "/.default";
             if (requestedScopes.contains(clientIDDefault)) {
                 scopes.add(clientIDDefault);

--- a/src/main/java/com/mongodb/jdbc/oidc/OidcAuthFlow.java
+++ b/src/main/java/com/mongodb/jdbc/oidc/OidcAuthFlow.java
@@ -92,10 +92,13 @@ public class OidcAuthFlow {
             if (requestedScopes.contains(clientIDDefault)) {
                 scopes.add(clientIDDefault);
             }
-            for (String scope : requestedScopes) {
-                if (supportedScopes != null) {
+            if (supportedScopes != null) {
+                for (String scope : requestedScopes) {
                     if (supportedScopes.contains(scope)) {
                         scopes.add(scope);
+                    } else {
+                        logger.warning(
+                                "Requested scope '" + scope + "' is not supported by the IdP");
                     }
                 }
             }

--- a/src/main/java/com/mongodb/jdbc/oidc/OidcAuthFlow.java
+++ b/src/main/java/com/mongodb/jdbc/oidc/OidcAuthFlow.java
@@ -65,17 +65,18 @@ public class OidcAuthFlow {
     }
 
     /**
-     * Builds the OIDC scopes for the authorization request by combining default scopes
-     * with client-requested scopes that are supported by the Identity Provider.  Adds
-     * openid and offline_access scopes by default, and includes the clientID/.default if
-     * in the requested scopes.
+     * Builds the OIDC scopes for the authorization request by combining default scopes with
+     * client-requested scopes that are supported by the Identity Provider. Adds openid and
+     * offline_access scopes by default, and includes the clientID/.default if in the requested
+     * scopes.
      *
      * @param clientID the OAuth2 client identifier
      * @param idpServerInfo server information containing requested scopes and other IdP details
      * @param providerMetadata OIDC provider metadata containing supported scopes
      * @return a Scope object containing all valid scopes to be requested
      */
-    public Scope buildScopes(String clientID, IdpInfo idpServerInfo, OIDCProviderMetadata providerMetadata) {
+    public Scope buildScopes(
+            String clientID, IdpInfo idpServerInfo, OIDCProviderMetadata providerMetadata) {
         Set<String> scopes = new HashSet<>();
         Scope supportedScopes = providerMetadata.getScopes();
 


### PR DESCRIPTION
Adding `openid` and `offline_access` by default.  If `clientID + "/.default"` is in the requested scopes will add that as well.  

Verified that it works with our Okta test instance `mongodb://sqlenginesoidctest-lxonw.a.query.mongodb-dev.net` and an Azure idp instance. 