### PR TITLE
SQL-3184: Dynamic dependency upgrade only pull final, ga or release version

### DIFF
--- a/.evg.yml
+++ b/.evg.yml
@@ -189,6 +189,8 @@ tasks:
         variant: "release"
       - name: "test-smoke"
         variant: "release"
+      - name: "make-docs"
+        variant: "release"
     commands:
       - *assume_role_cmd
       - command: s3.get

--- a/.evg.yml
+++ b/.evg.yml
@@ -65,6 +65,7 @@ buildvariants:
     tasks:
       - name: semgrep
       - name: sbom
+      - name: augment-sbom
       - name: ssdlc-artifacts-snapshot
 
   - name: ubuntu2204-64-jdk-8
@@ -239,8 +240,15 @@ tasks:
     commands:
       - func: "generate sbom"
       - func: "upload sbom"
-      - func: "augment sbom"
       - func: "scan sbom"
+
+  - name: augment-sbom
+    allowed_requesters: ["github_tag", "ad_hoc"]
+    depends_on:
+      - name: sbom
+        variant: code-quality-and-correctness
+    commands:
+      - func: "augment sbom"
 
   - name: ssdlc-artifacts-release
     run_on: ubuntu2204-small
@@ -261,7 +269,7 @@ tasks:
     run_on: ubuntu2204-small
     allow_for_git_tag: false
     depends_on:
-      - name: sbom
+      - name: augment-sbom
         variant: code-quality-and-correctness
       - name: semgrep
         variant: code-quality-and-correctness
@@ -274,6 +282,14 @@ tasks:
 
 functions:
   "augment sbom":
+    - *assume_role_cmd
+    - command: s3.get
+      display_name: Download SBOM Lite from S3
+      params:
+        <<: *evg_bucket_config
+        local_file: mongo-jdbc-driver/artifacts/ssdlc/${SBOM_LITE_NAME}
+        remote_file: artifacts/${version_id}/ssdlc/${SBOM_LITE_NAME}
+        content_type: application/json
     - command: ec2.assume_role
       display_name: Assume IAM role with permissions to pull Kondukto API token
       params:

--- a/build.gradle
+++ b/build.gradle
@@ -99,6 +99,23 @@ allprojects {
         mavenCentral()
     }
 
+    configurations.all { config ->
+        resolutionStrategy.componentSelection {
+            all { ComponentSelection selection ->
+                def candidate = selection.candidate
+                def isDynamic = config.allDependencies.any {
+                    it instanceof ExternalDependency &&
+                    it.group == candidate.group &&
+                    it.name == candidate.module &&
+                    it.version?.contains('+')
+                }
+                if (isDynamic && !(candidate.version ==~ /(?i)[0-9]+(\.[0-9]+)*([-.]?(final|ga|release))?/)) {
+                    selection.reject("Rejecting non-release version: ${candidate.version}")
+                }
+            }
+        }
+    }
+
     configurations {
         ajc
         aspects

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ commonsTextVersion=1.+
 nexusDomain = http://localhost:8081/nexus
 oauth2OIDCVersion = 11.+
 snakeYamlVersion = 2.+
-thymeLeafVersion = 3.1.2.RELEASE
+thymeLeafVersion = 3.1.+
 # to disable publication of both SHA-256 and SHA-512 checksums which causes error in maven release
 systemProp.org.gradle.internal.publish.checksums.insecure = true
 cyclonedxBomName = sbom_without_team_name


### PR DESCRIPTION
The existing logic would pull the latest version of a dependency and that meant pulling alpha, rc or beta releases if they were available.
For example, for the Java driver, it would  currently pull `5.7.0-beta1`.
We want to stick to stable versions.