### PR TITLE
SQL-3022: Update all catch Exception blocks to include message in thrown SQLException

### DIFF
--- a/src/main/java/com/mongodb/jdbc/MongoConnection.java
+++ b/src/main/java/com/mongodb/jdbc/MongoConnection.java
@@ -261,7 +261,8 @@ public class MongoConnection implements Connection {
                             throw new SQLException(
                                     "Failed to authenticate using GSSAPI (loginContextName: "
                                             + loginContextName
-                                            + ")",
+                                            + "). Root cause: "
+                                            + e.getMessage(),
                                     e);
                         }
                     }

--- a/src/main/java/com/mongodb/jdbc/MongoDriver.java
+++ b/src/main/java/com/mongodb/jdbc/MongoDriver.java
@@ -338,13 +338,14 @@ public class MongoDriver implements Driver {
             while (cause != null) {
                 if (cause instanceof com.mongodb.MongoSecurityException) {
                     throw new SQLException(
-                            "Authentication failed. Verify that the credentials are correct.",
+                            "Authentication failed. Verify that the credentials are correct. Root cause: "
+                                    + e.getMessage(),
                             AUTHENTICATION_ERROR_SQLSTATE,
                             e);
                 }
                 cause = cause.getCause();
             }
-            throw new SQLException("Connection failed.", e);
+            throw new SQLException("Connection failed. Root cause: " + e.getMessage(), e);
         }
     }
 
@@ -390,7 +391,7 @@ public class MongoDriver implements Driver {
                     connectionConfig.tlsCaFile,
                     connectionConfig.x509Passphrase);
         } catch (Exception e) {
-            throw new SQLException(e);
+            throw new SQLException("Failed to create connection. Root cause: " + e.getMessage(), e);
         }
     }
 
@@ -732,7 +733,7 @@ public class MongoDriver implements Driver {
             if ((e instanceof SQLException)) {
                 throw e;
             } else {
-                throw new SQLException(e);
+                throw new SQLException("Failed to build connection settings. Root cause: " + e.getMessage(), e);
             }
         }
     }
@@ -921,7 +922,7 @@ public class MongoDriver implements Driver {
         try {
             return URLEncoder.encode(item, "utf-8");
         } catch (Exception e) {
-            throw new SQLException(e);
+            throw new SQLException("Failed to URL encode. Root cause: " + e.getMessage(), e);
         }
     }
 

--- a/src/main/java/com/mongodb/jdbc/MongoDriver.java
+++ b/src/main/java/com/mongodb/jdbc/MongoDriver.java
@@ -733,7 +733,8 @@ public class MongoDriver implements Driver {
             if ((e instanceof SQLException)) {
                 throw e;
             } else {
-                throw new SQLException("Failed to build connection settings. Root cause: " + e.getMessage(), e);
+                throw new SQLException(
+                        "Failed to build connection settings. Root cause: " + e.getMessage(), e);
             }
         }
     }

--- a/src/main/java/com/mongodb/jdbc/MongoResultSet.java
+++ b/src/main/java/com/mongodb/jdbc/MongoResultSet.java
@@ -205,7 +205,7 @@ public class MongoResultSet implements ResultSet {
             }
             return result;
         } catch (Exception e) {
-            throw new SQLException(e);
+            throw new SQLException("Failed to get next result from cursor. Root cause: " + e.getMessage(), e);
         }
     }
 
@@ -241,7 +241,7 @@ public class MongoResultSet implements ResultSet {
                 columnIndex = rsMetaData.getColumnPositionFromLabel(columnLabel);
                 return getBsonValue(columnIndex + 1);
             } catch (Exception e) {
-                throw new SQLException(e.getMessage());
+                throw new SQLException("Failed to get BSON value. Root cause: " + e.getMessage(), e);
             }
         } else {
             throw new SQLException(String.format("column label '%s' not found", columnLabel));
@@ -805,7 +805,7 @@ public class MongoResultSet implements ResultSet {
         try {
             return rsMetaData.getColumnPositionFromLabel(columnLabel) + 1;
         } catch (Exception e) {
-            throw new SQLException(e.getMessage());
+            throw new SQLException("Failed to find column. Root cause: " + e.getMessage(), e);
         }
     }
 

--- a/src/main/java/com/mongodb/jdbc/MongoResultSet.java
+++ b/src/main/java/com/mongodb/jdbc/MongoResultSet.java
@@ -205,7 +205,8 @@ public class MongoResultSet implements ResultSet {
             }
             return result;
         } catch (Exception e) {
-            throw new SQLException("Failed to get next result from cursor. Root cause: " + e.getMessage(), e);
+            throw new SQLException(
+                    "Failed to get next result from cursor. Root cause: " + e.getMessage(), e);
         }
     }
 
