### PR TITLE
SQL-2966: Remove unnecessary shadowjar artifact from gradle publish

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -181,6 +181,7 @@ configurations {
 }
 
 shadowJar {
+    archiveClassifier = 'all'
     relocate 'com.google', 'shadow.com.google'
     relocate 'com.nimbusds', 'shadow.com.nimbusds'
     relocate 'net.jcip', 'shadow.net.jcip'

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -11,7 +11,6 @@ publishing {
             artifact sourceJar {
                 classifier 'sources'
             }
-            artifact shadowJar
             artifact javadocJar
 
             pom {


### PR DESCRIPTION
After removing the `artifact shadowjar` line then I am able to successfully run:
./gradlew clean publishToMavenLocal

And I see the -all JAR in the local published directory.