### PR TITLE
SQL-2920: Add configuration properties to support GSSAPI

### DIFF
--- a/src/main/java/com/mongodb/jdbc/MongoConnectionProperties.java
+++ b/src/main/java/com/mongodb/jdbc/MongoConnectionProperties.java
@@ -28,6 +28,8 @@ public class MongoConnectionProperties {
     private String clientInfo;
     private boolean extJsonMode;
     private String x509PemPath;
+    private String jaasConfigPath;
+    private String gssNativeMode;
 
     public MongoConnectionProperties(
             ConnectionString connectionString,
@@ -36,14 +38,18 @@ public class MongoConnectionProperties {
             File logDir,
             String clientInfo,
             boolean extJsonMode,
-            String x509PemPath) {
+            String x509PemPath,
+            String jaasConfigPath,
+            String gssNativeMode) {
         this.connectionString = connectionString;
         this.database = database;
         this.logLevel = logLevel;
         this.logDir = logDir;
         this.clientInfo = clientInfo;
         this.extJsonMode = extJsonMode;
-        this.x509PemPath = x509PemPath;
+        this.x509PemPath = (x509PemPath != null) ? x509PemPath.trim() : null;
+        this.jaasConfigPath = (jaasConfigPath != null) ? jaasConfigPath.trim() : null;
+        this.gssNativeMode = gssNativeMode != null ? gssNativeMode : null;
     }
 
     public ConnectionString getConnectionString() {
@@ -72,6 +78,14 @@ public class MongoConnectionProperties {
 
     public String getX509PemPath() {
         return x509PemPath;
+    }
+
+    public String getJaasConfigPath() {
+        return jaasConfigPath;
+    }
+
+    public String getGssNativeMode() {
+        return gssNativeMode;
     }
 
     /*

--- a/src/test/java/com/mongodb/jdbc/MongoDatabaseMetaDataTest.java
+++ b/src/test/java/com/mongodb/jdbc/MongoDatabaseMetaDataTest.java
@@ -40,7 +40,7 @@ public class MongoDatabaseMetaDataTest {
             new MongoDatabaseMetaData(
                     new MongoConnection(
                             new MongoConnectionProperties(
-                                    uri, database, null, null, null, false, null)));
+                                    uri, database, null, null, null, false, null, null, null)));
 
     // Report exception from MongoConnection
     public MongoDatabaseMetaDataTest() throws Exception {}

--- a/src/test/java/com/mongodb/jdbc/MongoDriverTest.java
+++ b/src/test/java/com/mongodb/jdbc/MongoDriverTest.java
@@ -900,4 +900,77 @@ class MongoDriverTest {
             e.printStackTrace();
         }
     }
+
+    @Test
+    void testJaasConfigPathIsSetForGSSAPI() throws SQLException {
+        MongoDriver d = new MongoDriver();
+        Properties p = new Properties();
+        p.setProperty(DATABASE.getPropertyName(), "test");
+        String jaasPathWithSpaces = "  /path/to/mongo/jaas.conf  ";
+        String jaasPathTrimmed = jaasPathWithSpaces.trim();
+
+        p.setProperty(JAAS_CONFIG_PATH.getPropertyName(), jaasPathWithSpaces);
+
+        MongoConnection conn =
+                (MongoConnection)
+                        d.getUnvalidatedConnection(userNoPWDURL + "?authMechanism=GSSAPI", p);
+        assertNotNull(conn);
+
+        // Verify system property was set
+        assertEquals(jaasPathTrimmed, System.getProperty("java.security.auth.login.config"));
+
+        System.clearProperty("java.security.auth.login.config");
+    }
+
+    @Test
+    void testGssNativeModeTrue_SetsSystemProperty() throws SQLException {
+        MongoDriver d = new MongoDriver();
+        Properties p = new Properties();
+        p.setProperty(DATABASE.getPropertyName(), "test");
+
+        String url = userNoPWDURL + "?authMechanism=GSSAPI";
+
+        p.setProperty(GSS_NATIVE_MODE.getPropertyName(), "true");
+
+        MongoConnection conn = (MongoConnection) d.getUnvalidatedConnection(url, p);
+        assertNotNull(conn);
+
+        // Verify system property was set to true
+        assertEquals("true", System.getProperty("sun.security.jgss.native"));
+
+        System.clearProperty("sun.security.jgss.native");
+    }
+
+    @Test
+    void testGssNativeModeFalse_SetsSystemProperty() throws SQLException {
+        MongoDriver d = new MongoDriver();
+        Properties p = new Properties();
+        p.setProperty(DATABASE.getPropertyName(), "test");
+
+        String url = userNoPWDURL + "?authMechanism=GSSAPI";
+        p.setProperty(GSS_NATIVE_MODE.getPropertyName(), "false");
+
+        MongoConnection conn = (MongoConnection) d.getUnvalidatedConnection(url, p);
+        assertNotNull(conn);
+
+        // Verify system property was set to false
+        assertEquals("false", System.getProperty("sun.security.jgss.native"));
+
+        System.clearProperty("sun.security.jgss.native");
+    }
+
+    @Test
+    void testGssNativeMode_InvalidValue_ThrowsSQLException() throws SQLException {
+        MongoDriver d = new MongoDriver();
+        Properties p = new Properties();
+        p.setProperty(DATABASE.getPropertyName(), "test");
+
+        String url = userNoPWDURL + "?authMechanism=GSSAPI";
+        p.setProperty(GSS_NATIVE_MODE.getPropertyName(), "invalid");
+
+        assertThrows(
+                SQLException.class,
+                () -> d.getUnvalidatedConnection(url, p),
+                "Invalid gssnativemode value should throw SQLException");
+    }
 }

--- a/src/test/java/com/mongodb/jdbc/MongoMock.java
+++ b/src/test/java/com/mongodb/jdbc/MongoMock.java
@@ -193,7 +193,7 @@ public abstract class MongoMock {
             mongoConnection =
                     new MongoConnection(
                             new MongoConnectionProperties(
-                                    uri, database, null, null, null, false, null));
+                                    uri, database, null, null, null, false, null, null, null));
         } catch (Exception e) {
             // The connection initialization should not fail, but if it does, we log the error to have more info.
             e.printStackTrace();


### PR DESCRIPTION
Adding properties:
`jaasconfigpath`: Set a custom jaas.config file path if the default doesn't work or can't be modified.  This was used since the default jaas.conf that was getting picked up by Tableau was in the `jdbcserver.jar` needed to be changed to get a working connection.
`gssnativemode`: Used on Windows to allow the use of MIT Kerberos vs the native Windows Kerberos.  Set this to `false` to use MIT Kerberos. 

Tested on Mac with a locally setup KDC using Docker containers. 
Tested on Windows against ldaptest.10gen.cc using MIT Kerberos. 