@@ -241,7 +242,8 @@ public class MongoResultSet implements ResultSet {
                 columnIndex = rsMetaData.getColumnPositionFromLabel(columnLabel);
                 return getBsonValue(columnIndex + 1);
             } catch (Exception e) {
-                throw new SQLException("Failed to get BSON value. Root cause: " + e.getMessage(), e);
+                throw new SQLException(
+                        "Failed to get BSON value. Root cause: " + e.getMessage(), e);
             }
         } else {
             throw new SQLException(String.format("column label '%s' not found", columnLabel));

--- a/src/test/java/com/mongodb/jdbc/MongoDriverTest.java
+++ b/src/test/java/com/mongodb/jdbc/MongoDriverTest.java
@@ -1055,9 +1055,17 @@ class MongoDriverTest {
                 e.getMessage());
     }
 
+    static class MockMongoDriver extends MongoDriver {
+        @Override
+        protected MongoConnection getUnvalidatedConnection(String url, Properties info)
+                throws SQLException {
+            throw new SQLException(new com.mongodb.MongoSecurityException(null, "exception"));
+        }
+    }
+
     @Test
     void testConnectExceptionContainsRootCauseForAuthExceptions() throws Exception {
-        MongoDriver d = new MongoDriver();
+        MockMongoDriver d = new MockMongoDriver();
         Properties p = new Properties();
         p.setProperty(DATABASE.getPropertyName(), "test");
 
@@ -1066,7 +1074,7 @@ class MongoDriverTest {
 
         Exception e = assertThrows(SQLException.class, () -> d.connect(url, p));
         assertEquals(
-                "Authentication failed. Verify that the credentials are correct. Root cause: com.mongodb.MongoSecurityException: Failed to login Subject",
+                "Authentication failed. Verify that the credentials are correct. Root cause: com.mongodb.MongoSecurityException: exception",
                 e.getMessage());
     }
 

--- a/src/test/java/com/mongodb/jdbc/MongoDriverTest.java
+++ b/src/test/java/com/mongodb/jdbc/MongoDriverTest.java
@@ -21,6 +21,8 @@ import static com.mongodb.jdbc.utils.X509AuthenticationTest.TEST_PEM_DIR;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.mongodb.AuthenticationMechanism;
+import com.mongodb.ConnectionString;
+import com.mongodb.MongoConfigurationException;
 import com.mongodb.client.MongoClient;
 import java.io.File;
 import java.io.IOException;
@@ -969,10 +971,11 @@ class MongoDriverTest {
         String url = userNoPWDURL + "?authMechanism=GSSAPI";
         p.setProperty(GSS_NATIVE_MODE.getPropertyName(), "invalid");
 
-        assertThrows(
+        Exception e = assertThrows(
                 SQLException.class,
                 () -> d.getUnvalidatedConnection(url, p),
                 "Invalid gssnativemode value should throw SQLException");
+        assertEquals("Failed to create connection. Root cause: Invalid gssnativemode property value: invalid. Valid values are: 'true', 'false'.", e.getMessage());
     }
 
     @Test
@@ -1030,5 +1033,44 @@ class MongoDriverTest {
                 SQLException.class,
                 () -> d.getUnvalidatedConnection(url, p),
                 "The connection should fail because of a tlscafile mismatch between the URI and the properties");
+    }
+
+    @Test
+    void testConnectExceptionContainsRootCauseForNonTimeoutAndNonAuthExceptions() throws Exception {
+        MongoDriver d = new MongoDriver();
+        Properties p = new Properties();
+        p.setProperty(DATABASE.getPropertyName(), "test");
+
+        String url = userNoPWDURL + "?authMechanism=GSSAPI";
+        p.setProperty(GSS_NATIVE_MODE.getPropertyName(), "invalid");
+
+        Exception e = assertThrows(
+                SQLException.class,
+                () -> d.connect(url, p),
+                "Invalid gssnativemode value should throw SQLException");
+        assertEquals("Connection failed. Root cause: Failed to create connection. Root cause: Invalid gssnativemode property value: invalid. Valid values are: 'true', 'false'.", e.getMessage());
+    }
+
+    @Test
+    void testConnectExceptionContainsRootCauseForAuthExceptions() throws Exception {
+        MongoDriver d = new MongoDriver();
+        Properties p = new Properties();
+        p.setProperty(DATABASE.getPropertyName(), "test");
+
+        String url = userNoPWDURL + "?authMechanism=GSSAPI";
+        p.setProperty(GSS_NATIVE_MODE.getPropertyName(), "true");
+
+        Exception e = assertThrows(
+                SQLException.class,
+                () -> d.connect(url, p));
+        assertEquals("Authentication failed. Verify that the credentials are correct. Root cause: com.mongodb.MongoSecurityException: Failed to login Subject", e.getMessage());
+    }
+
+    @Test
+    void testGetConnectionSettingsExceptionContainsRootCause() throws Exception {
+        Exception e = assertThrows(
+                SQLException.class,
+                () -> MongoDriver.getConnectionSettings("", null));
+        assertEquals("Failed to build connection settings. Root cause: The connection string is invalid. Connection strings must start with either 'mongodb://' or 'mongodb+srv://", e.getMessage());
     }
 }

