### PR TITLE
SQL-2965: Remove artifact declarations in publishing to continue release

### DIFF
--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -13,12 +13,6 @@ publishing {
             }
             artifact shadowJar
             artifact javadocJar
-            artifact("$buildDir/"+thirdpartyNoticeDir+"/"+thirdpartyNoticeName) {
-                classifier = 'license'
-            }
-            artifact("$rootDir/artifacts/ssdlc/mongodb-jdbc.sbom.json") {
-                classifier = 'sbom'
-            }
 
             pom {
                 name = 'JDBC Driver'


### PR DESCRIPTION
The sbom artifact can't be found during the publish step.  This could be due to the gradle upgrade, but not certain. 
Failure patch:
https://spruce.mongodb.com/task/mongo_jdbc_driver_release_publish_maven__v3.0.2_libv1.0.0_25_09_23_22_46_43/logs?execution=1

This change comments out the artifact lines to continue with jdbc release. 