### PR TITLE
SQL-2914: Disallow Maven publishing for eap builds

### DIFF
--- a/gradle/deploy.gradle
+++ b/gradle/deploy.gradle
@@ -6,13 +6,17 @@ afterEvaluate {
             description = 'Publishes snapshots to Sonatype'
             println("Will publish snapshots to Sonatype")
             dependsOn project.tasks.named('publishToSonatype')
+        } else if (project.hasProperty('isEapBuild')) {
+            description = 'This is an EAP build, skipping publishing'
+            println("This is an EAP build, skipping publishing")
         } else {
             description = 'Publishes a release and uploads to Sonatype / Maven Central'
             println("Will publish a release and uploads to Sonatype / Maven Central")
             if (project.name == rootProject.name) {
                 dependsOn project.tasks.named('publishToSonatype')
-                project.tasks.named('publishToSonatype').finalizedBy(project.tasks.named('closeAndReleaseRepository'))
-            }
+                project.tasks.named('publishToSonatype').configure {
+                    finalizedBy(project.tasks.named('closeAndReleaseRepository'))
+                }            }
         }
     }
 }

--- a/gradle/deploy.gradle
+++ b/gradle/deploy.gradle
@@ -16,7 +16,8 @@ afterEvaluate {
                 dependsOn project.tasks.named('publishToSonatype')
                 project.tasks.named('publishToSonatype').configure {
                     finalizedBy(project.tasks.named('closeAndReleaseRepository'))
-                }            }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
The JDBC Release is failing with an error related to the `closeAndReleaseRepository` task which shouldn't be run for EAP builds.  Added a check for the `isEapBuild` property. 

Added a proposed fix for the standard build as well, but that wouldn't be tested until we release a non-eap build. 