--- a/src/test/java/com/mongodb/jdbc/MongoDriverTest.java
+++ b/src/test/java/com/mongodb/jdbc/MongoDriverTest.java
@@ -21,8 +21,6 @@ import static com.mongodb.jdbc.utils.X509AuthenticationTest.TEST_PEM_DIR;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.mongodb.AuthenticationMechanism;
-import com.mongodb.ConnectionString;
-import com.mongodb.MongoConfigurationException;
 import com.mongodb.client.MongoClient;
 import java.io.File;
 import java.io.IOException;
@@ -971,11 +969,14 @@ class MongoDriverTest {
         String url = userNoPWDURL + "?authMechanism=GSSAPI";
         p.setProperty(GSS_NATIVE_MODE.getPropertyName(), "invalid");
 
-        Exception e = assertThrows(
-                SQLException.class,
-                () -> d.getUnvalidatedConnection(url, p),
-                "Invalid gssnativemode value should throw SQLException");
-        assertEquals("Failed to create connection. Root cause: Invalid gssnativemode property value: invalid. Valid values are: 'true', 'false'.", e.getMessage());
+        Exception e =
+                assertThrows(
+                        SQLException.class,
+                        () -> d.getUnvalidatedConnection(url, p),
+                        "Invalid gssnativemode value should throw SQLException");
+        assertEquals(
+                "Failed to create connection. Root cause: Invalid gssnativemode property value: invalid. Valid values are: 'true', 'false'.",
+                e.getMessage());
     }
 
     @Test
@@ -1044,11 +1045,14 @@ class MongoDriverTest {
         String url = userNoPWDURL + "?authMechanism=GSSAPI";
         p.setProperty(GSS_NATIVE_MODE.getPropertyName(), "invalid");
 
-        Exception e = assertThrows(
-                SQLException.class,
-                () -> d.connect(url, p),
-                "Invalid gssnativemode value should throw SQLException");
-        assertEquals("Connection failed. Root cause: Failed to create connection. Root cause: Invalid gssnativemode property value: invalid. Valid values are: 'true', 'false'.", e.getMessage());
+        Exception e =
+                assertThrows(
+                        SQLException.class,
+                        () -> d.connect(url, p),
+                        "Invalid gssnativemode value should throw SQLException");
+        assertEquals(
+                "Connection failed. Root cause: Failed to create connection. Root cause: Invalid gssnativemode property value: invalid. Valid values are: 'true', 'false'.",
+                e.getMessage());
     }
 
     @Test
@@ -1060,17 +1064,18 @@ class MongoDriverTest {
         String url = userNoPWDURL + "?authMechanism=GSSAPI";
         p.setProperty(GSS_NATIVE_MODE.getPropertyName(), "true");
 
-        Exception e = assertThrows(
-                SQLException.class,
-                () -> d.connect(url, p));
-        assertEquals("Authentication failed. Verify that the credentials are correct. Root cause: com.mongodb.MongoSecurityException: Failed to login Subject", e.getMessage());
+        Exception e = assertThrows(SQLException.class, () -> d.connect(url, p));
+        assertEquals(
+                "Authentication failed. Verify that the credentials are correct. Root cause: com.mongodb.MongoSecurityException: Failed to login Subject",
+                e.getMessage());
     }
 
     @Test
     void testGetConnectionSettingsExceptionContainsRootCause() throws Exception {
-        Exception e = assertThrows(
-                SQLException.class,
-                () -> MongoDriver.getConnectionSettings("", null));
-        assertEquals("Failed to build connection settings. Root cause: The connection string is invalid. Connection strings must start with either 'mongodb://' or 'mongodb+srv://", e.getMessage());
+        Exception e =
+                assertThrows(SQLException.class, () -> MongoDriver.getConnectionSettings("", null));
+        assertEquals(
+                "Failed to build connection settings. Root cause: The connection string is invalid. Connection strings must start with either 'mongodb://' or 'mongodb+srv://",
+                e.getMessage());
     }
 }

