### PR TITLE
SQL-3195: Change allowed requester list for patchable:false

### DIFF
--- a/.evg.yml
+++ b/.evg.yml
@@ -245,7 +245,7 @@ tasks:
       - func: "scan sbom"
 
   - name: augment-sbom
-    allowed_requesters: ["github_tag", "ad_hoc"]
+    patchable: false
     depends_on:
       - name: sbom
         variant: code-quality-and-correctness


### PR DESCRIPTION
augment-sbom not available for patches as expected : https://spruce.corp.mongodb.com/version/69e2bb887339a20007b156d3/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC