### PR TITLE
SQL-3039: Fixing weak ssl context

### DIFF
--- a/.evg.yml
+++ b/.evg.yml
@@ -1441,12 +1441,11 @@ functions:
           # confirm
           semgrep --version
           set +e
-          semgrep --config p/java --verbose --exclude "vendor" --error --severity=ERROR --sarif-output=${STATIC_CODE_ANALYSIS_NAME} > mongo-jdbc-driver.sast.cmd.verbose.out 2>&1
+          semgrep --config p/java --verbose --error --severity=ERROR --sarif-output=${STATIC_CODE_ANALYSIS_NAME} > mongo-jdbc-driver.sast.cmd.verbose.out 2>&1
           SCAN_RESULT=$?
           set -e
 
-          # Exit with a failure if the scan found an issue
-          exit $SCAN_RESULT
+          echo "$SCAN_RESULT" > scan_result
     - command: s3.put
       params:
         <<: *evg_bucket_config
@@ -1455,6 +1454,16 @@ functions:
         remote_file: artifacts/${version_id}/ssdlc/
         content_type: application/json
         permissions: public-read
+    - command: shell.exec
+      type: test
+      params:
+        shell: bash
+        working_dir: mongo-jdbc-driver
+        script: |
+          # Exit with a failure if the scan found an issue
+          SCAN_RESULT=$(cat scan_result | tr -d '\n')
+          echo "Scan result = $SCAN_RESULT"
+          exit $SCAN_RESULT
 
   "publish static code analysis":
     - *assume_role_cmd

--- a/src/main/java/com/mongodb/jdbc/utils/X509Authentication.java
+++ b/src/main/java/com/mongodb/jdbc/utils/X509Authentication.java
@@ -392,7 +392,7 @@ public class X509Authentication {
             tmf.init((KeyStore) null);
         }
 
-        SSLContext sslContext = SSLContext.getInstance("TLS");
+        SSLContext sslContext = SSLContext.getDefault();
         sslContext.init(kmf.getKeyManagers(), tmf.getTrustManagers(), new SecureRandom());
         return sslContext;
     }


### PR DESCRIPTION
The driver will now use the default system SSL context.
I also updated the Semgrep task to make sure that we copy the files in the Evergreen bucket to be able to check the error.
Here is a [patch](https://spruce.mongodb.com/task/mongo_jdbc_driver_code_quality_and_correctness_semgrep_patch_186e80027c616d7a9e89657634cfe66696e0e1d7_6969194b0bde150007c6dfb3_26_01_15_17_08_35?execution=0 ) to show that it works.