--- a/src/test/java/com/mongodb/jdbc/MongoResultSetTest.java
+++ b/src/test/java/com/mongodb/jdbc/MongoResultSetTest.java
@@ -63,6 +63,7 @@ import org.mockito.quality.Strictness;
 @MockitoSettings(strictness = Strictness.WARN)
 class MongoResultSetTest extends MongoMock {
     @Mock MongoCursor<BsonDocument> cursor;
+    @Mock MongoResultSetMetaData mockMetaData;
     MongoResultSet mockResultSet;
     static MongoResultSet mongoResultSet;
     static MongoResultSet mongoResultSetAllTypes;
@@ -70,6 +71,7 @@ class MongoResultSetTest extends MongoMock {
     static MongoResultSet mongoResultSetAllTypesExtJson;
     static MongoResultSet closedMongoResultSet;
     static MongoResultSet mongoResultSetExtended;
+    static MockMongoResultSet mongoResultSetWithMockMetaData;
 
     private static MongoResultSetMetaData resultSetMetaData;
     private static MongoStatement mongoStatement;
@@ -172,6 +174,14 @@ class MongoResultSetTest extends MongoMock {
                             schema,
                             null,
                             true,
+                            UuidRepresentation.STANDARD);
+            mongoResultSetWithMockMetaData =
+                    new MockMongoResultSet(
+                            mongoStatement,
+                            new BsonExplicitCursor(mongoResultDocs),
+                            schema,
+                            null,
+                            false,
                             UuidRepresentation.STANDARD);
             mongoResultSet.next();
             mongoResultSetAllTypes.next();
@@ -1300,5 +1310,46 @@ class MongoResultSetTest extends MongoMock {
         metaData = mockResultSet.getMetaData();
         assertEquals(1, metaData.getColumnCount());
         assertEquals(Types.INTEGER, metaData.getColumnType(1));
+    }
+
+    /**
+     * Class used for testing exceptions thrown by certain methods. The underlying ResultSetMetaData needs
+     * to be overwritten to test certain methods, such as findColumn and getBsonValue.
+     */
+    static class MockMongoResultSet extends MongoResultSet {
+        public MockMongoResultSet(MongoStatement statement, MongoCursor<BsonDocument> cursor, MongoJsonSchema resultSetSchema, List<List<String>> selectOrder, boolean extJsonMode, UuidRepresentation uuidRepresentation) throws SQLException {
+            super(statement, cursor, resultSetSchema, selectOrder, extJsonMode, uuidRepresentation);
+        }
+
+        public void setMetaData(MongoResultSetMetaData metaData) {
+            this.rsMetaData = metaData;
+        }
+    }
+
+    @Test
+    void testGetBsonValueExceptionContainsRootCause() throws Exception {
+        when(mockMetaData.hasColumnWithLabel(DOUBLE_COL_LABEL)).thenReturn(true);
+        when(mockMetaData.getColumnPositionFromLabel(DOUBLE_COL_LABEL)).thenThrow(new Exception("exception"));
+        mongoResultSetWithMockMetaData.setMetaData(mockMetaData);
+
+        SQLException e = assertThrows(
+                SQLException.class,
+                // getBsonValue is private, so we call it indirectly via getDouble.
+                () -> mongoResultSetWithMockMetaData.getDouble(DOUBLE_COL_LABEL)
+        );
+        assertEquals("Failed to get BSON value. Root cause: exception", e.getMessage());
+    }
+
+    @Test
+    void testFindColumnExceptionContainsRootCause() throws Exception {
+        when(mockMetaData.hasColumnWithLabel(DOUBLE_COL_LABEL)).thenReturn(true);
+        when(mockMetaData.getColumnPositionFromLabel(DOUBLE_COL_LABEL)).thenThrow(new Exception("exception"));
+        mongoResultSetWithMockMetaData.setMetaData(mockMetaData);
+
+        SQLException e = assertThrows(
+                SQLException.class,
+                () -> mongoResultSetWithMockMetaData.findColumn(DOUBLE_COL_LABEL)
+        );
+        assertEquals("Failed to find column. Root cause: exception", e.getMessage());
     }
 }

--- a/src/test/java/com/mongodb/jdbc/MongoResultSetTest.java
+++ b/src/test/java/com/mongodb/jdbc/MongoResultSetTest.java
@@ -1313,11 +1313,18 @@ class MongoResultSetTest extends MongoMock {
     }
 
     /**
-     * Class used for testing exceptions thrown by certain methods. The underlying ResultSetMetaData needs
-     * to be overwritten to test certain methods, such as findColumn and getBsonValue.
+     * Class used for testing exceptions thrown by certain methods. The underlying ResultSetMetaData
+     * needs to be overwritten to test certain methods, such as findColumn and getBsonValue.
      */
     static class MockMongoResultSet extends MongoResultSet {
-        public MockMongoResultSet(MongoStatement statement, MongoCursor<BsonDocument> cursor, MongoJsonSchema resultSetSchema, List<List<String>> selectOrder, boolean extJsonMode, UuidRepresentation uuidRepresentation) throws SQLException {
+        public MockMongoResultSet(
+                MongoStatement statement,
+                MongoCursor<BsonDocument> cursor,
+                MongoJsonSchema resultSetSchema,
+                List<List<String>> selectOrder,
+                boolean extJsonMode,
+                UuidRepresentation uuidRepresentation)
+                throws SQLException {
             super(statement, cursor, resultSetSchema, selectOrder, extJsonMode, uuidRepresentation);
         }
 
@@ -1329,27 +1336,29 @@ class MongoResultSetTest extends MongoMock {
     @Test
     void testGetBsonValueExceptionContainsRootCause() throws Exception {
         when(mockMetaData.hasColumnWithLabel(DOUBLE_COL_LABEL)).thenReturn(true);
-        when(mockMetaData.getColumnPositionFromLabel(DOUBLE_COL_LABEL)).thenThrow(new Exception("exception"));
+        when(mockMetaData.getColumnPositionFromLabel(DOUBLE_COL_LABEL))
+                .thenThrow(new Exception("exception"));
         mongoResultSetWithMockMetaData.setMetaData(mockMetaData);
 
-        SQLException e = assertThrows(
-                SQLException.class,
-                // getBsonValue is private, so we call it indirectly via getDouble.
-                () -> mongoResultSetWithMockMetaData.getDouble(DOUBLE_COL_LABEL)
-        );
+        SQLException e =
+                assertThrows(
+                        SQLException.class,
+                        // getBsonValue is private, so we call it indirectly via getDouble.
+                        () -> mongoResultSetWithMockMetaData.getDouble(DOUBLE_COL_LABEL));
         assertEquals("Failed to get BSON value. Root cause: exception", e.getMessage());
     }
 
     @Test
     void testFindColumnExceptionContainsRootCause() throws Exception {
         when(mockMetaData.hasColumnWithLabel(DOUBLE_COL_LABEL)).thenReturn(true);
-        when(mockMetaData.getColumnPositionFromLabel(DOUBLE_COL_LABEL)).thenThrow(new Exception("exception"));
+        when(mockMetaData.getColumnPositionFromLabel(DOUBLE_COL_LABEL))
+                .thenThrow(new Exception("exception"));
         mongoResultSetWithMockMetaData.setMetaData(mockMetaData);
 
-        SQLException e = assertThrows(
-                SQLException.class,
-                () -> mongoResultSetWithMockMetaData.findColumn(DOUBLE_COL_LABEL)
-        );
+        SQLException e =
+                assertThrows(
+                        SQLException.class,
+                        () -> mongoResultSetWithMockMetaData.findColumn(DOUBLE_COL_LABEL));
         assertEquals("Failed to find column. Root cause: exception", e.getMessage());
     }
 }


### PR DESCRIPTION
This PR adds root cause exception messages to `SQLException`s that are thrown after catching `Exception`s. The ticket highlights connection exceptions in particular, but also suggested doing this anywhere in the codebase where we did `catch (Exception e)` and subsequently threw a `SQLException`. I found 9 instances of this behavior and updated all 9 to include `e.getMessage()` as part of the thrown exception message.